### PR TITLE
Fix #28 (Issue 2): Use correct process ID placeholder in profiler filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replaced relative paths (`./bin/*`) with absolute paths using `dirname(__DIR__)`
   - Enables Claude Code to invoke xdebug-mcp tools regardless of current working directory
   - All MCP tools (x-trace, x-debug, x-profile, x-coverage) now work standalone
+- **Profiler Filename Placeholder**: Fixed cachegrind output filename to display actual process ID ([#28](https://github.com/koriym/xdebug-mcp/issues/28))
+  - Changed placeholder from `%s` (script name) to `%p` (process ID) in profiler_output_name
+  - Output now shows `/tmp/cachegrind.out.12345` instead of `/tmp/cachegrind.out.%s`
+  - Makes profile files easy to identify and use with analysis tools
 
 ## [0.2.1] - 2025-08-31
 

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -143,7 +143,7 @@ $xdebugOptions = [
     '-dxdebug.mode=profile',
     '-dxdebug.start_with_request=yes',
     "-dxdebug.output_dir={$xdebugOutputDir}",
-    '-dxdebug.profiler_output_name=cachegrind.out.%%s',
+    '-dxdebug.profiler_output_name=cachegrind.out.%%p',
     '-dxdebug.use_compression=0',  // Disable compression for easier parsing
 ];
 


### PR DESCRIPTION
## Summary

Resolves Issue #28 (Issue 2) by fixing the cachegrind output filename to use the correct Xdebug placeholder for process ID.

## Problem

When running `xdebug-profile`, the output displayed:
```
✅ Profile complete: /tmp/cachegrind.out.%s
```

The literal `%s` placeholder was shown instead of the actual process ID, making it difficult to:
- Identify specific profile files when multiple processes run
- Correlate profile files with their originating processes
- Use the displayed filename directly for analysis tools

## Root Cause

Line 146 in `bin/xdebug-profile` used `%s` (script name) instead of `%p` (process ID):
```php
'-dxdebug.profiler_output_name=cachegrind.out.%%s',  // Wrong placeholder
```

According to [Xdebug documentation](https://xdebug.org/docs/profiler):
- `%p` = Process ID (PID)
- `%s` = Script name

## Solution

Changed the placeholder from `%s` to `%p`:
```php
'-dxdebug.profiler_output_name=cachegrind.out.%%p',  // Correct placeholder
```

Now the output displays actual process IDs:
```
✅ Profile complete: /tmp/cachegrind.out.12345
```

## Benefits

- ✅ Displays actual process ID in output
- ✅ Easy to identify and locate specific profile files
- ✅ Follows Xdebug documentation conventions
- ✅ Filename can be directly used with analysis tools
- ✅ No ambiguity when multiple profiles are generated

## Testing

The fix ensures that:
- Profile files are generated with actual process IDs (e.g., `cachegrind.out.98765`)
- Output message displays the correct filename
- Users can immediately use the displayed filename for analysis

## Related

This addresses Issue 2 from #28. Other suggestions from #28 (full report, filtering, exclude-vendor) can be addressed in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる要約

バグ修正:
- cachegrindの出力ファイル名において、スクリプト名プレースホルダー（%s）の代わりに、プロセスIDに正しいXdebugプレースホルダー（%p）を使用するようにしました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use the correct Xdebug placeholder (%p) for process ID in cachegrind output filenames instead of the script name placeholder (%s)

</details>