### PR TITLE
docs: Fix slash command examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ composer global require koriym/xdebug-mcp
 
 **AI Slash Commands** (Claude Code):
 ```bash
-/x-debug "script.php" "script.php:42:$error!=null" "" "Debug error handling"
-/x-trace script="auth.php" context="Login flow analysis" include_vendor="bear/*"
+/x-trace php script.php         # Execution tracing
+/x-profile php api.php          # Performance profiling
+/x-coverage vendor/bin/phpunit  # Code coverage
+/x-debug php script.php         # Interactive debugging
 ```
 
 


### PR DESCRIPTION
## Summary
- Update slash command examples to match actual implementation
- Simpler, clearer syntax

## Before
```bash
/x-debug "script.php" "script.php:42:$error!=null" "" "Debug error handling"
/x-trace script="auth.php" context="Login flow analysis" include_vendor="bear/*"
```

## After
```bash
/x-trace php script.php         # Execution tracing
/x-profile php api.php          # Performance profiling
/x-coverage vendor/bin/phpunit  # Code coverage
/x-debug php script.php         # Interactive debugging
```

## Summary by Sourcery

Documentation:
- README 内の AI スラッシュコマンドの例を更新し、トレーシング、プロファイリング、カバレッジ、およびデバッグに関する、より正確で分かりやすい使用パターンを示すようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh AI slash command examples in the README to show accurate, clearer usage patterns for tracing, profiling, coverage, and debugging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Slash Commands examples with explicit command syntax and inline comments for improved clarity and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->