### PR TITLE
Enhance CLI Tools: Add Command Arguments Support and Unify Implementation

### DIFF
--- a/bin/autoload.php
+++ b/bin/autoload.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Common autoloader for bin scripts
- * Returns the path to the actual autoload.php file
+ * Common autoloader and project root detection for bin scripts
+ * Returns an array with 'autoload' and 'project_root' paths
  */
 
-// Load autoloader and return its path
+// Load autoloader and determine project root
 $autoloadPaths = [
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../autoload.php',
@@ -15,7 +15,22 @@ $autoloadPaths = [
 foreach ($autoloadPaths as $autoloadPath) {
     if (file_exists($autoloadPath)) {
         require_once $autoloadPath;
-        return $autoloadPath;
+        
+        // Determine project root from autoloader path
+        $normalized = str_replace('\\', '/', $autoloadPath);
+        $projectRoot = str_ends_with($normalized, '/vendor/autoload.php')
+            ? dirname($autoloadPath, 2)
+            : dirname($autoloadPath);
+        
+        if (!file_exists($projectRoot . '/composer.json')) {
+            fwrite(STDERR, "Error: Could not determine project root from autoloader path: $autoloadPath\n");
+            exit(1);
+        }
+        
+        return [
+            'autoload' => $autoloadPath,
+            'project_root' => $projectRoot
+        ];
     }
 }
 

--- a/bin/autoload.php
+++ b/bin/autoload.php
@@ -2,7 +2,7 @@
 
 /**
  * Common autoloader and project root detection for bin scripts
- * Returns an array with 'autoload' and 'project_root' paths
+ * Returns the project root path
  */
 
 // Load autoloader and determine project root
@@ -27,10 +27,7 @@ foreach ($autoloadPaths as $autoloadPath) {
             exit(1);
         }
         
-        return [
-            'autoload' => $autoloadPath,
-            'project_root' => $projectRoot
-        ];
+        return $projectRoot;
     }
 }
 

--- a/bin/parse.php
+++ b/bin/parse.php
@@ -28,7 +28,7 @@ return function (array $argv): array {
         $phpArgs = [];
         
         // Find -- separator
-        $separatorIndex = array_search('--', $argv);
+        $separatorIndex = array_search('--', $argv, true);
         if ($separatorIndex !== false) {
             $phpArgs = array_slice($argv, $separatorIndex + 1);
         }

--- a/bin/parse.php
+++ b/bin/parse.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Common functions for CLI debugging tools
+ * Returns parse function
+ */
+
+return function (array $argv): array {
+    /**
+     * Parse CLI arguments supporting dual patterns:
+     * Pattern 1: script.php -- args
+     * Pattern 2: -- php script.php args
+     */
+    if ($argv[1] === '--') {
+        // Pattern 2: -- php script.php args
+        if (count($argv) < 3) {
+            fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
+            fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+            exit(1);
+        }
+        $phpBinary = $argv[2];
+        $targetFile = $argv[3] ?? '';
+        $phpArgs = array_slice($argv, 4);
+    } else {
+        // Pattern 1: script.php -- args
+        $phpBinary = PHP_BINARY;
+        $targetFile = $argv[1];
+        $phpArgs = [];
+        
+        // Find -- separator
+        $separatorIndex = array_search('--', $argv);
+        if ($separatorIndex !== false) {
+            $phpArgs = array_slice($argv, $separatorIndex + 1);
+        }
+    }
+    
+    return [$phpBinary, $targetFile, $phpArgs];
+};

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -1,93 +1,114 @@
-#!/bin/bash
-
-# Xdebug Coverage Testing Script
-cd "$(dirname "$0")/.."
-PROJECT_ROOT=$(pwd)
-
-# Check for help flag or missing argument
-if [ "$1" = "--help" ] || [ "$1" = "-h" ] || [ -z "$1" ]; then
-    echo "Usage: $0 PHP_FILE [OPTIONS]"
-    echo ""
-    echo "Runs Xdebug code coverage analysis on the specified PHP file."
-    echo ""
-    echo "Arguments:"
-    echo "  PHP_FILE    Path to PHP file to analyze (required)"
-    echo ""
-    echo "Options:"
-    echo "  --html      Generate HTML coverage report"
-    echo "  --text      Generate text coverage summary (default)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 test/debug_test.php           # Basic coverage analysis"
-    echo "  $0 my_script.php --html          # Generate HTML report"
-    echo "  $0 tests/Unit/SomeTest.php       # Coverage for test file"
-    echo ""
-    if [ -z "$1" ]; then
-        echo "❌ Error: PHP file argument is required"
-        exit 1
-    fi
-    exit 0
-fi
-
-# Parse arguments
-TARGET_FILE="$1"
-OUTPUT_FORMAT="text"
-
-# Check for output format option
-if [ "$2" = "--html" ]; then
-    OUTPUT_FORMAT="html"
-elif [ "$2" = "--text" ]; then
-    OUTPUT_FORMAT="text"
-fi
-
-# Check target file exists
-if [ ! -f "$TARGET_FILE" ]; then
-    echo "❌ Error: File '$TARGET_FILE' not found"
-    echo "Use '$0 --help' for usage information"
-    exit 1
-fi
-
-# Generate unique coverage filename
-COVERAGE_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-COVERAGE_DIR="/tmp/xdebug_coverage_${COVERAGE_TIMESTAMP}"
-
-# Create coverage directory
-mkdir -p "$COVERAGE_DIR"
-
-# Xdebug coverage configuration
-XDEBUG_OPTS="-dzend_extension=xdebug \
-    -dxdebug.mode=coverage \
-    -dxdebug.start_with_request=yes"
-
-echo "📊 Coverage Analysis: $TARGET_FILE"
-echo "📁 Output format: $OUTPUT_FORMAT"
-
-# Create a simple coverage wrapper script
-WRAPPER_SCRIPT="/tmp/coverage_wrapper_${COVERAGE_TIMESTAMP}.php"
-cat > "$WRAPPER_SCRIPT" << EOF
+#!/usr/bin/env php
 <?php
+
+declare(strict_types=1);
+
+// Load autoloader and get project root
+$paths = require __DIR__ . '/autoload.php';
+$projectRoot = $paths['project_root'];
+
+// Parse command line arguments
+function showHelp(string $scriptName): void {
+    echo "Usage: $scriptName PHP_FILE [OPTIONS] [-- PHP_ARGS...]\n";
+    echo "\n";
+    echo "Runs Xdebug code coverage analysis on the specified PHP file or command.\n";
+    echo "\n";
+    echo "Arguments:\n";
+    echo "  PHP_FILE    Path to PHP file to analyze (required)\n";
+    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "\n";
+    echo "Options:\n";
+    echo "  --html      Generate HTML coverage report\n";
+    echo "  --text      Generate text coverage summary (default)\n";
+    echo "\n";
+    echo "Examples:\n";
+    echo "  $scriptName test/debug_test.php                    # Basic coverage analysis\n";
+    echo "  $scriptName my_script.php --html                  # Generate HTML report\n";
+    echo "  $scriptName bin/page.php --text -- get /          # Coverage with arguments\n";
+    echo "  $scriptName bin/console.php --html -- cache:clear --env=dev  # Console command coverage\n";
+    echo "\n";
+}
+
+// Check for help flag or missing argument
+if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+    showHelp($argv[0]);
+    if (count($argv) < 2) {
+        fwrite(STDERR, "❌ Error: PHP file argument is required\n");
+        exit(1);
+    }
+    exit(0);
+}
+
+// Parse arguments
+$targetFile = $argv[1];
+$outputFormat = 'text';
+$phpArgs = [];
+
+// Parse options and find -- separator
+for ($i = 2; $i < count($argv); $i++) {
+    if ($argv[$i] === '--') {
+        $phpArgs = array_slice($argv, $i + 1);
+        break;
+    } elseif ($argv[$i] === '--html') {
+        $outputFormat = 'html';
+    } elseif ($argv[$i] === '--text') {
+        $outputFormat = 'text';
+    }
+}
+
+// Check target file exists
+if (!file_exists($targetFile)) {
+    fwrite(STDERR, "❌ Error: File '$targetFile' not found\n");
+    fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+    exit(1);
+}
+
+// Generate unique coverage filename
+$coverageTimestamp = date('Ymd_His');
+$coverageDir = "/tmp/xdebug_coverage_$coverageTimestamp";
+
+// Create coverage directory
+mkdir($coverageDir, 0755, true);
+
+// Build Xdebug options
+$xdebugOpts = [
+    '-dzend_extension=xdebug',
+    '-dxdebug.mode=coverage',
+    '-dxdebug.start_with_request=yes'
+];
+
+// Create a coverage wrapper script
+$wrapperScript = "/tmp/coverage_wrapper_$coverageTimestamp.php";
+$wrapperContent = "<?php
 // Coverage analysis wrapper
 xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
 
+// Capture arguments for the target script
+\$targetArgs = " . var_export($phpArgs, true) . ";
+if (!empty(\$targetArgs)) {
+    \$_SERVER['argv'] = array_merge(['" . addslashes($targetFile) . "'], \$targetArgs);
+    \$_SERVER['argc'] = count(\$_SERVER['argv']);
+}
+
 // Include and execute the target file
-include '$TARGET_FILE';
+include '" . addslashes($targetFile) . "';
 
 // Get coverage data
 \$coverage = xdebug_get_code_coverage();
 xdebug_stop_code_coverage();
 
 // Generate report based on format
-if ('$OUTPUT_FORMAT' === 'html') {
-    \$htmlDir = '$COVERAGE_DIR/html';
+if ('" . $outputFormat . "' === 'html') {
+    \$htmlDir = '" . addslashes($coverageDir) . "/html';
     mkdir(\$htmlDir, 0755, true);
     
     foreach (\$coverage as \$file => \$lines) {
         \$filename = basename(\$file);
         \$htmlFile = \$htmlDir . '/' . \$filename . '.html';
         
-        \$html = "<html><head><title>Coverage: \$filename</title></head><body>";
-        \$html .= "<h1>Coverage Report: \$filename</h1>";
-        \$html .= "<table border='1'><tr><th>Line</th><th>Status</th></tr>";
+        \$html = '<html><head><title>Coverage: ' . htmlspecialchars(\$filename) . '</title></head><body>';
+        \$html .= '<h1>Coverage Report: ' . htmlspecialchars(\$filename) . '</h1>';
+        \$html .= '<table border=\"1\"><tr><th>Line</th><th>Code</th><th>Status</th></tr>';
         
         \$fileLines = file(\$file);
         foreach (\$fileLines as \$lineNum => \$line) {
@@ -96,53 +117,94 @@ if ('$OUTPUT_FORMAT' === 'html') {
             if (isset(\$lines[\$lineNum])) {
                 \$status = \$lines[\$lineNum] === 1 ? 'covered' : 'not covered';
             }
-            \$color = \$status === 'covered' ? 'green' : (\$status === 'not covered' ? 'red' : 'gray');
-            \$html .= "<tr style='background-color: \$color'>";
-            \$html .= "<td>\$lineNum</td><td>\$status</td></tr>";
+            \$color = \$status === 'covered' ? '#90EE90' : (\$status === 'not covered' ? '#FFB6C1' : '#D3D3D3');
+            \$html .= '<tr style=\"background-color: ' . \$color . '\">';
+            \$html .= '<td>' . \$lineNum . '</td>';
+            \$html .= '<td><pre>' . htmlspecialchars(rtrim(\$line)) . '</pre></td>';
+            \$html .= '<td>' . \$status . '</td></tr>';
         }
-        \$html .= "</table></body></html>";
+        \$html .= '</table></body></html>';
         
         file_put_contents(\$htmlFile, \$html);
     }
     
-    echo "✅ HTML coverage report generated in: \$htmlDir\n";
-    echo "📂 Open: \$htmlDir/index.html\n";
+    echo \"✅ HTML coverage report generated in: \$htmlDir\\n\";
+    echo \"📂 Open: \$htmlDir/\\n\";
 } else {
     // Text format
     \$totalLines = 0;
     \$coveredLines = 0;
     
     foreach (\$coverage as \$file => \$lines) {
-        echo "File: \$file\n";
+        echo \"File: \$file\\n\";
         foreach (\$lines as \$line => \$count) {
             \$totalLines++;
             if (\$count > 0) \$coveredLines++;
             \$status = \$count > 0 ? 'COVERED' : 'NOT COVERED';
-            echo "  Line \$line: \$status (\$count)\n";
+            echo \"  Line \$line: \$status (\$count)\\n\";
         }
-        echo "\n";
+        echo \"\\n\";
     }
     
     \$percentage = \$totalLines > 0 ? (\$coveredLines / \$totalLines) * 100 : 0;
-    echo "📊 Coverage Summary:\n";
-    echo "   Total lines: \$totalLines\n";
-    echo "   Covered lines: \$coveredLines\n";
-    echo "   Coverage: " . number_format(\$percentage, 2) . "%\n";
+    echo \"📊 Coverage Summary:\\n\";
+    echo \"   Total lines: \$totalLines\\n\";
+    echo \"   Covered lines: \$coveredLines\\n\";
+    echo \"   Coverage: \" . number_format(\$percentage, 2) . \"%\\n\";
 }
-EOF
+";
 
-# Execute with coverage
-php $XDEBUG_OPTS "$WRAPPER_SCRIPT"
+file_put_contents($wrapperScript, $wrapperContent);
 
-# Cleanup wrapper script
-rm -f "$WRAPPER_SCRIPT"
+// Execute command
+if (empty($phpArgs)) {
+    echo "📊 Coverage Analysis: $targetFile\n";
+} else {
+    echo "📊 Coverage Analysis: $targetFile with arguments: " . implode(' ', $phpArgs) . "\n";
+}
+echo "📁 Output format: $outputFormat\n";
 
-echo ""
-echo "✅ Coverage analysis complete!"
+// Build and execute command
+$command = ['php'];
+$command = array_merge($command, $xdebugOpts);
+$command[] = $wrapperScript;
 
-if [ "$OUTPUT_FORMAT" = "html" ]; then
-    echo "💡 View HTML report:"
-    echo "   open $COVERAGE_DIR/html/"
-else
-    echo "💡 Coverage data saved to: $COVERAGE_DIR"
-fi
+// Execute and suppress stderr
+$descriptors = [
+    0 => ['pipe', 'r'],  // stdin
+    1 => ['pipe', 'w'],  // stdout
+    2 => ['pipe', 'w'],  // stderr
+];
+
+$process = proc_open($command, $descriptors, $pipes);
+
+if (is_resource($process)) {
+    // Close stdin
+    fclose($pipes[0]);
+    
+    // Read stdout
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    
+    // Read and ignore stderr
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    
+    // Wait for process to finish
+    $returnCode = proc_close($process);
+    
+    // Output the results
+    echo $stdout;
+}
+
+// Cleanup wrapper script
+unlink($wrapperScript);
+
+echo "\n✅ Coverage analysis complete!\n";
+
+if ($outputFormat === 'html') {
+    echo "💡 View HTML report:\n";
+    echo "   open $coverageDir/html/\n";
+} else {
+    echo "💡 Coverage data saved to: $coverageDir\n";
+}

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -52,25 +52,17 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments - handle both patterns:
-// Pattern 1: script.php [--html|--text] [-- args]
-// Pattern 2: -- php script.php args (always text format)
+// Load common argument parser
+$parse = require __DIR__ . '/parse.php';
+
+// Parse base arguments - coverage has special option handling
 if ($argv[1] === '--') {
-    // Pattern 2: -- php script.php args
-    if (count($argv) < 3) {
-        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
-        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
-        exit(1);
-    }
-    $phpBinary = PHP_BINARY; // Use detected PHP for Xdebug execution
-    $customPhpBinary = $argv[2]; // Custom PHP for target script
-    $targetFile = $argv[3] ?? '';
-    $phpArgs = array_slice($argv, 4);
-    $outputFormat = 'text'; // Default for -- pattern
+    // Pattern 2: -- php script.php args (text format only)
+    [$phpBinary, $targetFile, $phpArgs] = $parse($argv);
+    $outputFormat = 'text';
 } else {
     // Pattern 1: script.php [--html|--text] [-- args]
     $phpBinary = PHP_BINARY;
-    $customPhpBinary = null;
     $targetFile = $argv[1];
     $outputFormat = 'text';
     $phpArgs = [];

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -28,8 +28,14 @@ function showHelp(string $scriptName): void {
     echo "\n";
 }
 
-// Check for help flag or missing argument
-if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+// Find -- separator to limit help flag checking
+$separatorIndex = array_search('--', $argv);
+$argsToCheck = $separatorIndex !== false 
+    ? array_slice($argv, 0, $separatorIndex)  // Args before --
+    : $argv;                                   // All args if no --
+
+// Check for help flag or missing argument (only in pre-separator args)
+if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($argv) < 2) {
     showHelp($argv[0]);
     if (count($argv) < 2) {
         fwrite(STDERR, "❌ Error: PHP file argument is required\n");

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -9,22 +9,30 @@ $projectRoot = require __DIR__ . '/autoload.php';
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [OPTIONS] [-- PHP_ARGS...]\n";
+    echo "       $scriptName -- PHP_BINARY SCRIPT_FILE [SCRIPT_ARGS...]\n";
     echo "\n";
     echo "Runs Xdebug code coverage analysis on the specified PHP file or command.\n";
     echo "\n";
     echo "Arguments:\n";
-    echo "  PHP_FILE    Path to PHP file to analyze (required)\n";
-    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_FILE      Path to PHP file to analyze (required)\n";
+    echo "  PHP_ARGS      Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_BINARY    Custom PHP binary path (when using -- prefix)\n";
+    echo "  SCRIPT_FILE   PHP script to analyze (when using -- prefix)\n";
+    echo "  SCRIPT_ARGS   Arguments for the script (when using -- prefix)\n";
     echo "\n";
     echo "Options:\n";
-    echo "  --html      Generate HTML coverage report\n";
-    echo "  --text      Generate text coverage summary (default)\n";
+    echo "  --html        Generate HTML coverage report\n";
+    echo "  --text        Generate text coverage summary (default)\n";
     echo "\n";
     echo "Examples:\n";
+    echo "  # Standard usage:\n";
     echo "  $scriptName test/debug_test.php                    # Basic coverage analysis\n";
     echo "  $scriptName my_script.php --html                  # Generate HTML report\n";
     echo "  $scriptName bin/page.php --text -- get /          # Coverage with arguments\n";
-    echo "  $scriptName bin/console.php --html -- cache:clear --env=dev  # Console command coverage\n";
+    echo "\n";
+    echo "  # Custom PHP binary:\n";
+    echo "  $scriptName -- php bin/page.php get /             # Natural PHP command style\n";
+    echo "  $scriptName -- /usr/bin/php8.3 script.php args   # Specific PHP version\n";
     echo "\n";
 }
 
@@ -44,20 +52,39 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments
-$targetFile = $argv[1];
-$outputFormat = 'text';
-$phpArgs = [];
-
-// Parse options and find -- separator
-for ($i = 2; $i < count($argv); $i++) {
-    if ($argv[$i] === '--') {
-        $phpArgs = array_slice($argv, $i + 1);
-        break;
-    } elseif ($argv[$i] === '--html') {
-        $outputFormat = 'html';
-    } elseif ($argv[$i] === '--text') {
-        $outputFormat = 'text';
+// Parse arguments - handle both patterns:
+// Pattern 1: script.php [--html|--text] [-- args]
+// Pattern 2: -- php script.php args (always text format)
+if ($argv[1] === '--') {
+    // Pattern 2: -- php script.php args
+    if (count($argv) < 3) {
+        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
+        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+        exit(1);
+    }
+    $phpBinary = PHP_BINARY; // Use detected PHP for Xdebug execution
+    $customPhpBinary = $argv[2]; // Custom PHP for target script
+    $targetFile = $argv[3] ?? '';
+    $phpArgs = array_slice($argv, 4);
+    $outputFormat = 'text'; // Default for -- pattern
+} else {
+    // Pattern 1: script.php [--html|--text] [-- args]
+    $phpBinary = PHP_BINARY;
+    $customPhpBinary = null;
+    $targetFile = $argv[1];
+    $outputFormat = 'text';
+    $phpArgs = [];
+    
+    // Parse options and find -- separator
+    for ($i = 2; $i < count($argv); $i++) {
+        if ($argv[$i] === '--') {
+            $phpArgs = array_slice($argv, $i + 1);
+            break;
+        } elseif ($argv[$i] === '--html') {
+            $outputFormat = 'html';
+        } elseif ($argv[$i] === '--text') {
+            $outputFormat = 'text';
+        }
     }
 }
 
@@ -169,8 +196,8 @@ if (empty($phpArgs)) {
 }
 echo "📁 Output format: $outputFormat\n";
 
-// Build and execute command
-$command = [PHP_BINARY];
+// Build and execute command  
+$command = [$phpBinary];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $wrapperScript;
 

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -4,8 +4,7 @@
 declare(strict_types=1);
 
 // Load autoloader and get project root
-$paths = require __DIR__ . '/autoload.php';
-$projectRoot = $paths['project_root'];
+$projectRoot = require __DIR__ . '/autoload.php';
 
 // Parse command line arguments
 function showHelp(string $scriptName): void {

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -164,7 +164,7 @@ if (empty($phpArgs)) {
 echo "📁 Output format: $outputFormat\n";
 
 // Build and execute command
-$command = ['php'];
+$command = [PHP_BINARY];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $wrapperScript;
 

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -168,7 +168,7 @@ $command = [PHP_BINARY];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $wrapperScript;
 
-// Execute and suppress stderr
+// Execute with proper output handling
 $descriptors = [
     0 => ['pipe', 'r'],  // stdin
     1 => ['pipe', 'w'],  // stdout
@@ -181,19 +181,29 @@ if (is_resource($process)) {
     // Close stdin
     fclose($pipes[0]);
     
-    // Read stdout
+    // Read and forward stdout
     $stdout = stream_get_contents($pipes[1]);
     fclose($pipes[1]);
     
-    // Read and ignore stderr
+    // Read and forward stderr
     $stderr = stream_get_contents($pipes[2]);
     fclose($pipes[2]);
     
-    // Wait for process to finish
+    // Wait for process to finish and get exit code
     $returnCode = proc_close($process);
     
-    // Output the results
-    echo $stdout;
+    // Forward child process output
+    if ($stdout !== '') {
+        echo $stdout;
+    }
+    if ($stderr !== '') {
+        fwrite(STDERR, $stderr);
+    }
+    
+    // Propagate child process exit code
+    if ($returnCode !== 0) {
+        exit($returnCode);
+    }
 }
 
 // Cleanup wrapper script

--- a/bin/xdebug-coverage
+++ b/bin/xdebug-coverage
@@ -9,14 +9,13 @@ $projectRoot = require __DIR__ . '/autoload.php';
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [OPTIONS] [-- PHP_ARGS...]\n";
-    echo "       $scriptName -- PHP_BINARY SCRIPT_FILE [SCRIPT_ARGS...]\n";
+    echo "       $scriptName -- SCRIPT_FILE [SCRIPT_ARGS...]\n";
     echo "\n";
     echo "Runs Xdebug code coverage analysis on the specified PHP file or command.\n";
     echo "\n";
     echo "Arguments:\n";
     echo "  PHP_FILE      Path to PHP file to analyze (required)\n";
     echo "  PHP_ARGS      Arguments to pass to the PHP script (after --)\n";
-    echo "  PHP_BINARY    Custom PHP binary path (when using -- prefix)\n";
     echo "  SCRIPT_FILE   PHP script to analyze (when using -- prefix)\n";
     echo "  SCRIPT_ARGS   Arguments for the script (when using -- prefix)\n";
     echo "\n";
@@ -30,14 +29,13 @@ function showHelp(string $scriptName): void {
     echo "  $scriptName my_script.php --html                  # Generate HTML report\n";
     echo "  $scriptName bin/page.php --text -- get /          # Coverage with arguments\n";
     echo "\n";
-    echo "  # Custom PHP binary:\n";
-    echo "  $scriptName -- php bin/page.php get /             # Natural PHP command style\n";
-    echo "  $scriptName -- /usr/bin/php8.3 script.php args   # Specific PHP version\n";
+    echo "  # Direct script execution:\n";
+    echo "  $scriptName -- bin/page.php get /                 # Natural command style\n";
     echo "\n";
 }
 
 // Find -- separator to limit help flag checking
-$separatorIndex = array_search('--', $argv);
+$separatorIndex = array_search('--', $argv, true);
 $argsToCheck = $separatorIndex !== false 
     ? array_slice($argv, 0, $separatorIndex)  // Args before --
     : $argv;                                   // All args if no --
@@ -55,10 +53,17 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
 // Load common argument parser
 $parse = require __DIR__ . '/parse.php';
 
-// Parse base arguments - coverage has special option handling
+// Parse base arguments - coverage has simplified pattern handling  
 if ($argv[1] === '--') {
-    // Pattern 2: -- php script.php args (text format only)
-    [$phpBinary, $targetFile, $phpArgs] = $parse($argv);
+    // Pattern 2: -- script.php args (text format only)
+    if (count($argv) < 3) {
+        fwrite(STDERR, "❌ Error: Script file required after --\n");
+        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+        exit(1);
+    }
+    $phpBinary = PHP_BINARY;
+    $targetFile = $argv[2];
+    $phpArgs = array_slice($argv, 3);
     $outputFormat = 'text';
 } else {
     // Pattern 1: script.php [--html|--text] [-- args]
@@ -88,7 +93,7 @@ if (!file_exists($targetFile)) {
 }
 
 // Generate unique coverage filename
-$coverageTimestamp = date('Ymd_His');
+$coverageTimestamp = date('Ymd_His') . '_' . getmypid();
 $coverageDir = "/tmp/xdebug_coverage_$coverageTimestamp";
 
 // Create coverage directory
@@ -110,8 +115,16 @@ xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
 // Capture arguments for the target script
 \$targetArgs = " . var_export($phpArgs, true) . ";
 if (!empty(\$targetArgs)) {
-    \$_SERVER['argv'] = array_merge(['" . addslashes($targetFile) . "'], \$targetArgs);
-    \$_SERVER['argc'] = count(\$_SERVER['argv']);
+    \$newArgv = array_merge(['" . addslashes($targetFile) . "'], \$targetArgs);
+    \$newArgc = count(\$newArgv);
+    
+    // Update all argument accessors
+    \$_SERVER['argv'] = \$newArgv;
+    \$_SERVER['argc'] = \$newArgc;
+    \$GLOBALS['argv'] = \$newArgv;
+    \$GLOBALS['argc'] = \$newArgc;
+    \$argv = \$newArgv;
+    \$argc = \$newArgc;
 }
 
 // Include and execute the target file

--- a/bin/xdebug-phpunit
+++ b/bin/xdebug-phpunit
@@ -3,19 +3,9 @@
 
 declare(strict_types=1);
 
-// Load autoloader and determine project root
-$autoloadPath = require __DIR__ . '/autoload.php';
-
-// Determine project root from autoloader path
-$normalized = str_replace('\\', '/', $autoloadPath);
-$projectRoot = str_ends_with($normalized, '/vendor/autoload.php')
-    ? dirname($autoloadPath, 2)
-    : dirname($autoloadPath);
-
-if (!file_exists($projectRoot . '/composer.json')) {
-    fwrite(STDERR, "Error: Could not determine project root from autoloader path: $autoloadPath\n");
-    exit(1);
-}
+// Load autoloader and get project root
+$paths = require __DIR__ . '/autoload.php';
+$projectRoot = $paths['project_root'];
 
 // Note: Using absolute paths instead of chdir() for stability
 

--- a/bin/xdebug-phpunit
+++ b/bin/xdebug-phpunit
@@ -4,8 +4,7 @@
 declare(strict_types=1);
 
 // Load autoloader and get project root
-$paths = require __DIR__ . '/autoload.php';
-$projectRoot = $paths['project_root'];
+$projectRoot = require __DIR__ . '/autoload.php';
 
 // Note: Using absolute paths instead of chdir() for stability
 

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -77,7 +77,7 @@ if (empty($phpArgs)) {
     echo "📊 Profiling: $targetFile with arguments: " . implode(' ', $phpArgs) . "\n";
 }
 
-// Execute and suppress stderr
+// Execute with proper output handling
 $descriptors = [
     0 => ['pipe', 'r'],  // stdin
     1 => ['pipe', 'w'],  // stdout
@@ -90,16 +90,29 @@ if (is_resource($process)) {
     // Close stdin
     fclose($pipes[0]);
     
-    // Read stdout (if needed for debugging)
+    // Read and forward stdout
     $stdout = stream_get_contents($pipes[1]);
     fclose($pipes[1]);
     
-    // Read and ignore stderr
+    // Read and forward stderr
     $stderr = stream_get_contents($pipes[2]);
     fclose($pipes[2]);
     
-    // Wait for process to finish
+    // Wait for process to finish and get exit code
     $returnCode = proc_close($process);
+    
+    // Forward child process output
+    if ($stdout !== '') {
+        echo $stdout;
+    }
+    if ($stderr !== '') {
+        fwrite(STDERR, $stderr);
+    }
+    
+    // Propagate child process exit code
+    if ($returnCode !== 0) {
+        exit($returnCode);
+    }
 }
 
 // Find the generated profile file (Cachegrind format)

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -9,18 +9,25 @@ $projectRoot = require __DIR__ . '/autoload.php';
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
+    echo "       $scriptName -- PHP_BINARY SCRIPT_FILE [SCRIPT_ARGS...]\n";
     echo "\n";
     echo "Runs Xdebug profiling on the specified PHP file or command.\n";
     echo "\n";
     echo "Arguments:\n";
-    echo "  PHP_FILE    Path to PHP file to profile (required)\n";
-    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_FILE      Path to PHP file to profile (required)\n";
+    echo "  PHP_ARGS      Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_BINARY    Custom PHP binary path (when using -- prefix)\n";
+    echo "  SCRIPT_FILE   PHP script to profile (when using -- prefix)\n";
+    echo "  SCRIPT_ARGS   Arguments for the script (when using -- prefix)\n";
     echo "\n";
     echo "Examples:\n";
+    echo "  # Standard usage:\n";
     echo "  $scriptName test/debug_test.php                    # Profile test file\n";
-    echo "  $scriptName my_script.php                         # Profile specific file\n";
     echo "  $scriptName bin/page.php -- get /                 # Profile with arguments\n";
-    echo "  $scriptName bin/console.php -- cache:clear --env=dev  # Profile console command\n";
+    echo "\n";
+    echo "  # Custom PHP binary:\n";
+    echo "  $scriptName -- php bin/page.php get /             # Natural PHP command style\n";
+    echo "  $scriptName -- /usr/bin/php8.3 script.php args   # Specific PHP version\n";
     echo "\n";
 }
 
@@ -40,14 +47,30 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments - separate PHP file from PHP arguments
-$targetFile = $argv[1];
-$phpArgs = [];
-
-// Find -- separator
-$separatorIndex = array_search('--', $argv);
-if ($separatorIndex !== false) {
-    $phpArgs = array_slice($argv, $separatorIndex + 1);
+// Parse arguments - handle both patterns:
+// Pattern 1: script.php -- args
+// Pattern 2: -- php script.php args
+if ($argv[1] === '--') {
+    // Pattern 2: -- php script.php args
+    if (count($argv) < 3) {
+        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
+        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+        exit(1);
+    }
+    $phpBinary = $argv[2];
+    $targetFile = $argv[3] ?? '';
+    $phpArgs = array_slice($argv, 4);
+} else {
+    // Pattern 1: script.php -- args
+    $phpBinary = PHP_BINARY;
+    $targetFile = $argv[1];
+    $phpArgs = [];
+    
+    // Find -- separator
+    $separatorIndex = array_search('--', $argv);
+    if ($separatorIndex !== false) {
+        $phpArgs = array_slice($argv, $separatorIndex + 1);
+    }
 }
 
 // Check target file exists
@@ -71,7 +94,7 @@ $xdebugOpts = [
 ];
 
 // Build command
-$command = [PHP_BINARY];
+$command = [$phpBinary];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $targetFile;
 $command = array_merge($command, $phpArgs);

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -65,7 +65,7 @@ $xdebugOpts = [
 ];
 
 // Build command
-$command = ['php'];
+$command = [PHP_BINARY];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $targetFile;
 $command = array_merge($command, $phpArgs);

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -1,79 +1,149 @@
-#!/bin/bash
+#!/usr/bin/env php
+<?php
 
-# Xdebug Profile Testing Script
-cd "$(dirname "$0")/.."
-PROJECT_ROOT=$(pwd)
+declare(strict_types=1);
 
-# Check for help flag or missing argument
-if [ "$1" = "--help" ] || [ "$1" = "-h" ] || [ -z "$1" ]; then
-    echo "Usage: $0 PHP_FILE"
-    echo ""
-    echo "Runs Xdebug profiling on the specified PHP file."
-    echo ""
-    echo "Arguments:"
-    echo "  PHP_FILE    Path to PHP file to profile (required)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 test/debug_test.php       # Profile test file"
-    echo "  $0 my_script.php             # Profile specific file"
-    echo "  $0 tests/Unit/SomeTest.php   # Profile test file"
-    echo ""
-    if [ -z "$1" ]; then
-        echo "❌ Error: PHP file argument is required"
-        exit 1
-    fi
-    exit 0
-fi
+// Load autoloader and get project root
+$paths = require __DIR__ . '/autoload.php';
+$projectRoot = $paths['project_root'];
 
-# Check target file exists
-TARGET_FILE="$1"
-if [ ! -f "$TARGET_FILE" ]; then
-    echo "❌ Error: File '$TARGET_FILE' not found"
-    echo "Use '$0 --help' for usage information"
-    exit 1
-fi
+// Parse command line arguments
+function showHelp(string $scriptName): void {
+    echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
+    echo "\n";
+    echo "Runs Xdebug profiling on the specified PHP file or command.\n";
+    echo "\n";
+    echo "Arguments:\n";
+    echo "  PHP_FILE    Path to PHP file to profile (required)\n";
+    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "\n";
+    echo "Examples:\n";
+    echo "  $scriptName test/debug_test.php                    # Profile test file\n";
+    echo "  $scriptName my_script.php                         # Profile specific file\n";
+    echo "  $scriptName bin/page.php -- get /                 # Profile with arguments\n";
+    echo "  $scriptName bin/console.php -- cache:clear --env=dev  # Profile console command\n";
+    echo "\n";
+}
 
-# Generate unique profile filename
-PROFILE_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-PROFILE_FILE="/tmp/xdebug_profile_${PROFILE_TIMESTAMP}.out"
+// Check for help flag or missing argument
+if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+    showHelp($argv[0]);
+    if (count($argv) < 2) {
+        fwrite(STDERR, "❌ Error: PHP file argument is required\n");
+        exit(1);
+    }
+    exit(0);
+}
 
-# Xdebug profiling configuration (Xdebug 3.x format)
-XDEBUG_OPTS="-dzend_extension=xdebug \
-    -dxdebug.mode=profile \
-    -dxdebug.start_with_request=yes \
-    -dxdebug.output_dir=/tmp \
-    -dxdebug.profiler_output_name=cachegrind.out.%t \
-    -dxdebug.use_compression=0"
+// Parse arguments - separate PHP file from PHP arguments
+$targetFile = $argv[1];
+$phpArgs = [];
 
-echo "📊 Profiling: $TARGET_FILE"
+// Find -- separator
+$separatorIndex = array_search('--', $argv);
+if ($separatorIndex !== false) {
+    $phpArgs = array_slice($argv, $separatorIndex + 1);
+}
 
-# Execute with profiling
-php $XDEBUG_OPTS "$TARGET_FILE" 2>/dev/null
+// Check target file exists
+if (!file_exists($targetFile)) {
+    fwrite(STDERR, "❌ Error: File '$targetFile' not found\n");
+    fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+    exit(1);
+}
 
-# Find the generated profile file (Cachegrind format)
-LATEST_PROFILE=$(ls -t /tmp/cachegrind.out.* 2>/dev/null | head -1)
+// Generate unique profile filename
+$profileTimestamp = date('Ymd_His');
 
-if [ -f "$LATEST_PROFILE" ]; then
-    echo "✅ Profile complete: $LATEST_PROFILE"
-    echo "📊 Size: $(ls -lh "$LATEST_PROFILE" | awk '{print $5}')"
+// Build Xdebug options (Xdebug 3.x format)
+$xdebugOpts = [
+    '-dzend_extension=xdebug',
+    '-dxdebug.mode=profile',
+    '-dxdebug.start_with_request=yes',
+    '-dxdebug.output_dir=/tmp',
+    '-dxdebug.profiler_output_name=cachegrind.out.%t',
+    '-dxdebug.use_compression=0'
+];
+
+// Build command
+$command = ['php'];
+$command = array_merge($command, $xdebugOpts);
+$command[] = $targetFile;
+$command = array_merge($command, $phpArgs);
+
+// Execute command
+if (empty($phpArgs)) {
+    echo "📊 Profiling: $targetFile\n";
+} else {
+    echo "📊 Profiling: $targetFile with arguments: " . implode(' ', $phpArgs) . "\n";
+}
+
+// Execute and suppress stderr
+$descriptors = [
+    0 => ['pipe', 'r'],  // stdin
+    1 => ['pipe', 'w'],  // stdout
+    2 => ['pipe', 'w'],  // stderr
+];
+
+$process = proc_open($command, $descriptors, $pipes);
+
+if (is_resource($process)) {
+    // Close stdin
+    fclose($pipes[0]);
     
-    # Display basic profile info if available
-    if command -v grep >/dev/null 2>&1; then
-        FUNCTION_COUNT=$(grep -c "^fn=" "$LATEST_PROFILE" 2>/dev/null || echo "0")
-        CALL_COUNT=$(grep -c "^calls=" "$LATEST_PROFILE" 2>/dev/null || echo "0")
-        echo "📈 Functions: $FUNCTION_COUNT"
-        echo "📞 Calls: $CALL_COUNT"
-    fi
+    // Read stdout (if needed for debugging)
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
     
-    echo ""
-    echo "💡 Analyze with KCachegrind:"
-    echo "   kcachegrind $LATEST_PROFILE"
-    echo ""
-    echo "💡 Or use qcachegrind on macOS:"
-    echo "   qcachegrind $LATEST_PROFILE"
-else
-    echo "❌ No profile file generated. Check Xdebug configuration."
-    echo "💡 Ensure Xdebug is installed and profiling is enabled:"
-    echo "   php -m | grep xdebug"
-    exit 1
-fi
+    // Read and ignore stderr
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    
+    // Wait for process to finish
+    $returnCode = proc_close($process);
+}
+
+// Find the generated profile file (Cachegrind format)
+$profileFiles = glob('/tmp/cachegrind.out.*');
+
+if (!empty($profileFiles)) {
+    // Sort by modification time (newest first)
+    usort($profileFiles, function($a, $b) {
+        return filemtime($b) - filemtime($a);
+    });
+    
+    $latestProfile = $profileFiles[0];
+    $fileSize = formatBytes(filesize($latestProfile));
+    
+    echo "✅ Profile complete: $latestProfile\n";
+    echo "📊 Size: $fileSize\n";
+    
+    // Display basic profile info if available
+    $content = file_get_contents($latestProfile);
+    $functionCount = substr_count($content, "\nfn=");
+    $callCount = substr_count($content, "\ncalls=");
+    
+    echo "📈 Functions: $functionCount\n";
+    echo "📞 Calls: $callCount\n";
+    echo "\n";
+    echo "💡 Analyze with KCachegrind:\n";
+    echo "   kcachegrind $latestProfile\n";
+    echo "\n";
+    echo "💡 Or use qcachegrind on macOS:\n";
+    echo "   qcachegrind $latestProfile\n";
+} else {
+    echo "❌ No profile file generated. Check Xdebug configuration.\n";
+    echo "💡 Ensure Xdebug is installed and profiling is enabled:\n";
+    echo "   php -m | grep xdebug\n";
+    exit(1);
+}
+
+function formatBytes(int $bytes, int $precision = 1): string {
+    $units = ['B', 'K', 'M', 'G'];
+    
+    for ($i = 0; $bytes > 1024 && $i < count($units) - 1; $i++) {
+        $bytes /= 1024;
+    }
+    
+    return round($bytes, $precision) . $units[$i];
+}

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -6,6 +6,9 @@ declare(strict_types=1);
 // Load autoloader and get project root
 $projectRoot = require __DIR__ . '/autoload.php';
 
+// Load common argument parser
+$parse = require __DIR__ . '/parse.php';
+
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
@@ -47,31 +50,8 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments - handle both patterns:
-// Pattern 1: script.php -- args
-// Pattern 2: -- php script.php args
-if ($argv[1] === '--') {
-    // Pattern 2: -- php script.php args
-    if (count($argv) < 3) {
-        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
-        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
-        exit(1);
-    }
-    $phpBinary = $argv[2];
-    $targetFile = $argv[3] ?? '';
-    $phpArgs = array_slice($argv, 4);
-} else {
-    // Pattern 1: script.php -- args
-    $phpBinary = PHP_BINARY;
-    $targetFile = $argv[1];
-    $phpArgs = [];
-    
-    // Find -- separator
-    $separatorIndex = array_search('--', $argv);
-    if ($separatorIndex !== false) {
-        $phpArgs = array_slice($argv, $separatorIndex + 1);
-    }
-}
+// Parse arguments using common function
+[$phpBinary, $targetFile, $phpArgs] = $parse($argv);
 
 // Check target file exists
 if (!file_exists($targetFile)) {

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -4,8 +4,7 @@
 declare(strict_types=1);
 
 // Load autoloader and get project root
-$paths = require __DIR__ . '/autoload.php';
-$projectRoot = $paths['project_root'];
+$projectRoot = require __DIR__ . '/autoload.php';
 
 // Parse command line arguments
 function showHelp(string $scriptName): void {

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -24,8 +24,14 @@ function showHelp(string $scriptName): void {
     echo "\n";
 }
 
-// Check for help flag or missing argument
-if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+// Find -- separator to limit help flag checking
+$separatorIndex = array_search('--', $argv);
+$argsToCheck = $separatorIndex !== false 
+    ? array_slice($argv, 0, $separatorIndex)  // Args before --
+    : $argv;                                   // All args if no --
+
+// Check for help flag or missing argument (only in pre-separator args)
+if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($argv) < 2) {
     showHelp($argv[0]);
     if (count($argv) < 2) {
         fwrite(STDERR, "❌ Error: PHP file argument is required\n");

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -35,7 +35,7 @@ function showHelp(string $scriptName): void {
 }
 
 // Find -- separator to limit help flag checking
-$separatorIndex = array_search('--', $argv);
+$separatorIndex = array_search('--', $argv, true);
 $argsToCheck = $separatorIndex !== false 
     ? array_slice($argv, 0, $separatorIndex)  // Args before --
     : $argv;                                   // All args if no --
@@ -61,7 +61,9 @@ if (!file_exists($targetFile)) {
 }
 
 // Generate unique profile filename
-$profileTimestamp = date('Ymd_His');
+$profileTimestamp = date('Ymd_His') . '_' . getmypid();
+$profileFileName = "cachegrind.out.{$profileTimestamp}";
+$profilePath = "/tmp/{$profileFileName}";
 
 // Build Xdebug options (Xdebug 3.x format)
 $xdebugOpts = [
@@ -69,7 +71,7 @@ $xdebugOpts = [
     '-dxdebug.mode=profile',
     '-dxdebug.start_with_request=yes',
     '-dxdebug.output_dir=/tmp',
-    '-dxdebug.profiler_output_name=cachegrind.out.%t',
+    "-dxdebug.profiler_output_name={$profileFileName}",
     '-dxdebug.use_compression=0'
 ];
 
@@ -124,23 +126,15 @@ if (is_resource($process)) {
     }
 }
 
-// Find the generated profile file (Cachegrind format)
-$profileFiles = glob('/tmp/cachegrind.out.*');
-
-if (!empty($profileFiles)) {
-    // Sort by modification time (newest first)
-    usort($profileFiles, function($a, $b) {
-        return filemtime($b) - filemtime($a);
-    });
+// Check for the generated profile file
+if (file_exists($profilePath)) {
+    $fileSize = formatBytes(filesize($profilePath));
     
-    $latestProfile = $profileFiles[0];
-    $fileSize = formatBytes(filesize($latestProfile));
-    
-    echo "✅ Profile complete: $latestProfile\n";
+    echo "✅ Profile complete: $profilePath\n";
     echo "📊 Size: $fileSize\n";
     
     // Display basic profile info if available
-    $content = file_get_contents($latestProfile);
+    $content = file_get_contents($profilePath);
     $functionCount = substr_count($content, "\nfn=");
     $callCount = substr_count($content, "\ncalls=");
     
@@ -148,10 +142,10 @@ if (!empty($profileFiles)) {
     echo "📞 Calls: $callCount\n";
     echo "\n";
     echo "💡 Analyze with KCachegrind:\n";
-    echo "   kcachegrind $latestProfile\n";
+    echo "   kcachegrind $profilePath\n";
     echo "\n";
     echo "💡 Or use qcachegrind on macOS:\n";
-    echo "   qcachegrind $latestProfile\n";
+    echo "   qcachegrind $profilePath\n";
 } else {
     echo "❌ No profile file generated. Check Xdebug configuration.\n";
     echo "💡 Ensure Xdebug is installed and profiling is enabled:\n";

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -3,19 +3,9 @@
 
 declare(strict_types=1);
 
-// Load autoloader and determine project root
-$autoloadPath = require __DIR__ . '/autoload.php';
-
-// Determine project root from autoloader path
-$normalized = str_replace('\\', '/', $autoloadPath);
-$projectRoot = str_ends_with($normalized, '/vendor/autoload.php')
-    ? dirname($autoloadPath, 2)
-    : dirname($autoloadPath);
-
-if (!file_exists($projectRoot . '/composer.json')) {
-    fwrite(STDERR, "Error: Could not determine project root from autoloader path: $autoloadPath\n");
-    exit(1);
-}
+// Load autoloader and get project root
+$paths = require __DIR__ . '/autoload.php';
+$projectRoot = $paths['project_root'];
 
 // Parse command line arguments
 function showHelp(string $scriptName): void {

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -9,18 +9,25 @@ $projectRoot = require __DIR__ . '/autoload.php';
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
+    echo "       $scriptName -- PHP_BINARY SCRIPT_FILE [SCRIPT_ARGS...]\n";
     echo "\n";
     echo "Runs Xdebug trace testing on the specified PHP file or command.\n";
     echo "\n";
     echo "Arguments:\n";
-    echo "  PHP_FILE    Path to PHP file to trace (required)\n";
-    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_FILE      Path to PHP file to trace (required)\n";
+    echo "  PHP_ARGS      Arguments to pass to the PHP script (after --)\n";
+    echo "  PHP_BINARY    Custom PHP binary path (when using -- prefix)\n";
+    echo "  SCRIPT_FILE   PHP script to trace (when using -- prefix)\n";
+    echo "  SCRIPT_ARGS   Arguments for the script (when using -- prefix)\n";
     echo "\n";
     echo "Examples:\n";
+    echo "  # Standard usage:\n";
     echo "  $scriptName test/debug_test.php                    # Trace test file\n";
-    echo "  $scriptName my_script.php                         # Trace specific file\n";
     echo "  $scriptName bin/page.php -- get /                 # Trace with arguments\n";
-    echo "  $scriptName bin/console.php -- cache:clear --env=dev  # Trace console command\n";
+    echo "\n";
+    echo "  # Custom PHP binary:\n";
+    echo "  $scriptName -- php bin/page.php get /             # Natural PHP command style\n";
+    echo "  $scriptName -- /usr/bin/php8.3 script.php args   # Specific PHP version\n";
     echo "\n";
 }
 
@@ -40,14 +47,30 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments - separate PHP file from PHP arguments
-$targetFile = $argv[1];
-$phpArgs = [];
-
-// Find -- separator
-$separatorIndex = array_search('--', $argv);
-if ($separatorIndex !== false) {
-    $phpArgs = array_slice($argv, $separatorIndex + 1);
+// Parse arguments - handle both patterns:
+// Pattern 1: script.php -- args
+// Pattern 2: -- php script.php args
+if ($argv[1] === '--') {
+    // Pattern 2: -- php script.php args
+    if (count($argv) < 3) {
+        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
+        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+        exit(1);
+    }
+    $phpBinary = $argv[2];
+    $targetFile = $argv[3] ?? '';
+    $phpArgs = array_slice($argv, 4);
+} else {
+    // Pattern 1: script.php -- args
+    $phpBinary = PHP_BINARY;
+    $targetFile = $argv[1];
+    $phpArgs = [];
+    
+    // Find -- separator
+    $separatorIndex = array_search('--', $argv);
+    if ($separatorIndex !== false) {
+        $phpArgs = array_slice($argv, $separatorIndex + 1);
+    }
 }
 
 // Check target file exists
@@ -74,7 +97,7 @@ $xdebugOpts = [
 ];
 
 // Build command
-$command = [PHP_BINARY];
+$command = [$phpBinary];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $targetFile;
 $command = array_merge($command, $phpArgs);

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -68,7 +68,7 @@ $xdebugOpts = [
 ];
 
 // Build command
-$command = ['php'];
+$command = [PHP_BINARY];
 $command = array_merge($command, $xdebugOpts);
 $command[] = $targetFile;
 $command = array_merge($command, $phpArgs);

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -1,63 +1,140 @@
-#!/bin/bash
+#!/usr/bin/env php
+<?php
 
-# Xdebug Trace Testing Script - Flexible Version
-cd "$(dirname "$0")/.."
-PROJECT_ROOT=$(pwd)
+declare(strict_types=1);
 
-# Check for help flag or missing argument
-if [ "$1" = "--help" ] || [ "$1" = "-h" ] || [ -z "$1" ]; then
-    echo "Usage: $0 PHP_FILE"
-    echo ""
-    echo "Runs Xdebug trace testing on the specified PHP file."
-    echo ""
-    echo "Arguments:"
-    echo "  PHP_FILE    Path to PHP file to trace (required)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 test/debug_test.php       # Trace test file"
-    echo "  $0 my_script.php             # Trace specific file"
-    echo "  $0 tests/Unit/SomeTest.php   # Trace test file"
-    echo ""
-    if [ -z "$1" ]; then
-        echo "❌ Error: PHP file argument is required"
-        exit 1
-    fi
-    exit 0
-fi
+// Load autoloader and determine project root
+$autoloadPath = require __DIR__ . '/autoload.php';
 
-# Check target file exists
-TARGET_FILE="$1"
-if [ ! -f "$TARGET_FILE" ]; then
-    echo "❌ Error: File '$TARGET_FILE' not found"
-    echo "Use '$0 --help' for usage information"
-    exit 1
-fi
+// Determine project root from autoloader path
+$normalized = str_replace('\\', '/', $autoloadPath);
+$projectRoot = str_ends_with($normalized, '/vendor/autoload.php')
+    ? dirname($autoloadPath, 2)
+    : dirname($autoloadPath);
 
-# Generate unique trace filename
-TRACE_TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-TRACE_FILE="/tmp/xdebug_trace_${TRACE_TIMESTAMP}"
+if (!file_exists($projectRoot . '/composer.json')) {
+    fwrite(STDERR, "Error: Could not determine project root from autoloader path: $autoloadPath\n");
+    exit(1);
+}
 
-# Xdebug設定（圧縮を明示的に無効化）
-XDEBUG_OPTS="-dzend_extension=xdebug \
-    -dxdebug.mode=trace \
-    -dxdebug.start_with_request=trigger \
-    -dxdebug.trigger_value=TRACE \
-    -dxdebug.trace_format=1 \
-    -dxdebug.use_compression=0 \
-    -dxdebug.output_dir=/tmp \
-    -dxdebug.trace_output_name=xdebug_trace_${TRACE_TIMESTAMP}"
+// Parse command line arguments
+function showHelp(string $scriptName): void {
+    echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
+    echo "\n";
+    echo "Runs Xdebug trace testing on the specified PHP file or command.\n";
+    echo "\n";
+    echo "Arguments:\n";
+    echo "  PHP_FILE    Path to PHP file to trace (required)\n";
+    echo "  PHP_ARGS    Arguments to pass to the PHP script (after --)\n";
+    echo "\n";
+    echo "Examples:\n";
+    echo "  $scriptName test/debug_test.php                    # Trace test file\n";
+    echo "  $scriptName my_script.php                         # Trace specific file\n";
+    echo "  $scriptName bin/page.php -- get /                 # Trace with arguments\n";
+    echo "  $scriptName bin/console.php -- cache:clear --env=dev  # Trace console command\n";
+    echo "\n";
+}
 
-echo "🔍 Tracing: $TARGET_FILE"
-# Execute with trace
-XDEBUG_TRIGGER=TRACE php $XDEBUG_OPTS "$TARGET_FILE" 2>/dev/null
+// Check for help flag or missing argument
+if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+    showHelp($argv[0]);
+    if (count($argv) < 2) {
+        fwrite(STDERR, "❌ Error: PHP file argument is required\n");
+        exit(1);
+    }
+    exit(0);
+}
 
-# Find the generated trace file
-LATEST_TRACE=$(ls -t /tmp/*trace*${TRACE_TIMESTAMP}*.xt 2>/dev/null | head -1)
+// Parse arguments - separate PHP file from PHP arguments
+$targetFile = $argv[1];
+$phpArgs = [];
 
-if [ -f "$LATEST_TRACE" ]; then
-    echo "✅ Trace complete: $LATEST_TRACE"
-    echo "📊 $(wc -l < "$LATEST_TRACE") lines generated"
-else
-    echo "❌ No trace file generated. Check Xdebug configuration."
-    exit 1
-fi
+// Find -- separator
+$separatorIndex = array_search('--', $argv);
+if ($separatorIndex !== false) {
+    $phpArgs = array_slice($argv, $separatorIndex + 1);
+}
+
+// Check target file exists
+if (!file_exists($targetFile)) {
+    fwrite(STDERR, "❌ Error: File '$targetFile' not found\n");
+    fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
+    exit(1);
+}
+
+// Generate unique trace filename
+$traceTimestamp = date('Ymd_His');
+$traceFile = "/tmp/xdebug_trace_$traceTimestamp";
+
+// Build Xdebug options
+$xdebugOpts = [
+    '-dzend_extension=xdebug',
+    '-dxdebug.mode=trace',
+    '-dxdebug.start_with_request=trigger',
+    '-dxdebug.trigger_value=TRACE',
+    '-dxdebug.trace_format=1',
+    '-dxdebug.use_compression=0',
+    '-dxdebug.output_dir=/tmp',
+    "-dxdebug.trace_output_name=xdebug_trace_$traceTimestamp"
+];
+
+// Build command
+$command = ['php'];
+$command = array_merge($command, $xdebugOpts);
+$command[] = $targetFile;
+$command = array_merge($command, $phpArgs);
+
+// Set environment variable
+putenv('XDEBUG_TRIGGER=TRACE');
+
+// Execute command
+if (empty($phpArgs)) {
+    echo "🔍 Tracing: $targetFile\n";
+} else {
+    echo "🔍 Tracing: $targetFile with arguments: " . implode(' ', $phpArgs) . "\n";
+}
+
+// Execute and suppress stderr
+$descriptors = [
+    0 => ['pipe', 'r'],  // stdin
+    1 => ['pipe', 'w'],  // stdout
+    2 => ['pipe', 'w'],  // stderr
+];
+
+$process = proc_open($command, $descriptors, $pipes);
+
+if (is_resource($process)) {
+    // Close stdin
+    fclose($pipes[0]);
+    
+    // Read stdout (if needed for debugging)
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    
+    // Read and ignore stderr
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    
+    // Wait for process to finish
+    $returnCode = proc_close($process);
+}
+
+// Find the generated trace file
+$tracePattern = "/tmp/*trace*{$traceTimestamp}*.xt";
+$traceFiles = glob($tracePattern);
+
+if (!empty($traceFiles)) {
+    // Sort by modification time (newest first)
+    usort($traceFiles, function($a, $b) {
+        return filemtime($b) - filemtime($a);
+    });
+    
+    $latestTrace = $traceFiles[0];
+    $lineCount = count(file($latestTrace));
+    
+    echo "✅ Trace complete: $latestTrace\n";
+    echo "📊 $lineCount lines generated\n";
+} else {
+    echo "❌ No trace file generated. Check Xdebug configuration.\n";
+    exit(1);
+}

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -6,6 +6,9 @@ declare(strict_types=1);
 // Load autoloader and get project root
 $projectRoot = require __DIR__ . '/autoload.php';
 
+// Load common argument parser
+$parse = require __DIR__ . '/parse.php';
+
 // Parse command line arguments
 function showHelp(string $scriptName): void {
     echo "Usage: $scriptName PHP_FILE [-- PHP_ARGS...]\n";
@@ -47,31 +50,8 @@ if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($a
     exit(0);
 }
 
-// Parse arguments - handle both patterns:
-// Pattern 1: script.php -- args
-// Pattern 2: -- php script.php args
-if ($argv[1] === '--') {
-    // Pattern 2: -- php script.php args
-    if (count($argv) < 3) {
-        fwrite(STDERR, "❌ Error: PHP command and script required after --\n");
-        fwrite(STDERR, "Use '{$argv[0]} --help' for usage information\n");
-        exit(1);
-    }
-    $phpBinary = $argv[2];
-    $targetFile = $argv[3] ?? '';
-    $phpArgs = array_slice($argv, 4);
-} else {
-    // Pattern 1: script.php -- args
-    $phpBinary = PHP_BINARY;
-    $targetFile = $argv[1];
-    $phpArgs = [];
-    
-    // Find -- separator
-    $separatorIndex = array_search('--', $argv);
-    if ($separatorIndex !== false) {
-        $phpArgs = array_slice($argv, $separatorIndex + 1);
-    }
-}
+// Parse arguments using common function
+[$phpBinary, $targetFile, $phpArgs] = $parse($argv);
 
 // Check target file exists
 if (!file_exists($targetFile)) {

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -4,8 +4,7 @@
 declare(strict_types=1);
 
 // Load autoloader and get project root
-$paths = require __DIR__ . '/autoload.php';
-$projectRoot = $paths['project_root'];
+$projectRoot = require __DIR__ . '/autoload.php';
 
 // Parse command line arguments
 function showHelp(string $scriptName): void {

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -83,7 +83,7 @@ if (empty($phpArgs)) {
     echo "🔍 Tracing: $targetFile with arguments: " . implode(' ', $phpArgs) . "\n";
 }
 
-// Execute and suppress stderr
+// Execute with proper output handling
 $descriptors = [
     0 => ['pipe', 'r'],  // stdin
     1 => ['pipe', 'w'],  // stdout
@@ -96,16 +96,29 @@ if (is_resource($process)) {
     // Close stdin
     fclose($pipes[0]);
     
-    // Read stdout (if needed for debugging)
+    // Read and forward stdout
     $stdout = stream_get_contents($pipes[1]);
     fclose($pipes[1]);
     
-    // Read and ignore stderr
+    // Read and forward stderr
     $stderr = stream_get_contents($pipes[2]);
     fclose($pipes[2]);
     
-    // Wait for process to finish
+    // Wait for process to finish and get exit code
     $returnCode = proc_close($process);
+    
+    // Forward child process output
+    if ($stdout !== '') {
+        echo $stdout;
+    }
+    if ($stderr !== '') {
+        fwrite(STDERR, $stderr);
+    }
+    
+    // Propagate child process exit code
+    if ($returnCode !== 0) {
+        exit($returnCode);
+    }
 }
 
 // Find the generated trace file

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -24,8 +24,14 @@ function showHelp(string $scriptName): void {
     echo "\n";
 }
 
-// Check for help flag or missing argument
-if (in_array('--help', $argv) || in_array('-h', $argv) || count($argv) < 2) {
+// Find -- separator to limit help flag checking
+$separatorIndex = array_search('--', $argv);
+$argsToCheck = $separatorIndex !== false 
+    ? array_slice($argv, 0, $separatorIndex)  // Args before --
+    : $argv;                                   // All args if no --
+
+// Check for help flag or missing argument (only in pre-separator args)
+if (in_array('--help', $argsToCheck) || in_array('-h', $argsToCheck) || count($argv) < 2) {
     showHelp($argv[0]);
     if (count($argv) < 2) {
         fwrite(STDERR, "❌ Error: PHP file argument is required\n");

--- a/src/PhpunitConfigManager.php
+++ b/src/PhpunitConfigManager.php
@@ -95,7 +95,7 @@ class PhpunitConfigManager
 
         // Determine output path
         if (! $outputPath) {
-            $outputPath = tempnam(sys_get_temp_dir(), 'phpunit_xdebug_mcp_') . '.xml';
+            $outputPath = tempnam('/tmp', 'phpunit_xdebug_mcp_') . '.xml';
         }
 
         if (! $dom->save($outputPath)) {


### PR DESCRIPTION
## Summary
- Add `--` separator support to all CLI debugging tools for passing arguments to traced PHP scripts
- Convert CLI tools from bash to PHP implementations for consistency and maintainability  
- Centralize project root detection in autoload.php to eliminate code duplication
- Fix original issue: `./bin/xdebug-trace script.php -- arg1 arg2` now works correctly

## Problem Solved
**Before**: `./bin/xdebug-trace php bin/page.php get /` → ❌ "Error: File 'php' not found"  
**After**: `./bin/xdebug-trace bin/page.php -- get /` → ✅ Works with proper argument passing

## Changes Made

### 🔧 xdebug-trace Enhancements
- **Full PHP rewrite** with robust argument parsing using `--` separator pattern
- **Comprehensive help system** with detailed usage examples  
- **Error handling** with clear messaging and usage hints
- **Process management** with proper stdin/stdout/stderr handling

### 📊 xdebug-profile Improvements  
- **PHP implementation** with consistent argument support
- **Cachegrind format** output analysis
- **File size formatting** and statistics display
- **Tool integration** suggestions (KCachegrind/qcachegrind)

### 📈 xdebug-coverage Enhancements
- **Advanced argument parsing** supporting both `--html/--text` options and `-- PHP_ARGS`
- **Dynamic wrapper script** generation for coverage collection
- **Multiple output formats** (HTML with color coding, text summary)
- **Proper argument forwarding** to target scripts

### 🏗️ Infrastructure Improvements
- **Centralized autoload.php** eliminates code duplication across all tools
- **Direct project root return** simplifies usage pattern: `$projectRoot = require __DIR__ . '/autoload.php';`
- **Consistent PHP implementation** pattern across all CLI tools
- **Unified error handling** and user experience

## Technical Details

### Argument Parsing Implementation
```php
// Find -- separator and extract PHP arguments
$separatorIndex = array_search('--', $argv);
if ($separatorIndex !== false) {
    $phpArgs = array_slice($argv, $separatorIndex + 1);
}
```

### Process Execution Pattern
```php
// Build command with proper argument forwarding
$command = ['php'];
$command = array_merge($command, $xdebugOpts);
$command[] = $targetFile;
$command = array_merge($command, $phpArgs);
```

### Autoloader Centralization
```php
// Returns project root directly - no more duplication
$projectRoot = require __DIR__ . '/autoload.php';
```

## Test Plan
- [x] Test xdebug-trace with arguments: `./bin/xdebug-trace test/debug_test.php -- arg1 arg2`
- [x] Test xdebug-profile with arguments: `./bin/xdebug-profile script.php -- args`  
- [x] Test xdebug-coverage with options and arguments: `./bin/xdebug-coverage script.php --html -- args`
- [x] Verify all tools show proper help with `--help` flag
- [x] Confirm centralized autoload.php works across all tools
- [x] Validate original problem is completely resolved

## Example Usage

### Before (Broken)
```bash
./bin/xdebug-trace php bin/page.php get /
# ❌ Error: File 'php' not found
```

### After (Working)
```bash
./bin/xdebug-trace bin/page.php -- get /
# 🔍 Tracing: bin/page.php with arguments: get /
# ✅ Trace complete: /tmp/xdebug_trace_20250821_071447.xt
# 📊 64 lines generated
```

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによる要約

CLIデバッグツールをPHPで書き直し、`--`引数セパレータのサポートを追加し、オートロードロジックを一元化し、エラーハンドリングとプロセス実行を統一し、スクリプト引数の転送を修正しました。

新機能:
- 全てのCLIツールで、ターゲットPHPスクリプトに引数を転送するための`--`セパレータのサポートを追加
- 一貫性があり保守しやすい実装のために、CLIツールをbashからPHPに移行

バグ修正:
- xdebug-traceにおける引数転送を修正し、`--`以降のパラメータがスクリプトに正しく渡されるようにした

改善点:
- bin/autoload.phpでプロジェクトルートの検出を一元化し、重複するローダーロジックを削除
- xdebug-trace, xdebug-profile, xdebug-coverage, xdebug-phpunit全体で、引数解析、ヘルプ出力、エラーハンドリングを標準化
- カバレッジおよびプロファイリングツールに、ファイルサイズ統計と複数の出力形式（HTML/テキスト）を導入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rewrite CLI debugging tools in PHP, add support for the `--` argument separator, centralize autoload logic, unify error handling and process execution, and fix script argument forwarding.

New Features:
- Add `--` separator support to forward arguments to target PHP scripts in all CLI tools
- Migrate CLI tools from bash to PHP for consistent and maintainable implementation

Bug Fixes:
- Fix argument forwarding in xdebug-trace so that parameters after `--` are correctly passed to scripts

Enhancements:
- Centralize project root detection in bin/autoload.php and remove duplicated loader logic
- Standardize argument parsing, help output, and error handling across xdebug-trace, xdebug-profile, xdebug-coverage, and xdebug-phpunit
- Introduce file size statistics and multiple output formats (HTML/text) in coverage and profiling tools

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - New PHP-based CLI tools for Xdebug: coverage (HTML/text), trace, and profile with improved help, argument passing, and informative output; coverage and trace support passing target script arguments.

- Refactor
  - Replaced Bash tools with PHP implementations for more robust execution, reporting, and error handling.
  - Project-root detection now validates and returns the detected project root, emitting clearer errors when undetermined.

- Bug Fixes
  - Default temporary output path standardized to /tmp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->