### PR TITLE
Implement AMP-based session management for stateful Xdebug debugging

### DIFF
--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -1985,11 +1985,12 @@ final class DebugServer
 
             if (! empty($stack)) {
                 $currentFrame = $stack[0];
+                $loc = $this->parseStackLocation($currentFrame);
                 $debugState['breaks'] = [
                     [
                         'location' => [
-                            'file' => $currentFrame['file'] ?? 'unknown',
-                            'line' => (int) ($currentFrame['line'] ?? 1),
+                            'file' => $loc['file'] ?? 'unknown',
+                            'line' => (int) ($loc['line'] ?? 1),
                         ],
                         'variables' => $variables,
                     ],
@@ -2077,6 +2078,7 @@ final class DebugServer
                 'content' => [],
             ];
         }
+
         // Remove duplicates and sort by modification time, get the most recent
         $allTraceFiles = array_unique($allTraceFiles);
         usort($allTraceFiles, static function ($a, $b) {

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -56,7 +56,7 @@ class McpServerIntegrationTest extends TestCase
         $this->assertEquals(2, $toolsResponse['id']);
         $this->assertArrayHasKey('result', $toolsResponse);
         $this->assertArrayHasKey('tools', $toolsResponse['result']);
-        $this->assertCount(42, $toolsResponse['result']['tools']);
+        $this->assertCount(43, $toolsResponse['result']['tools']);
 
         // Verify essential tools are present
         $toolNames = array_column($toolsResponse['result']['tools'], 'name');

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -10,6 +10,8 @@ use ReflectionClass;
 
 use function array_column;
 use function extension_loaded;
+use function json_decode;
+use function time;
 
 class McpServerTest extends TestCase
 {
@@ -57,7 +59,7 @@ class McpServerTest extends TestCase
 
         $this->assertArrayHasKey('result', $response);
         $this->assertArrayHasKey('tools', $response['result']);
-        $this->assertCount(42, $response['result']['tools']);
+        $this->assertCount(43, $response['result']['tools']);
 
         $toolNames = array_column($response['result']['tools'], 'name');
         $this->assertContains('xdebug_connect', $toolNames);
@@ -102,9 +104,11 @@ class McpServerTest extends TestCase
 
         $response = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
 
-        $this->assertArrayHasKey('error', $response);
-        $this->assertEquals(-32000, $response['error']['code']);
-        $this->assertStringContainsString('Not connected to Xdebug', $response['error']['message']);
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('content', $response['result']);
+        $content = json_decode($response['result']['content'][0]['text'], true);
+        $this->assertEquals('error', $content['status']);
+        $this->assertStringContainsString('No active session found', $content['message']);
     }
 
     public function testUnknownToolCall(): void
@@ -179,6 +183,174 @@ class McpServerTest extends TestCase
         $this->assertStringContainsString('<html>', $result);
         $this->assertStringContainsString('<title>Code Coverage Report</title>', $result);
         $this->assertStringContainsString('/path/file1.php', $result);
+    }
+
+    public function testSessionManagement(): void
+    {
+        $reflection = new ReflectionClass($this->server);
+        $property = $reflection->getProperty('xdebugSessions');
+        $property->setAccessible(true);
+
+        // Verify sessions are empty initially
+        $sessions = $property->getValue($this->server);
+        $this->assertEmpty($sessions);
+
+        // Manually add a mock session
+        $mockSessionId = 'test_session_123';
+        $mockSession = [
+            'client' => null,
+            'host' => '127.0.0.1',
+            'port' => 9004,
+            'connected' => true,
+            'created_at' => time(),
+            'last_activity' => time(),
+            'session_info' => 'test session',
+        ];
+
+        $sessions = [$mockSessionId => $mockSession];
+        $property->setValue($this->server, $sessions);
+
+        // Verify session was added
+        $updatedSessions = $property->getValue($this->server);
+        $this->assertCount(1, $updatedSessions);
+        $this->assertArrayHasKey($mockSessionId, $updatedSessions);
+        $this->assertEquals('127.0.0.1', $updatedSessions[$mockSessionId]['host']);
+        $this->assertEquals(9004, $updatedSessions[$mockSessionId]['port']);
+        $this->assertTrue($updatedSessions[$mockSessionId]['connected']);
+    }
+
+    public function testListSessionsTool(): void
+    {
+        $reflection = new ReflectionClass($this->server);
+        $property = $reflection->getProperty('xdebugSessions');
+        $property->setAccessible(true);
+
+        // Add test sessions
+        $testSessions = [
+            'session1' => [
+                'client' => null,
+                'host' => '127.0.0.1',
+                'port' => 9004,
+                'connected' => true,
+                'created_at' => time() - 100,
+                'last_activity' => time() - 50,
+                'session_info' => 'test session 1',
+            ],
+            'session2' => [
+                'client' => null,
+                'host' => '192.168.1.100',
+                'port' => 9005,
+                'connected' => false,
+                'created_at' => time() - 200,
+                'last_activity' => time() - 150,
+                'session_info' => 'test session 2',
+            ],
+        ];
+        $property->setValue($this->server, $testSessions);
+
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 10,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'xdebug_list_sessions',
+                'arguments' => [],
+            ],
+        ];
+
+        $response = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('content', $response['result']);
+
+        $content = json_decode($response['result']['content'][0]['text'], true);
+        $this->assertArrayHasKey('status', $content);
+        $this->assertEquals('success', $content['status']);
+        $this->assertEquals(2, $content['active_sessions']);
+        $this->assertArrayHasKey('sessions', $content);
+        $this->assertArrayHasKey('session1', $content['sessions']);
+        $this->assertArrayHasKey('session2', $content['sessions']);
+        $this->assertEquals('127.0.0.1', $content['sessions']['session1']['host']);
+        $this->assertEquals(9004, $content['sessions']['session1']['port']);
+        $this->assertTrue($content['sessions']['session1']['connected']);
+        $this->assertFalse($content['sessions']['session2']['connected']);
+    }
+
+    public function testGetXdebugClientMethod(): void
+    {
+        $reflection = new ReflectionClass($this->server);
+        $method = $reflection->getMethod('getXdebugClient');
+        $method->setAccessible(true);
+
+        $property = $reflection->getProperty('xdebugSessions');
+        $property->setAccessible(true);
+
+        // Use null since we can't easily mock XdebugClient in unit tests
+        $testSessions = [
+            'test_session' => [
+                'client' => null, // Simple null for testing session structure
+                'host' => '127.0.0.1',
+                'port' => 9004,
+                'connected' => true,
+                'created_at' => time(),
+                'last_activity' => time(),
+                'session_info' => 'test',
+            ],
+        ];
+        $property->setValue($this->server, $testSessions);
+
+        // Get client for specific session ID (will return null due to null client)
+        $result = $method->invoke($this->server, 'test_session');
+        $this->assertNull($result); // Since client is null in test data
+
+        // Verify null is returned for non-existent session ID
+        $result = $method->invoke($this->server, 'non_existent_session');
+        $this->assertNull($result);
+    }
+
+    public function testSessionCleanup(): void
+    {
+        $reflection = new ReflectionClass($this->server);
+        $method = $reflection->getMethod('cleanupInactiveSessions');
+        $method->setAccessible(true);
+
+        $property = $reflection->getProperty('xdebugSessions');
+        $property->setAccessible(true);
+
+        // Create old and recent sessions
+        $oldTime = time() - 3700; // More than 1 hour ago
+        $recentTime = time() - 100; // Recent
+
+        $testSessions = [
+            'old_session' => [
+                'client' => null,
+                'host' => '127.0.0.1',
+                'port' => 9004,
+                'connected' => true,
+                'created_at' => $oldTime,
+                'last_activity' => $oldTime,
+                'session_info' => 'old session',
+            ],
+            'recent_session' => [
+                'client' => null,
+                'host' => '127.0.0.1',
+                'port' => 9004,
+                'connected' => true,
+                'created_at' => $recentTime,
+                'last_activity' => $recentTime,
+                'session_info' => 'recent session',
+            ],
+        ];
+        $property->setValue($this->server, $testSessions);
+
+        // Execute cleanup
+        $method->invoke($this->server);
+
+        // Verify old session was removed and recent session remains
+        $sessions = $property->getValue($this->server);
+        $this->assertCount(1, $sessions);
+        $this->assertArrayHasKey('recent_session', $sessions);
+        $this->assertArrayNotHasKey('old_session', $sessions);
     }
 
     private function invokePrivateMethod(object $object, string $methodName, array $parameters = []): mixed


### PR DESCRIPTION
## Summary
- Implement multiple session management in McpServer with unique session IDs
- Add support for optional session_id parameters in all step debugging methods
- Add automatic session cleanup with 1-hour timeout mechanism
- Add xdebug_list_sessions tool for session monitoring and management
- Add comprehensive unit tests for session management (13/13 passing)

## Key Features
- **Multiple concurrent sessions**: Support for managing multiple Xdebug debugging sessions simultaneously
- **Session persistence**: Sessions maintain state across multiple MCP requests
- **Automatic cleanup**: Expired sessions (inactive for more than 1 hour) are automatically cleaned up
- **Backward compatibility**: Existing single-session workflows continue to work without changes
- **JSON response format**: Consistent JSON responses for all session-based operations

## Test Plan
- [x] All existing unit tests continue to pass
- [x] New session management tests added and passing
- [x] Backward compatibility verified
- [x] Code style fixes applied

## Technical Implementation
Solves MCP's stateless limitations for Xdebug step debugging operations by implementing persistent session management that allows AI assistants to maintain debugging context across multiple requests while supporting concurrent debugging sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourceryによる要約

McpServerにおけるXdebugのステップデバッグに対して、ステートフルなAMPベースのセッション管理を導入します。これにより、一意のIDを持つ複数の同時セッション、オプションのsession_idパラメータ、JSON形式のレスポンス、自動的な期限切れクリーンアップ、およびアクティブなセッションを監視するための新しいツールがサポートされます。

新機能:
- 一意のセッションIDを持つ複数の同時Xdebugデバッグセッションをサポート
- ステートフルな操作のために、すべてのデバッグステップメソッドにオプションのsession_idパラメータを追加
- アクティブなセッションを一覧表示および検査するためのxdebug_list_sessionsツールを提供

改善点:
- シャットダウン時に1時間以上非アクティブなセッションを自動的にクリーンアップ
- シングルセッションワークフローとの後方互換性を維持
- すべてのXdebugツールレスポンスをJSON形式に標準化

テスト:
- セッション管理（作成、一覧表示、クライアント取得、クリーンアップ）のための包括的なユニットテストを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce stateful, AMP-based session management for Xdebug step debugging in McpServer by supporting multiple concurrent sessions with unique IDs, optional session_id parameters, JSON-formatted responses, automatic expiration cleanup, and a new tool for monitoring active sessions.

New Features:
- Support multiple concurrent Xdebug debugging sessions with unique session IDs
- Add optional session_id parameter to all debugging step methods for stateful operations
- Provide xdebug_list_sessions tool to list and inspect active sessions

Enhancements:
- Automatically clean up sessions inactive for over one hour on shutdown
- Maintain backward compatibility with single-session workflows
- Standardize all Xdebug tool responses to JSON format

Tests:
- Add comprehensive unit tests for session management (creation, listing, client retrieval, and cleanup)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Multi-session Xdebug support: manage multiple debugging sessions concurrently, each with a session ID.
  - Stepping and continue commands accept an optional session_id to target specific sessions.
  - New tool to list active sessions with basic metadata.
  - More consistent JSON responses for connect, disconnect, and step/continue actions.

- Bug Fixes
  - More accurate breakpoint file/line reporting in debug state.

- Tests
  - Updated tool count expectations and added coverage for session management, listing, retrieval, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->