### PR TITLE
Fix #28 (Issue 1): Suppress script output in JSON mode for clean parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed placeholder from `%s` (script name) to `%p` (process ID) in profiler_output_name
   - Output now shows `/tmp/cachegrind.out.12345` instead of `/tmp/cachegrind.out.%s`
   - Makes profile files easy to identify and use with analysis tools
+- **JSON Output Parsing**: Fixed `xdebug-profile --json` to suppress script output for clean JSON ([#28](https://github.com/koriym/xdebug-mcp/issues/28))
+  - Script stdout/stderr now automatically suppressed in JSON mode
+  - Enables clean piping to jq: `... | jq '.["🎯 bottleneck_functions"]'`
+  - Human-readable mode unchanged (still shows script output)
+  - Updated documentation with jq usage examples
 
 ## [0.2.1] - 2025-08-31
 

--- a/bin/xdebug-profile
+++ b/bin/xdebug-profile
@@ -28,7 +28,7 @@ function showHelp(string $scriptName): void
     echo "  ✅ Comprehensive metrics: CPU time, memory, function calls, I/O operations\n";
     echo "\n";
     echo "CORE OPTIONS:\n";
-    echo "  --json                      AI-optimized JSON output with comprehensive metrics\n";
+    echo "  --json                      AI-optimized JSON output (suppresses script output for clean parsing)\n";
     echo "  --claude                    Auto-analyze profile data with Claude AI\n";
     echo "  --context=TEXT             Add contextual description for AI analysis\n";
     echo "  --include-vendor=PATTERNS  Include vendor packages in performance analysis\n";
@@ -51,6 +51,9 @@ function showHelp(string $scriptName): void
     echo "  # 5. Test suite performance optimization\n";
     echo "  $scriptName --context=\"PHPUnit test suite performance\" -- php vendor/bin/phpunit\n";
     echo "\n";
+    echo "  # 6. JSON output for tooling (clean parsing with jq)\n";
+    echo "  $scriptName --json -- php script.php | jq '.\"🎯 bottleneck_functions\"'\n";
+    echo "\n";
     echo "PERFORMANCE ANALYSIS CAPABILITIES:\n";
     echo "  🚀 Function Timing: Identify slowest functions with microsecond precision\n";
     echo "  💾 Memory Analysis: Track memory usage patterns and identify leaks\n";
@@ -60,7 +63,8 @@ function showHelp(string $scriptName): void
     echo "\n";
     echo "OUTPUT FORMATS:\n";
     echo "  Default: Human-readable with proper time/memory units and KCachegrind suggestions\n";
-    echo "  --json: AI-optimized JSON with emoji keys and comprehensive performance metrics\n";
+    echo "  --json: Pure JSON output (script stdout/stderr suppressed for clean parsing with jq)\n";
+    echo "          AI-optimized with emoji keys and comprehensive performance metrics\n";
     echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json\n";
     echo "  Benefits: AI can rank bottlenecks, suggest optimizations, compare before/after\n";
     echo "\n";
@@ -158,9 +162,16 @@ if ($xdebugFlag !== '') {
 $allArgs = array_merge($xdebugOptions, [$targetFile], $phpArgs);
 $cmd = 'php ' . implode(' ', array_map('escapeshellarg', $allArgs));
 
-// Execute with passthru to show output
+// Execute command
 $exitCode = 0;
-passthru($cmd, $exitCode);
+if ($jsonOutput) {
+    // JSON mode: suppress script output for clean JSON parsing
+    $cmd .= ' > /dev/null 2>&1';
+    exec($cmd, $output, $exitCode);
+} else {
+    // Human-readable mode: show script output
+    passthru($cmd, $exitCode);
+}
 
 // Generate profile analysis
 try {

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -215,10 +215,23 @@ rm /tmp/trace.*.xt /tmp/cachegrind.out.*
 
 **Issue**: Output not in expected format or missing data
 
+**Common Problem - Script Output Mixing with JSON**:
+```bash
+# ❌ Before v0.x.x: Script output breaks jq parsing
+./bin/xdebug-profile --json -- php script.php | jq '.'
+# parse error: Invalid numeric literal at line 1, column 8
+
+# ✅ Now: Clean JSON output (script stdout/stderr automatically suppressed)
+./bin/xdebug-profile --json -- php script.php | jq '.["🎯 bottleneck_functions"]'
+```
+
 **Format Solutions**:
 ```bash
 # Ensure JSON output for AI processing
 ./bin/xdebug-profile --json -- php script.php
+
+# Pipe to jq for filtering
+./bin/xdebug-profile --json -- php script.php | jq '.["⏱️ execution_time_ms"]'
 
 # Verify schema compliance
 ./bin/validate-profile-json profile-output.json


### PR DESCRIPTION
## Summary

Resolves Issue #28 (Issue 1) by making `--json` output clean and parseable with `jq` and other JSON tools.

## Problem

When using `--json` mode, script stdout/stderr mixed with JSON output:

```bash
./bin/xdebug-profile --json -- php script.php | jq '.'
# parse error: Invalid numeric literal at line 1, column 8
```

**Root Cause:**
- Script output (echo, var_dump, errors) interleaved with JSON
- Broke `jq` parsing and piping to other tools
- Made JSON mode unusable for automation and MCP integration

## Solution

Automatically suppress script output when `--json` is used:

```php
if ($jsonOutput) {
    // Suppress script output for clean JSON
    $cmd .= ' > /dev/null 2>&1';
    exec($cmd, $output, $exitCode);
} else {
    // Show script output in human mode
    passthru($cmd, $exitCode);
}
```

## Benefits

✅ **Clean JSON output** - No more mixed output:
```bash
./bin/xdebug-profile --json -- php script.php | jq '.["🎯 bottleneck_functions"]'
# Works perfectly!
```

✅ **jq compatible** - Pipe directly to jq for filtering
✅ **MCP compatible** - Pure JSON response for AI integration
✅ **Tool-friendly** - Easy integration with other JSON processors
✅ **Backward compatible** - Human-readable mode unchanged

## Changes

### Code:
- `bin/xdebug-profile`: Conditional output suppression based on `$jsonOutput` flag
- Exit code preserved for error detection

### Documentation:
- `bin/xdebug-profile --help`: Updated option descriptions and added jq example
- `docs/TROUBLESHOOTING.md`: Added section on JSON output issues with before/after examples

## Usage Examples

**Before (broken):**
```bash
./bin/xdebug-profile --json -- php script.php
# Mixed output breaks parsing
```

**After (clean):**
```bash
# Pure JSON output
./bin/xdebug-profile --json -- php script.php | jq '.["⏱️ execution_time_ms"]'

# Human-readable with script output
./bin/xdebug-profile -- php script.php
```

## Testing

Verified that:
- JSON mode produces clean, parseable output
- jq filtering works correctly
- Human mode still shows script output
- Exit codes preserved for error handling

## Related

This addresses Issue 1 from #28. Other enhancements (--top, --filter) will be addressed in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourceryによる要約

JSONモードでのスクリプト出力を抑制し、クリーンでパース可能なJSONを生成し、jqフィルタリングの使用例を含むドキュメントを更新

バグ修正:
- `--json`使用時にスクリプトの標準出力および標準エラー出力を抑制し、出力の混在を防ぎ、クリーンなJSONパースを可能にする

機能改善:
- スクリプト出力抑制時に元のコマンドの終了コードを保持する

ドキュメント:
- JSONモードおよびjqフィルタリングの使用例（Before/After）を含むトラブルシューティングセクションを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Suppress script output in JSON mode to produce clean, parseable JSON and update documentation with usage examples for jq filtering

Bug Fixes:
- Suppress script stdout and stderr when --json is used to prevent interleaved output and enable clean JSON parsing

Enhancements:
- Preserve the original command’s exit code when suppressing script output

Documentation:
- Add troubleshooting section with before/after examples for JSON mode and jq filtering usage

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON output now suppresses profiled script stdout/stderr for clean, machine-parseable output; human-readable mode remains unchanged.

* **Documentation**
  * Help text and changelog updated with JSON workflow examples and usage.
  * Troubleshooting guide enhanced with examples for piping JSON to tools (e.g., jq) and avoiding mixed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->