### PR TITLE
Add natural language mapping and x-backtrace MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,7 @@ This project prioritizes **execution-time trace analysis** over traditional code
 
 **IMPORTANT: When asked to analyze, debug, or understand any PHP file, ALWAYS use appropriate Xdebug tools automatically unless explicitly told otherwise.**
 
-**CRITICAL: AIは常にMCPツールを優先して使用すること。CLIを直接実行するのではなく、MCPツールを使用してください。**
+**CRITICAL: AI should always prioritize MCP tools over direct CLI execution.**
 
 #### Natural Language to MCP Tool Mapping / 自然言語とMCPツールのマッピング
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,6 +379,23 @@ This project prioritizes **execution-time trace analysis** over traditional code
 
 **IMPORTANT: When asked to analyze, debug, or understand any PHP file, ALWAYS use appropriate Xdebug tools automatically unless explicitly told otherwise.**
 
+**CRITICAL: AIは常にMCPツールを優先して使用すること。CLIを直接実行するのではなく、MCPツールを使用してください。**
+
+#### Natural Language to MCP Tool Mapping / 自然言語とMCPツールのマッピング
+
+| User Request / ユーザーリクエスト | MCP Tool | Description / 説明 |
+|----------------------------------|----------|-------------------|
+| Forward trace, execution flow, trace execution<br>フォワードトレース、実行フロー、トレース実行 | `x-trace` | Record execution flow without stopping<br>実行の流れを記録（停止しない） |
+| Step execution, step debugging, breakpoints, inspect variables<br>ステップ実行、ステップデバッグ、ブレークポイント、変数検査 | `x-debug` | Stop at breakpoints and inspect<br>ブレークポイントで停止して検査 |
+| Profile, performance analysis, find bottlenecks<br>プロファイル、パフォーマンス分析、ボトルネック検出 | `x-profile` | Execution time and memory analysis<br>実行時間・メモリ分析 |
+| Coverage, test coverage, code coverage<br>カバレッジ、テストカバレッジ、コードカバレッジ | `x-coverage` | Code coverage analysis<br>コードカバレッジ分析 |
+| Backtrace, stack trace, call stack<br>バックトレース、スタックトレース、コールスタック | `x-backtrace` | Get stack trace at current position<br>現在位置のスタックトレースを取得 |
+
+**Note on "Trace" ambiguity / 「トレース」の曖昧さについて:**
+- **Forward Trace (フォワードトレース)**: Records execution flow from start to end → Use `x-trace`
+- **Backtrace (バックトレース)**: Shows call stack at a specific point → Use `x-backtrace`
+- **Step Debugging (ステップ実行)**: Interactive debugging with breakpoints → Use `x-debug`
+
 #### Available Xdebug Tools:
 - `./bin/xdebug-debug` - Interactive step debugging with breakpoints
 - `./bin/xdebug-profile` - Performance profiling

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ composer global require koriym/xdebug-mcp
 ~/.composer/vendor/bin/xdebug-coverage --help  # Understand AI coverage analysis
 ~/.composer/vendor/bin/xdebug-trace --help     # Master execution flow tracing
 ~/.composer/vendor/bin/xdebug-profile --help   # Performance optimization guidance
+~/.composer/vendor/bin/xdebug-backtrace --help # Get stack trace at breakpoint
 
 # Example: Catch null bugs automatically
 ~/.composer/vendor/bin/xdebug-debug --break='script.php:42:$user==null' --exit-on-break -- php script.php
@@ -125,6 +126,7 @@ composer global require koriym/xdebug-mcp
 ```bash
 /x-debug "script.php" "script.php:42:$error!=null" "" "Debug error handling"
 /x-trace script="auth.php" context="Login flow analysis" include_vendor="bear/*"
+/x-backtrace script="app.php" breakpoint="app.php:50" context="Check call hierarchy"
 ```
 
 
@@ -156,6 +158,12 @@ All tools now feature comprehensive AI-optimized help documentation. **Always ru
   ~/.composer/vendor/bin/xdebug-profile --help   # 📖 AI-driven optimization workflow
   ```
 
+- **`xdebug-backtrace`** 📋 - Get stack trace (backtrace) at breakpoint
+  ```bash
+  ~/.composer/vendor/bin/xdebug-backtrace --help  # 📖 Understand call hierarchy
+  ~/.composer/vendor/bin/xdebug-backtrace --break='app.php:50' -- php app.php
+  ```
+
 - **`xdebug-phpunit`** - PHPUnit integration with Xdebug profiling and coverage
 
 ### 🎯 AI-First Design Philosophy
@@ -176,7 +184,7 @@ All tools now feature comprehensive AI-optimized help documentation. **Always ru
 
 ### AI Integration Features
 - **42+ MCP Tools**: Performance profiling, code coverage, execution tracing, memory diagnostics, error tracking
-- **Slash Commands**: `/x-debug`, `/x-profile`, `/x-trace`, `/x-coverage` for Claude Code
+- **Slash Commands**: `/x-debug`, `/x-profile`, `/x-trace`, `/x-coverage`, `/x-backtrace` for Claude Code
 - **Schema-Validated Output**: JSON that any AI can understand and analyze
 - **Dynamic Vendor Filtering**: AI can specify which vendor packages to include/exclude during analysis
 

--- a/bin/xdebug-backtrace
+++ b/bin/xdebug-backtrace
@@ -19,8 +19,9 @@ function showHelp(): void
     echo "  --break=SPEC      Breakpoint (file.php:line or file.php:line:condition)\n";
     echo "  --depth=N         Maximum stack depth to return (default: 10)\n";
     echo "  --context=TEXT    Context description for AI analysis\n";
-    echo "  --json            Output in JSON format (default)\n";
     echo "  --help, -h        Show this help\n";
+    echo "\n";
+    echo "OUTPUT: JSON format (optimized for AI consumption)\n";
     echo "\n";
     echo "EXAMPLES:\n";
     echo "  xdebug-backtrace -- php script.php                    # Get stack at first line\n";
@@ -53,15 +54,14 @@ function parseBreakpoint(string $breakSpec): ?array
     $line = (int) $m[2];
     $condition = $m[3] ?? null;
 
-    // Try to resolve file path
-    $resolvedFile = null;
-    if (file_exists($file)) {
-        $resolvedFile = $file;
-    } elseif (!str_starts_with($file, '/') && file_exists(getcwd() . '/' . $file)) {
-        $resolvedFile = getcwd() . '/' . $file;
+    // Try to resolve file path (cross-platform)
+    $resolvedFile = realpath($file);
+    if ($resolvedFile === false) {
+        // Try relative to current working directory
+        $resolvedFile = realpath(getcwd() . DIRECTORY_SEPARATOR . $file);
     }
 
-    if (!$resolvedFile) {
+    if ($resolvedFile === false) {
         throw new RuntimeException("Breakpoint file not found: $file");
     }
 
@@ -108,11 +108,6 @@ function parseBreakpoint(string $breakSpec): ?array
 
         if ($parseOptions && str_starts_with($arg, '--context=')) {
             $context = substr($arg, 10);
-            continue;
-        }
-
-        if ($parseOptions && $arg === '--json') {
-            $jsonOutput = true;
             continue;
         }
 

--- a/bin/xdebug-backtrace
+++ b/bin/xdebug-backtrace
@@ -1,0 +1,164 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Koriym\XdebugMcp\DebugServer;
+use Koriym\XdebugMcp\Constants;
+
+/**
+ * Display help information
+ */
+function showHelp(): void
+{
+    echo "Usage: xdebug-backtrace [options] [--] command\n";
+    echo "\n";
+    echo "Get stack trace (backtrace) at breakpoint or first executable line\n";
+    echo "\n";
+    echo "OPTIONS:\n";
+    echo "  --break=SPEC      Breakpoint (file.php:line or file.php:line:condition)\n";
+    echo "  --depth=N         Maximum stack depth to return (default: 10)\n";
+    echo "  --context=TEXT    Context description for AI analysis\n";
+    echo "  --json            Output in JSON format (default)\n";
+    echo "  --help, -h        Show this help\n";
+    echo "\n";
+    echo "EXAMPLES:\n";
+    echo "  xdebug-backtrace -- php script.php                    # Get stack at first line\n";
+    echo "  xdebug-backtrace --break=app.php:50 -- php app.php    # Get stack at breakpoint\n";
+    echo "  xdebug-backtrace --depth=20 -- php main.php           # Deep stack trace\n";
+    echo "\n";
+    echo "USE CASES:\n";
+    echo "  - Understand call hierarchy at specific point\n";
+    echo "  - Debug 'how did we get here?' questions\n";
+    echo "  - Analyze function call depth and recursion\n";
+    echo "\n";
+    exit(0);
+}
+
+/**
+ * Parse breakpoint specification
+ */
+function parseBreakpoint(string $breakSpec): ?array
+{
+    $spec = trim($breakSpec);
+    if (empty($spec)) {
+        return null;
+    }
+
+    if (!preg_match('/^(.*):(\d+)(?::(.*))?$/', $spec, $m)) {
+        throw new RuntimeException("Invalid breakpoint format: $spec\n" .
+            "Use: file.php:line or file.php:line:condition");
+    }
+    $file = $m[1];
+    $line = (int) $m[2];
+    $condition = $m[3] ?? null;
+
+    // Try to resolve file path
+    $resolvedFile = null;
+    if (file_exists($file)) {
+        $resolvedFile = $file;
+    } elseif (!str_starts_with($file, '/') && file_exists(getcwd() . '/' . $file)) {
+        $resolvedFile = getcwd() . '/' . $file;
+    }
+
+    if (!$resolvedFile) {
+        throw new RuntimeException("Breakpoint file not found: $file");
+    }
+
+    return [
+        'file' => $resolvedFile,
+        'line' => $line,
+        'condition' => $condition
+    ];
+}
+
+(function () use ($argv){
+    require_once __DIR__ . '/autoload.php';
+
+    if (count($argv) === 1) {
+        showHelp();
+    }
+
+    // Parse command line arguments
+    $breakpoint = null;
+    $depth = 10;
+    $context = '';
+    $command = [];
+    $parseOptions = true;
+    $jsonOutput = true;
+
+    for ($i = 1; $i < count($argv); $i++) {
+        $arg = $argv[$i];
+
+        if ($parseOptions && $arg === '--') {
+            $parseOptions = false;
+            continue;
+        }
+
+        if ($parseOptions && str_starts_with($arg, '--break=')) {
+            $breakpoint = parseBreakpoint(substr($arg, 8));
+            continue;
+        }
+
+        if ($parseOptions && str_starts_with($arg, '--depth=')) {
+            $depth = (int)substr($arg, 8);
+            if ($depth <= 0) $depth = 10;
+            continue;
+        }
+
+        if ($parseOptions && str_starts_with($arg, '--context=')) {
+            $context = substr($arg, 10);
+            continue;
+        }
+
+        if ($parseOptions && $arg === '--json') {
+            $jsonOutput = true;
+            continue;
+        }
+
+        if ($parseOptions && ($arg === '--help' || $arg === '-h')) {
+            showHelp();
+        }
+
+        if (!$parseOptions || !str_starts_with($arg, '--')) {
+            $command[] = $arg;
+        }
+    }
+
+    if (empty($command)) {
+        showHelp();
+    }
+
+    // Determine target script
+    if ($command[0] === 'php' && isset($command[1])) {
+        $targetScript = $command[1];
+    } elseif (file_exists($command[0])) {
+        $targetScript = $command[0];
+    } else {
+        throw new RuntimeException("Could not determine target script from command: " . implode(' ', $command));
+    }
+
+    if (!file_exists($targetScript)) {
+        throw new RuntimeException("Target script not found: $targetScript");
+    }
+
+    // Build options for DebugServer
+    $breakpoints = [];
+    if ($breakpoint) {
+        $breakpoints[] = $breakpoint;
+    }
+
+    $options = [
+        'breakpoints' => $breakpoints,
+        'command' => $command,
+        'traceOnly' => true,
+        'jsonOutput' => $jsonOutput,
+        'context' => $context,
+        'maxSteps' => 1,  // Only need one step to get backtrace
+        'backtraceMode' => true,
+        'backtraceDepth' => $depth
+    ];
+
+    $server = new DebugServer($targetScript, Constants::XDEBUG_DEBUG_PORT, null, $options, $jsonOutput);
+    $server();
+})();

--- a/bin/xdebug-backtrace
+++ b/bin/xdebug-backtrace
@@ -16,12 +16,12 @@ function showHelp(): void
     echo "Get stack trace (backtrace) at breakpoint or first executable line\n";
     echo "\n";
     echo "OPTIONS:\n";
-    echo "  --break=SPEC      Breakpoint (file.php:line or file.php:line:condition)\n";
+    echo "  --break=SPEC      Breakpoint (file.php:line)\n";
     echo "  --depth=N         Maximum stack depth to return (default: 10)\n";
     echo "  --context=TEXT    Context description for AI analysis\n";
     echo "  --help, -h        Show this help\n";
     echo "\n";
-    echo "OUTPUT: JSON format (optimized for AI consumption)\n";
+    echo "OUTPUT: Structured JSON (schema: xdebug-backtrace.json)\n";
     echo "\n";
     echo "EXAMPLES:\n";
     echo "  xdebug-backtrace -- php script.php                    # Get stack at first line\n";
@@ -32,6 +32,8 @@ function showHelp(): void
     echo "  - Understand call hierarchy at specific point\n";
     echo "  - Debug 'how did we get here?' questions\n";
     echo "  - Analyze function call depth and recursion\n";
+    echo "\n";
+    echo "SCHEMA: https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json\n";
     echo "\n";
     exit(0);
 }
@@ -46,13 +48,12 @@ function parseBreakpoint(string $breakSpec): ?array
         return null;
     }
 
-    if (!preg_match('/^(.*):(\d+)(?::(.*))?$/', $spec, $m)) {
+    if (!preg_match('/^(.*):(\d+)$/', $spec, $m)) {
         throw new RuntimeException("Invalid breakpoint format: $spec\n" .
-            "Use: file.php:line or file.php:line:condition");
+            "Use: file.php:line");
     }
     $file = $m[1];
     $line = (int) $m[2];
-    $condition = $m[3] ?? null;
 
     // Try to resolve file path (cross-platform)
     $resolvedFile = realpath($file);
@@ -67,9 +68,26 @@ function parseBreakpoint(string $breakSpec): ?array
 
     return [
         'file' => $resolvedFile,
-        'line' => $line,
-        'condition' => $condition
+        'line' => $line
     ];
+}
+
+/**
+ * Output structured backtrace JSON
+ */
+function outputBacktraceJson(string $script, ?string $breakpointStr, string $context, int $depth, array $stack): void
+{
+    $result = [
+        '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json',
+        'script' => $script,
+        'breakpoint' => $breakpointStr,
+        'context' => $context,
+        'depth' => $depth,
+        'stack' => array_slice($stack, 0, $depth),
+        'timestamp' => date('c'),
+    ];
+
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
 }
 
 (function () use ($argv){
@@ -81,11 +99,11 @@ function parseBreakpoint(string $breakSpec): ?array
 
     // Parse command line arguments
     $breakpoint = null;
+    $breakpointStr = null;
     $depth = 10;
     $context = '';
     $command = [];
     $parseOptions = true;
-    $jsonOutput = true;
 
     for ($i = 1; $i < count($argv); $i++) {
         $arg = $argv[$i];
@@ -96,7 +114,8 @@ function parseBreakpoint(string $breakSpec): ?array
         }
 
         if ($parseOptions && str_starts_with($arg, '--break=')) {
-            $breakpoint = parseBreakpoint(substr($arg, 8));
+            $breakpointStr = substr($arg, 8);
+            $breakpoint = parseBreakpoint($breakpointStr);
             continue;
         }
 
@@ -137,7 +156,7 @@ function parseBreakpoint(string $breakSpec): ?array
         throw new RuntimeException("Target script not found: $targetScript");
     }
 
-    // Build options for DebugServer
+    // Use DebugServer to get backtrace at breakpoint
     $breakpoints = [];
     if ($breakpoint) {
         $breakpoints[] = $breakpoint;
@@ -147,13 +166,52 @@ function parseBreakpoint(string $breakSpec): ?array
         'breakpoints' => $breakpoints,
         'command' => $command,
         'traceOnly' => true,
-        'jsonOutput' => $jsonOutput,
+        'jsonOutput' => true,
         'context' => $context,
-        'maxSteps' => 1,  // Only need one step to get backtrace
+        'maxSteps' => 1,
         'backtraceMode' => true,
         'backtraceDepth' => $depth
     ];
 
-    $server = new DebugServer($targetScript, Constants::XDEBUG_DEBUG_PORT, null, $options, $jsonOutput);
+    // Capture DebugServer output
+    ob_start();
+    $server = new DebugServer($targetScript, Constants::XDEBUG_DEBUG_PORT, null, $options, true);
     $server();
+    $output = ob_get_clean();
+
+    // Parse DebugServer output and reformat to backtrace schema
+    $debugData = json_decode($output, true);
+
+    $stack = [];
+    if (isset($debugData['breaks'][0]['stack'])) {
+        // If DebugServer provides stack info
+        foreach ($debugData['breaks'][0]['stack'] as $level => $frameStr) {
+            if (preg_match('/^(.+) at (.+):(\d+)$/', $frameStr, $m)) {
+                $stack[] = [
+                    'level' => $level,
+                    'function' => $m[1],
+                    'file' => $m[2],
+                    'line' => (int)$m[3],
+                ];
+            }
+        }
+    } elseif (isset($debugData['breaks'][0]['location'])) {
+        // Fallback: use location from breaks
+        $loc = $debugData['breaks'][0]['location'];
+        $stack[] = [
+            'level' => 0,
+            'function' => '{main}',
+            'file' => $loc['file'] ?? $targetScript,
+            'line' => $loc['line'] ?? 1,
+        ];
+    }
+
+    // Output in backtrace schema format
+    outputBacktraceJson(
+        $targetScript,
+        $breakpointStr,
+        $context,
+        $depth,
+        $stack
+    );
 })();

--- a/bin/xdebug-backtrace
+++ b/bin/xdebug-backtrace
@@ -102,7 +102,7 @@ function parseBreakpoint(string $breakSpec): ?array
 
         if ($parseOptions && str_starts_with($arg, '--depth=')) {
             $depth = (int)substr($arg, 8);
-            if ($depth <= 0) $depth = 10;
+            if ($depth <= 0 || $depth > 1000) $depth = 10;
             continue;
         }
 

--- a/bin/xdebug-backtrace
+++ b/bin/xdebug-backtrace
@@ -169,8 +169,6 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
         'jsonOutput' => true,
         'context' => $context,
         'maxSteps' => 1,
-        'backtraceMode' => true,
-        'backtraceDepth' => $depth
     ];
 
     // Capture DebugServer output

--- a/bin/xdebug-trace
+++ b/bin/xdebug-trace
@@ -93,34 +93,60 @@ if (isset($argv[1]) && ($argv[1] === '--help' || $argv[1] === '-h')) {
     exit(0);
 }
 
-// Parse flags
-$jsonOutput = in_array('--json', $argv);
-$claudeAnalysis = in_array('--claude', $argv);
-$context = null;
+// Find the index of '--' separator to split xdebug-trace flags from target command
+$separatorIndex = array_search('--', $argv);
+if ($separatorIndex === false) {
+    // No separator found - all args are for xdebug-trace (legacy behavior)
+    $ownArgs = array_slice($argv, 1); // exclude script name
+    $targetArgs = [];
+} else {
+    // Split: before '--' are our flags, after '--' is the target command
+    $ownArgs = array_slice($argv, 1, $separatorIndex - 1);
+    $targetArgs = array_slice($argv, $separatorIndex + 1);
+}
 
-// Parse --context= flag
-foreach ($argv as $arg) {
+// Parse flags only from our own args (before '--')
+$jsonOutput = in_array('--json', $ownArgs);
+$claudeAnalysis = in_array('--claude', $ownArgs);
+$context = null;
+$includeVendor = null;
+
+// Parse --context= and --include-vendor= flags from our own args only
+foreach ($ownArgs as $arg) {
     if (str_starts_with($arg, '--context=')) {
         $context = substr($arg, 10);
-        break;
+    } elseif (str_starts_with($arg, '--include-vendor=')) {
+        $includeVendor = substr($arg, 17);
     }
 }
 
-// Remove flags and find target file
-$flagsToRemove = ['--json', '--claude', '--'];
-if ($context !== null) {
-    $flagsToRemove[] = '--context=' . $context;
-}
-$args = array_values(array_diff($argv, $flagsToRemove));
-array_shift($args); // remove script name
+// Build target command from args after '--'
+if (!empty($targetArgs)) {
+    // Skip 'php' if present at start of target args
+    if ($targetArgs[0] === 'php') {
+        array_shift($targetArgs);
+    }
+    $targetFile = $targetArgs[0] ?? '';
+    $phpArgs = array_slice($targetArgs, 1);
+} else {
+    // Legacy: no '--' separator, find target file from remaining args
+    $flagsToRemove = ['--json', '--claude'];
+    if ($context !== null) {
+        $flagsToRemove[] = '--context=' . $context;
+    }
+    if ($includeVendor !== null) {
+        $flagsToRemove[] = '--include-vendor=' . $includeVendor;
+    }
+    $args = array_values(array_diff($ownArgs, $flagsToRemove));
 
-// Skip 'php' if present
-if (isset($args[0]) && $args[0] === 'php') {
-    array_shift($args);
-}
+    // Skip 'php' if present
+    if (isset($args[0]) && $args[0] === 'php') {
+        array_shift($args);
+    }
 
-$targetFile = $args[0] ?? '';
-$phpArgs = array_slice($args, 1);
+    $targetFile = $args[0] ?? '';
+    $phpArgs = array_slice($args, 1);
+}
 
 // Check target file exists
 if (!file_exists($targetFile)) {

--- a/docs/schemas/xdebug-backtrace.json
+++ b/docs/schemas/xdebug-backtrace.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+  "title": "Xdebug Backtrace Result",
+  "description": "AI-optimized stack trace data for PHP debugging. Shows call hierarchy at a specific breakpoint or execution point.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+      "description": "JSON Schema reference for this backtrace result"
+    },
+    "script": {
+      "type": "string",
+      "description": "Target PHP script that was executed"
+    },
+    "breakpoint": {
+      "type": ["string", "null"],
+      "description": "Breakpoint location where backtrace was captured (file:line format)",
+      "pattern": "^.+:\\d+$"
+    },
+    "context": {
+      "type": "string",
+      "description": "Contextual description for AI analysis"
+    },
+    "depth": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum stack depth requested"
+    },
+    "stack": {
+      "type": "array",
+      "description": "Call stack frames from current position to entry point",
+      "items": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Stack frame level (0 = current position)"
+          },
+          "function": {
+            "type": "string",
+            "description": "Function or method name"
+          },
+          "file": {
+            "type": "string",
+            "description": "Source file path"
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Line number in source file"
+          },
+          "class": {
+            "type": ["string", "null"],
+            "description": "Class name if method call"
+          },
+          "type": {
+            "type": ["string", "null"],
+            "enum": ["->", "::", null],
+            "description": "Call type: -> for instance, :: for static"
+          }
+        },
+        "required": ["level", "function", "file", "line"]
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the backtrace was captured"
+    }
+  },
+  "required": ["$schema", "script", "stack", "timestamp"],
+  "additionalProperties": false,
+
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+      "title": "JSON Schema for Xdebug Backtrace Results"
+    },
+    {
+      "rel": "debug-guide",
+      "href": "https://koriym.github.io/xdebug-mcp/debug_guideline_for_ai.md",
+      "title": "PHP Xdebug Debugging Guidelines"
+    },
+    {
+      "rel": "command",
+      "href": "file:///bin/xdebug-backtrace",
+      "title": "Command Line Tool"
+    }
+  ],
+
+  "x-ai-usage": {
+    "purpose": "Understand 'how did execution reach this point?' questions",
+    "use_cases": [
+      "Debug unexpected function calls",
+      "Trace error origins through call hierarchy",
+      "Understand complex code flow",
+      "Analyze recursion depth"
+    ],
+    "analysis_tips": {
+      "read_bottom_up": "Stack is ordered current→entry, read from bottom to understand call sequence",
+      "check_file_line": "Each frame shows exact location for source code reference",
+      "identify_entry": "Last frame shows program entry point"
+    }
+  }
+}

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -1104,7 +1104,7 @@ final class McpServer
             $depth = $args['depth'] ?? 10;
 
             // Build command
-            $cmd = $this->binDir . '/xdebug-backtrace --json';
+            $cmd = $this->binDir . '/xdebug-backtrace';
 
             // Add breakpoint if specified
             if (! empty($breakpoint)) {

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -164,6 +164,35 @@ final class McpServer
                     'required' => ['script'],
                 ],
             ],
+            'x-backtrace' => [
+                'name' => 'x-backtrace',
+                'description' => 'Get stack trace (backtrace) at breakpoint | ex) ./x-backtrace --break="app.php:50" "php app.php"',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'script' => [
+                            'type' => 'string',
+                            'description' => 'PHP script to get backtrace from (e.g., "tests/fixtures/debug_test.php")',
+                        ],
+                        'breakpoint' => [
+                            'type' => 'string',
+                            'description' => 'Breakpoint location (e.g., "file.php:15")',
+                            'default' => '',
+                        ],
+                        'depth' => [
+                            'type' => 'integer',
+                            'description' => 'Maximum stack depth to return',
+                            'default' => 10,
+                        ],
+                        'context' => [
+                            'type' => 'string',
+                            'description' => 'Context description for backtrace analysis',
+                            'default' => '',
+                        ],
+                    ],
+                    'required' => ['script'],
+                ],
+            ],
         ];
     }
 
@@ -456,6 +485,32 @@ final class McpServer
                             ],
                         ],
                     ],
+                    [
+                        'name' => 'x-backtrace',
+                        'description' => 'Get stack trace (backtrace) at breakpoint | ex) /x-backtrace --script="app.php" --break="app.php:50"',
+                        'arguments' => [
+                            [
+                                'name' => 'script',
+                                'description' => 'PHP script to get backtrace from (e.g., "tests/fixtures/debug_test.php")',
+                                'required' => true,
+                            ],
+                            [
+                                'name' => 'breakpoint',
+                                'description' => 'Breakpoint location (e.g., "file.php:15")',
+                                'required' => false,
+                            ],
+                            [
+                                'name' => 'depth',
+                                'description' => 'Maximum stack depth to return (default: 10)',
+                                'required' => false,
+                            ],
+                            [
+                                'name' => 'context',
+                                'description' => 'Context description for backtrace analysis',
+                                'required' => false,
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -501,6 +556,9 @@ final class McpServer
 
             case 'x-coverage':
                 return $this->executeXCoverage($id, $args);
+
+            case 'x-backtrace':
+                return $this->executeXBacktrace($id, $args);
 
             default:
                 return [
@@ -577,6 +635,25 @@ final class McpServer
 
                 if (isset($args[2])) {
                     $args['format'] = $args[2];
+                }
+
+                break;
+
+            case 'x-backtrace':
+                if (isset($args[0])) {
+                    $args['script'] = $args[0];
+                }
+
+                if (isset($args[1])) {
+                    $args['breakpoint'] = $args[1];
+                }
+
+                if (isset($args[2])) {
+                    $args['depth'] = $args[2];
+                }
+
+                if (isset($args[3])) {
+                    $args['context'] = $args[3];
                 }
 
                 break;
@@ -692,6 +769,11 @@ final class McpServer
 
             case 'x-coverage':
                 $result = $this->executeXCoverage(null, $arguments);
+
+                return $result['result']['messages'][0]['content']['text'] ?? 'No result';
+
+            case 'x-backtrace':
+                $result = $this->executeXBacktrace(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
 
@@ -1005,6 +1087,91 @@ final class McpServer
                 'error' => [
                     'code' => -32000,
                     'message' => 'x-coverage execution failed: ' . $e->getMessage(),
+                ],
+            ];
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    private function executeXBacktrace(mixed $id, array $args): array
+    {
+        try {
+            $originalScript = $args['script'] ?? '';
+            $script = $this->processScriptArgument($originalScript);
+            $this->validatePhpBinaryScript($script);
+            $context = $args['context'] ?? '';
+            $breakpoint = $args['breakpoint'] ?? '';
+            $depth = $args['depth'] ?? 10;
+
+            // Build command
+            $cmd = $this->binDir . '/xdebug-backtrace --json';
+
+            // Add breakpoint if specified
+            if (! empty($breakpoint)) {
+                $cmd .= ' --break=' . escapeshellarg($breakpoint);
+            }
+
+            if (! empty($context)) {
+                $cmd .= ' --context=' . escapeshellarg($context);
+            }
+
+            if (! empty($depth)) {
+                $cmd .= ' --depth=' . escapeshellarg((string) $depth);
+            }
+
+            // Build command - user must specify PHP binary explicitly
+            $cmd .= ' -- ' . $script;
+
+            // Execute command
+            $output = [];
+            $returnCode = 0;
+            exec($cmd . ' 2>&1', $output, $returnCode);
+
+            // Handle common error cases
+            $outputText = implode("\n", $output);
+            if ($returnCode !== 0 && str_contains($outputText, 'No such file')) {
+                throw new FileNotFoundException('Script file not found: ' . $script);
+            }
+
+            if ($returnCode !== 0 && str_contains($outputText, 'Permission denied')) {
+                throw new InvalidArgumentException('Permission denied accessing: ' . $script);
+            }
+
+            $result = [
+                'command' => $cmd,
+                'exit_code' => $returnCode,
+                'output' => $outputText,
+                'context' => $context,
+                'script' => $script,
+                'breakpoint' => $breakpoint,
+                'depth' => $depth,
+                'timestamp' => date('Y-m-d H:i:s'),
+            ];
+
+            return [
+                'jsonrpc' => '2.0',
+                'id' => $id,
+                'result' => [
+                    'messages' => [
+                        [
+                            'role' => 'assistant',
+                            'content' => [
+                                'type' => 'text',
+                                'text' => 'Stack trace (backtrace) ' . ($returnCode === 0 ? 'retrieved' : 'failed') . ":\n\n**Script**: {$originalScript}\n**Context**: {$context}\n**Breakpoint**: {$breakpoint}\n**Depth**: {$depth}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Stack Trace**:\n```\n" . $outputText . "\n```",
+                            ],
+                        ],
+                    ],
+                    'debug_data' => $result,
+                ],
+            ];
+        } catch (Throwable $e) {
+            // @codeCoverageIgnoreStart - Exception handling path requires backtrace failures which are environment-dependent
+            return [
+                'jsonrpc' => '2.0',
+                'id' => $id,
+                'error' => [
+                    'code' => -32000,
+                    'message' => 'x-backtrace execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -1115,7 +1115,7 @@ final class McpServer
                 $cmd .= ' --context=' . escapeshellarg($context);
             }
 
-            if ($depth !== null && $depth !== '') {
+            if ($depth !== null && $depth !== '' && (int) $depth > 0 && (int) $depth <= 1000) {
                 $cmd .= ' --depth=' . escapeshellarg((string) (int) $depth);
             }
 

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -1115,8 +1115,8 @@ final class McpServer
                 $cmd .= ' --context=' . escapeshellarg($context);
             }
 
-            if (! empty($depth)) {
-                $cmd .= ' --depth=' . escapeshellarg((string) $depth);
+            if ($depth !== null && $depth !== '') {
+                $cmd .= ' --depth=' . escapeshellarg((string) (int) $depth);
             }
 
             // Build command - user must specify PHP binary explicitly

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -54,7 +54,7 @@ class McpServerIntegrationTest extends TestCase
         $this->assertEquals(2, $toolsResponse['id']);
         $this->assertArrayHasKey('result', $toolsResponse);
         $this->assertArrayHasKey('tools', $toolsResponse['result']);
-        $this->assertCount(4, $toolsResponse['result']['tools']);
+        $this->assertCount(5, $toolsResponse['result']['tools']);
 
         // Verify analysis tools are present
         $toolNames = array_column($toolsResponse['result']['tools'], 'name');
@@ -63,6 +63,7 @@ class McpServerIntegrationTest extends TestCase
             'x-profile',
             'x-debug',
             'x-coverage',
+            'x-backtrace',
         ];
 
         foreach ($expectedTools as $toolName) {

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -128,6 +128,20 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
         $this->assertStringContainsString('xdebug-debug', $output);
     }
 
+    public function testXdebugBacktraceCommandExists(): void
+    {
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-backtrace'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-backtrace'));
+    }
+
+    public function testXdebugBacktraceHelp(): void
+    {
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xdebug-backtrace --help 2>&1');
+        $this->assertNotNull($output);
+        $this->assertStringContainsString('Usage:', $output);
+        $this->assertStringContainsString('xdebug-backtrace', $output);
+    }
+
     public function testAllCommandsAreExecutable(): void
     {
         $commands = [
@@ -136,6 +150,7 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
             'xdebug-profile',
             'xdebug-coverage',
             'xdebug-debug',
+            'xdebug-backtrace',
         ];
 
         foreach ($commands as $command) {

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -182,6 +182,6 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
         $this->assertEquals(1, $response['id']);
         $this->assertArrayHasKey('result', $response);
         $this->assertArrayHasKey('tools', $response['result']);
-        $this->assertCount(4, $response['result']['tools'], 'Should have 4 execution tools after removing internal analysis tools');
+        $this->assertCount(5, $response['result']['tools'], 'Should have 5 execution tools');
     }
 }

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -59,7 +59,7 @@ class McpServerTest extends TestCase
 
         $this->assertArrayHasKey('result', $response);
         $this->assertArrayHasKey('tools', $response['result']);
-        $this->assertCount(4, $response['result']['tools']);
+        $this->assertCount(5, $response['result']['tools']);
 
         $toolNames = array_column($response['result']['tools'], 'name');
         // Test that execution tools are present
@@ -67,6 +67,7 @@ class McpServerTest extends TestCase
         $this->assertContains('x-profile', $toolNames);
         $this->assertContains('x-debug', $toolNames);
         $this->assertContains('x-coverage', $toolNames);
+        $this->assertContains('x-backtrace', $toolNames);
 
         // Test that interactive debugging tools are removed
         $this->assertNotContains('xdebug_connect', $toolNames);
@@ -185,13 +186,14 @@ class McpServerTest extends TestCase
 
         $this->assertArrayHasKey('result', $response);
         $this->assertArrayHasKey('prompts', $response['result']);
-        $this->assertCount(4, $response['result']['prompts']);
+        $this->assertCount(5, $response['result']['prompts']);
 
         $promptNames = array_column($response['result']['prompts'], 'name');
         $this->assertContains('x-trace', $promptNames);
         $this->assertContains('x-debug', $promptNames);
         $this->assertContains('x-profile', $promptNames);
         $this->assertContains('x-coverage', $promptNames);
+        $this->assertContains('x-backtrace', $promptNames);
     }
 
     public function testNotificationsInitialized(): void


### PR DESCRIPTION
# Summary
Based on xstep project learnings from docs/spec/xstep-learnings.md:

## Phase 1: CLAUDE.md Natural Language Mapping (High Priority)
	•	Add bilingual (EN/JP) natural language to MCP tool mapping table
	•	Clarify trace disambiguation (forward trace vs backtrace vs step debugging)
	•	Add instruction for AI to prioritize MCP tools over CLI
## Phase 2: x-backtrace MCP Tool (Medium Priority)
	•	Add new x-backtrace tool to get stack trace at breakpoint
	•	Create bin/xdebug-backtrace CLI script
	•	Update README documentation

## Summary by Sourcery

ブレークポイントでスタックトレースを取得するための x-backtrace MCP ツールを導入し、AI ガイダンスおよびドキュメントを更新して、自然言語によるデバッグ要求を適切な MCP ツールに優先的かつ対応付けてマッピングできるようにします。

New Features:
- スクリプト、ブレークポイント、深さ、コンテキストといったパラメータをサポートし、ブレークポイントでスタックトレースを取得するための x-backtrace MCP ツールおよびプロンプトを追加。
- AI 駆動のデバッグワークフローで利用できるよう、`xdebug-backtrace` CLI エントリポイントおよび対応するスラッシュコマンドを公開。
- MCP ツールへの自然言語（英語／日本語）マッピングを文書化し、直接 CLI を使用するのではなく MCP ツールを優先的に利用するための明示的なガイダンスを追加。

Enhancements:
- MCP サーバーを拡張し、位置引数を正規化して、新しい x-backtrace 機能へのツール呼び出しを既存の Xdebug ツールと併せてルーティングできるように変更。
- CLAUDE 向けガイダンスにおいて、フォワードトレース、バックトレース、ステップデバッグを区別できるよう、トレース関連の用語を明確化。

Tests:
- MCP サーバーのテストを更新し、ツールおよびプロンプトの一覧に新しい x-backtrace ツールとプロンプトを含めるように変更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an x-backtrace MCP tool for retrieving stack traces at breakpoints and update AI guidance and documentation to prioritize and map natural language debugging requests to the appropriate MCP tools.

New Features:
- Add an x-backtrace MCP tool and prompt with support for script, breakpoint, depth, and context parameters to retrieve stack traces at breakpoints.
- Expose the xdebug-backtrace CLI entry point and corresponding slash command for use in AI-driven debugging workflows.
- Document a bilingual (EN/JP) natural language to MCP tool mapping, including explicit guidance to prefer MCP tools over direct CLI usage.

Enhancements:
- Extend the MCP server to normalize positional arguments and route tool calls for the new x-backtrace capability alongside existing Xdebug tools.
- Clarify trace-related terminology in CLAUDE guidance to distinguish forward tracing, backtracing, and step debugging.

Tests:
- Update MCP server tests to cover the new x-backtrace tool and prompt in the tools and prompts lists.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added x-backtrace: a backtrace tool with /x-backtrace command and a CLI that emits JSON backtraces.

* **Documentation**
  * Updated README and docs with xdebug-backtrace usage/examples, AI tool mapping, workflow guidance, and a JSON schema for backtrace results.

* **UX**
  * Improved CLI argument parsing to better separate tool flags from target commands.

* **Tests**
  * Updated unit and integration tests to validate the new tool and its help/command outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->