### PR TITLE
Modify composer require command for xdebug-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This MCP server enables AI to debug PHP with superhuman capabilities:
 
 ```bash
 # Install
-composer require koriym/xdebug-mcp
+composer require --dev koriym/xdebug-mcp
 
 # Enable AI debugging
 echo "@vendor/koriym/xdebug-mcp/docs/debug_guideline_for_ai.md" >> CLAUDE.md


### PR DESCRIPTION
Updated installation command to include --dev flag.

## Sourceryによる要約

ドキュメント:
- `README` のインストールセクションにある `xdebug-mcp` パッケージの `composer require` コマンドに `--dev` フラグを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add --dev flag to the composer require command for the xdebug-mcp package in the README installation section

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include the `--dev` flag for package installation across multiple sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->