### PR TITLE
refactor: Align MCP tool names with CLI tool names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,16 +385,16 @@ This project prioritizes **execution-time trace analysis** over traditional code
 
 | User Request / ユーザーリクエスト | MCP Tool | Description / 説明 |
 |----------------------------------|----------|-------------------|
-| Forward trace, execution flow, trace execution<br>フォワードトレース、実行フロー、トレース実行 | `x-trace` | Record execution flow without stopping<br>実行の流れを記録（停止しない） |
-| Step execution, step debugging, breakpoints, inspect variables<br>ステップ実行、ステップデバッグ、ブレークポイント、変数検査 | `x-debug` | Stop at breakpoints and inspect<br>ブレークポイントで停止して検査 |
-| Profile, performance analysis, find bottlenecks<br>プロファイル、パフォーマンス分析、ボトルネック検出 | `x-profile` | Execution time and memory analysis<br>実行時間・メモリ分析 |
-| Coverage, test coverage, code coverage<br>カバレッジ、テストカバレッジ、コードカバレッジ | `x-coverage` | Code coverage analysis<br>コードカバレッジ分析 |
-| Backtrace, stack trace, call stack<br>バックトレース、スタックトレース、コールスタック | `x-backtrace` | Get stack trace at current position<br>現在位置のスタックトレースを取得 |
+| Forward trace, execution flow, trace execution<br>フォワードトレース、実行フロー、トレース実行 | `xtrace` | Record execution flow without stopping<br>実行の流れを記録（停止しない） |
+| Step execution, step debugging, breakpoints, inspect variables<br>ステップ実行、ステップデバッグ、ブレークポイント、変数検査 | `xstep` | Stop at breakpoints and inspect<br>ブレークポイントで停止して検査 |
+| Profile, performance analysis, find bottlenecks<br>プロファイル、パフォーマンス分析、ボトルネック検出 | `xprofile` | Execution time and memory analysis<br>実行時間・メモリ分析 |
+| Coverage, test coverage, code coverage<br>カバレッジ、テストカバレッジ、コードカバレッジ | `xcoverage` | Code coverage analysis<br>コードカバレッジ分析 |
+| Backtrace, stack trace, call stack<br>バックトレース、スタックトレース、コールスタック | `xback` | Get stack trace at current position<br>現在位置のスタックトレースを取得 |
 
 **Note on "Trace" ambiguity / 「トレース」の曖昧さについて:**
-- **Forward Trace (フォワードトレース)**: Records execution flow from start to end → Use `x-trace`
-- **Backtrace (バックトレース)**: Shows call stack at a specific point → Use `x-backtrace`
-- **Step Debugging (ステップ実行)**: Interactive debugging with breakpoints → Use `x-debug`
+- **Forward Trace (フォワードトレース)**: Records execution flow from start to end → Use `xtrace`
+- **Backtrace (バックトレース)**: Shows call stack at a specific point → Use `xback`
+- **Step Debugging (ステップ実行)**: Interactive debugging with breakpoints → Use `xstep`
 
 #### Available Xdebug Tools:
 - `./bin/xstep` - Interactive step debugging with breakpoints
@@ -405,10 +405,10 @@ This project prioritizes **execution-time trace analysis** over traditional code
 - `./bin/xdebug-mcp` - MCP server entry point
 
 #### MCP Slash Commands for Claude Code:
-- `/x-debug` - Interactive debugging with breakpoints
-- `/x-profile` - Performance profiling and analysis
-- `/x-trace` - Execution flow tracing
-- `/x-coverage` - Code coverage analysis
+- `/xstep` - Interactive debugging with breakpoints
+- `/xprofile` - Performance profiling and analysis
+- `/xtrace` - Execution flow tracing
+- `/xcoverage` - Code coverage analysis
 
 These slash commands provide direct access to Xdebug functionality within Claude Code, making PHP debugging more efficient and accessible.
 

--- a/PACKAGE_USAGE.md
+++ b/PACKAGE_USAGE.md
@@ -11,10 +11,10 @@ composer require koriym/xdebug-mcp
 **Before using any tool, read the AI-optimized help documentation:**
 
 ```bash
-./vendor/bin/xdebug-debug --help     # 🔍 Interactive debugging workflow
-./vendor/bin/xdebug-coverage --help  # 🎯 Coverage analysis (beats HTML/XML)
-./vendor/bin/xdebug-trace --help     # 📊 Execution flow tracing
-./vendor/bin/xdebug-profile --help   # ⚡ Performance optimization
+./vendor/bin/xstep --help      # 🔍 Interactive debugging workflow
+./vendor/bin/xcoverage --help  # 🎯 Coverage analysis (beats HTML/XML)
+./vendor/bin/xtrace --help     # 📊 Execution flow tracing
+./vendor/bin/xprofile --help   # ⚡ Performance optimization
 ```
 
 **Recommended AI Prompt:**
@@ -34,21 +34,21 @@ Each tool's help includes:
 
 ```bash
 # Multiple breakpoints with context
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="src/OrderProcessor.php:25,src/TaxCalculator.php:15" \
   --context="Order processing debug session" \
   --exit-on-break \
   -- php process_order.php
 
 # Conditional breakpoint
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="src/User.php:42:\$user_id>1000" \
   --context="Debug high-value user processing" \
   --exit-on-break \
   -- php user_handler.php
 
 # Step recording (capture variable evolution)
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="src/Calculator.php:20" \
   --steps=50 \
   --context="Track calculation steps" \
@@ -101,16 +101,16 @@ Each tool's help includes:
 
 ```bash
 # Interactive debugging with context
-/x-debug --script="php app.php" --context="Login flow debugging" --breakpoints="User.php:42"
+/xstep --script="php app.php" --context="Login flow debugging" --breakpoints="User.php:42"
 
 # Performance analysis
-/x-profile --script="php slow_endpoint.php" --context="API performance analysis"
+/xprofile --script="php slow_endpoint.php" --context="API performance analysis"
 
 # Execution tracing
-/x-trace --script="php workflow.php" --context="Business logic flow analysis"
+/xtrace --script="php workflow.php" --context="Business logic flow analysis"
 
 # Code coverage
-/x-coverage --script="php vendor/bin/phpunit UserTest.php" --context="Test coverage analysis"
+/xcoverage --script="php vendor/bin/phpunit UserTest.php" --context="Test coverage analysis"
 ```
 
 ### MCP Tool Parameters
@@ -139,16 +139,16 @@ xdebug-mcp uses `XDEBUG_SESSION=xdebug-mcp` to isolate sessions from IDEs:
 
 ```bash
 # Default: Exclude all vendor code (focus on application logic)
-./vendor/bin/xdebug-debug --exit-on-break -- php app.php
+./vendor/bin/xstep --exit-on-break -- php app.php
 
 # Include specific packages
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --include-vendor="doctrine/orm,symfony/console" \
   --exit-on-break \
   -- php app.php
 
 # Include all vendor code
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --include-vendor="*/*" \
   --exit-on-break \
   -- php app.php
@@ -160,13 +160,13 @@ Always use `--context` for self-explanatory debugging data:
 
 ```bash
 # ✅ Good: Self-explanatory
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --context="Testing user authentication with expired tokens" \
   --exit-on-break \
   -- php AuthTest.php
 
 # ❌ Bad: Requires external knowledge
-./vendor/bin/xdebug-debug --exit-on-break -- php AuthTest.php
+./vendor/bin/xstep --exit-on-break -- php AuthTest.php
 ```
 
 ## Integration with Testing Frameworks
@@ -175,14 +175,14 @@ Always use `--context` for self-explanatory debugging data:
 
 ```bash
 # Debug specific test with breakpoints
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="UserTest.php:25,User.php:42" \
   --context="Debug user authentication test failure" \
   --exit-on-break \
   -- php vendor/bin/phpunit tests/UserTest.php::testLogin
 
 # Coverage analysis for tests  
-./vendor/bin/xdebug-coverage \
+./vendor/bin/xcoverage \
   --context="User module test coverage analysis" \
   -- php vendor/bin/phpunit tests/Unit/UserTest.php
 ```
@@ -191,7 +191,7 @@ Always use `--context` for self-explanatory debugging data:
 
 ```bash
 # Works with any PHP-based test runner
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="TestRunner.php:15" \
   --context="Custom test runner debugging" \
   --exit-on-break \
@@ -223,7 +223,7 @@ php -m | grep xdebug
 
 ### 1. Use Context for All Sessions
 ```bash
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --context="Debugging checkout process with invalid coupon codes" \
   --exit-on-break \
   -- php checkout.php
@@ -242,7 +242,7 @@ php -m | grep xdebug
 
 ### 4. Step Recording for Complex Issues
 ```bash
-./vendor/bin/xdebug-debug \
+./vendor/bin/xstep \
   --break="ComplexAlgorithm.php:15" \
   --steps=200 \
   --context="Algorithm variable evolution tracking" \

--- a/PACKAGE_USAGE.md
+++ b/PACKAGE_USAGE.md
@@ -60,7 +60,7 @@ Each tool's help includes:
 
 ```json
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [
         {
             "step": 1,

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ flowchart LR
 
 | Tool | Purpose | Example Prompt |
 |------|---------|----------------|
-| `x-debug` | Breakpoint debugging, variable inspection | "Stop at line 42 and show me the variables" |
-| `x-trace` | Execution flow analysis | "Trace how the request flows through the app" |
-| `x-profile` | Performance profiling | "Find what's making this endpoint slow" |
-| `x-coverage` | Code coverage analysis | "Which lines aren't covered by tests?" |
-| `x-backtrace` | Call stack at breakpoint | "Show me how we got to this error" |
+| `xstep` | Breakpoint debugging, variable inspection | "Stop at line 42 and show me the variables" |
+| `xtrace` | Execution flow analysis | "Trace how the request flows through the app" |
+| `xprofile` | Performance profiling | "Find what's making this endpoint slow" |
+| `xcoverage` | Code coverage analysis | "Which lines aren't covered by tests?" |
+| `xback` | Call stack at breakpoint | "Show me how we got to this error" |
 
 ## CLI Usage
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -4,59 +4,59 @@ This directory contains executable tools for PHP debugging, profiling, and analy
 
 ## Core Debugging Tools
 
-### `./xdebug-debug`
+### `./xstep`
 Interactive step debugging with conditional breakpoints and Forward Trace™ capabilities.
 ```bash
 # Interactive debugging session
-./xdebug-debug script.php
+./xstep script.php
 
 # Conditional breakpoints (Forward Trace)
-./xdebug-debug --break='User.php:42:$id==null' --exit-on-break -- php script.php
+./xstep --break='User.php:42:$id==null' --exit-on-break -- php script.php
 
 # Step recording with JSON output
-./xdebug-debug --break='loop.php:15' --steps=100 --json -- php script.php
+./xstep --break='loop.php:15' --steps=100 --json -- php script.php
 
 # Multiple conditions (first match triggers)
-./xdebug-debug --break='Auth.php:20:empty($token),User.php:85:$id==0' --exit-on-break -- php app.php
+./xstep --break='Auth.php:20:empty($token),User.php:85:$id==0' --exit-on-break -- php app.php
 ```
 
-### `./xdebug-profile`
+### `./xprofile`
 Performance profiling with microsecond precision and AI analysis integration.
 ```bash
 # Basic profiling
-./xdebug-profile script.php
+./xprofile script.php
 
 # With context for AI analysis
-./xdebug-profile --context="API endpoint performance" -- php api.php
+./xprofile --context="API endpoint performance" -- php api.php
 
 # JSON output for MCP integration
-./xdebug-profile --json -- php slow-script.php
+./xprofile --json -- php slow-script.php
 ```
 
-### `./xdebug-trace`
+### `./xtrace`
 Execution flow tracing with complete function call analysis.
 ```bash
 # Basic execution tracing
-./xdebug-trace script.php
+./xtrace script.php
 
 # With context documentation
-./xdebug-trace --context="Authentication flow analysis" -- php login.php
+./xtrace --context="Authentication flow analysis" -- php login.php
 
 # JSON output for AI processing
-./xdebug-trace --json -- php complex-workflow.php
+./xtrace --json -- php complex-workflow.php
 ```
 
-### `./xdebug-coverage`
+### `./xcoverage`
 Code coverage analysis with multiple output formats.
 ```bash
 # Basic coverage analysis
-./xdebug-coverage tests/MyTest.php
+./xcoverage tests/MyTest.php
 
 # With context
-./xdebug-coverage --context="Unit test coverage verification" -- php vendor/bin/phpunit tests/
+./xcoverage --context="Unit test coverage verification" -- php vendor/bin/phpunit tests/
 
 # Multiple formats: HTML, XML, JSON, text
-./xdebug-coverage --format=html --format=json -- php tests/suite.php
+./xcoverage --format=html --format=json -- php tests/suite.php
 ```
 
 ### `./xdebug-phpunit`
@@ -122,10 +122,10 @@ Legacy debugging server utility (development purposes).
 ## Tool Categories
 
 **Forward Trace Tools (AI-Optimized):**
-- `xdebug-debug` - Conditional breakpoints with step recording
-- `xdebug-trace` - Complete execution flow analysis
-- `xdebug-profile` - Performance bottleneck identification
-- `xdebug-coverage` - Test coverage verification
+- `xstep` - Conditional breakpoints with step recording
+- `xtrace` - Complete execution flow analysis
+- `xprofile` - Performance bottleneck identification
+- `xcoverage` - Test coverage verification
 
 **Integration Tools:**
 - `xdebug-mcp` - AI assistant protocol handler
@@ -141,25 +141,25 @@ Legacy debugging server utility (development purposes).
 ### Bug Investigation
 ```bash
 # Catch specific problem conditions
-./xdebug-debug --break='ErrorHandler.php:45:$error_code>400' --exit-on-break -- php api.php
+./xstep --break='ErrorHandler.php:45:$error_code>400' --exit-on-break -- php api.php
 ```
 
-### Performance Analysis  
+### Performance Analysis
 ```bash
 # Profile slow endpoints
-./xdebug-profile --context="Payment processing bottleneck analysis" -- php checkout.php
+./xprofile --context="Payment processing bottleneck analysis" -- php checkout.php
 ```
 
 ### Test Coverage Verification
 ```bash
 # Analyze test effectiveness
-./xdebug-coverage --context="AuthController test coverage" -- php vendor/bin/phpunit tests/AuthTest.php
+./xcoverage --context="AuthController test coverage" -- php vendor/bin/phpunit tests/AuthTest.php
 ```
 
 ### Complex Flow Understanding
 ```bash
 # Trace execution paths
-./xdebug-trace --context="Multi-step form submission workflow" -- php form-handler.php
+./xtrace --context="Multi-step form submission workflow" -- php form-handler.php
 ```
 
 All tools support `--help` option for detailed usage information.

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -44,12 +44,12 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "OUTPUT FORMAT:\n";
     echo "  📊 Standard: PHPUnit TestDox results + JSON line coverage data\n";
     echo "  🌳 Branch Mode: PHPUnit TestDox + JSON branch coverage + GraphViz dot file\n";
-    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json\n";
+    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json\n";
     echo "  Benefits: AI can distinguish test output from coverage data automatically\n";
     echo "\n";
     echo "📋 JSON SCHEMA RESOURCES (Essential for AI):\n";
-    echo "  Schema Definition: https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json\n";
-    echo "  Branch Coverage Schema: https://koriym.github.io/xdebug-mcp/schemas/xdebug-branch-coverage.json\n";
+    echo "  Schema Definition: https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json\n";
+    echo "  Branch Coverage Schema: https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json\n";
     echo "  Xdebug Coverage Docs: https://xdebug.org/docs/code_coverage\n";
     echo "  Function Reference: https://xdebug.org/docs/code_coverage#xdebug_get_code_coverage\n";
     echo "  Branch Coverage: https://xdebug.org/docs/code_coverage#XDEBUG_CC_BRANCH_CHECK\n";
@@ -153,7 +153,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
         $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
         
         $result = [
-            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xdebug-branch-coverage.json", 
+            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json", 
             "coverage_type" => "branch",
             "coverage" => $filtered,
             "graphviz_dot" => $dotContent,
@@ -232,7 +232,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
         $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
         
         $result = [
-            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json", 
+            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json", 
             "coverage_type" => "line",
             "coverage" => $filtered,
             "graphviz_dot" => $dotContent,

--- a/bin/xprofile
+++ b/bin/xprofile
@@ -48,7 +48,7 @@ function showHelp(string $scriptName): void
     echo "OUTPUT:\n";
     echo "  Default: Human-readable with KCachegrind suggestions\n";
     echo "  --json: AI-optimized JSON with emoji keys and metrics\n";
-    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json\n";
+    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xprofile.json\n";
     echo "\n";
 }
 
@@ -187,7 +187,7 @@ function generateEnhancedProfileData(string $profileFile, bool $jsonOutput = fal
             
             // Schema and specification
             '📋 specification' => 'https://kcachegrind.github.io/html/CallgrindFormat.html',
-            '🔗 schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json'
+            '🔗 schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xprofile.json'
         ];
         
         if ($context !== null) {

--- a/bin/xtrace
+++ b/bin/xtrace
@@ -55,7 +55,7 @@ function showHelp(string $scriptName): void {
     echo "OUTPUT FORMATS:\n";
     echo "  Default: Human-readable execution statistics and summary\n";
     echo "  --json: Structured JSON with trace file path and metadata\n";
-    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xdebug-trace.json\n";
+    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xtrace.json\n";
     echo "\n";
 }
 

--- a/docs/ADR-001-forward-trace-only-approach.md
+++ b/docs/ADR-001-forward-trace-only-approach.md
@@ -25,7 +25,7 @@ We decided to **remove 8 interactive debugging tools** and focus exclusively on 
 - **Profiling**: `xdebug_start/stop_profiling`, `x-profile`
 - **Coverage**: `xdebug_start/stop_coverage`, `x-coverage`
 - **Diagnostics**: `xdebug_info`, memory usage, error collection
-- **AI-Optimized Commands**: `xdebug-debug` (Forward Trace with breakpoints)
+- **AI-Optimized Commands**: `xstep` (Forward Trace with breakpoints)
 ## Rationale
 
 ### Why Interactive Debugging is Incompatible with AI
@@ -45,7 +45,7 @@ We decided to **remove 8 interactive debugging tools** and focus exclusively on 
    step → inspect $var → step → inspect $array → step...
    
    # Forward Trace (Complete Context)
-   ./bin/xdebug-trace php script.php
+   ./bin/xtrace php script.php
    # → Complete execution flow with all variable states
    ```
 
@@ -73,7 +73,7 @@ xdebug_set_breakpoint(...) → xdebug_step_into() → xdebug_get_variables()
 **After (Forward Trace)**:
 ```bash
 # Complete execution analysis with conditional capture
-./bin/xdebug-debug script.php \
+./bin/xstep script.php \
   --breakpoint 'User.php:42:$user==null' \
   --context 'User validation analysis'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ This folder contains documentation, guides, and presentation materials for the P
 
 ### Technical Specifications
 - **`schemas/`** - JSON schema definitions for tool outputs
-  - `xdebug-debug.json` - Debug session output schema
-  - `xdebug-profile.json` - Performance profiling schema
-  - `xdebug-trace.json` - Execution trace schema
+  - `xstep.json` - Debug session output schema
+  - `xprofile.json` - Performance profiling schema
+  - `xtrace.json` - Execution trace schema
   - `alps.json` - ALPS API documentation
 
 ### Presentation Materials

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -110,7 +110,7 @@ wc -l src/User.php  # Check total lines
 head -n 50 src/User.php | tail -n 10  # Check around line 42
 
 # Test with simple breakpoint first
-./bin/xdebug-debug --break="src/User.php:42" -- php script.php
+./bin/xstep --break="src/User.php:42" -- php script.php
 ```
 
 ### 2. Step Recording Not Working
@@ -120,16 +120,16 @@ head -n 50 src/User.php | tail -n 10  # Check around line 42
 **Check Command Format**:
 ```bash
 # ✅ Correct format
-./bin/xdebug-debug --break="loop.php:15" --steps=100 --json -- php script.php
+./bin/xstep --break="loop.php:15" --steps=100 --json -- php script.php
 
 # ❌ Wrong format
-./bin/xdebug-debug --break="loop.php:15" --steps 100  # Missing equals sign
+./bin/xstep --break="loop.php:15" --steps 100  # Missing equals sign
 ```
 
 **Verify Output**:
 ```bash
 # Check if JSON contains "breaks" array with step data
-./bin/xdebug-debug --break="test.php:1" --steps=5 --json -- php -r "echo 'test';" | jq '.breaks'
+./bin/xstep --break="test.php:1" --steps=5 --json -- php -r "echo 'test';" | jq '.breaks'
 ```
 
 ### 3. Context Memory Problems
@@ -202,10 +202,10 @@ MCP_DEBUG=1 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | php bin/xdeb
 **Optimizations**:
 ```bash
 # Use specific conditions to limit scope
-./bin/xdebug-debug --break='file.php:42:$specific_condition' --exit-on-break
+./bin/xstep --break='file.php:42:$specific_condition' --exit-on-break
 
 # Limit step recording
-./bin/xdebug-debug --break='file.php:42' --steps=50  # Instead of 1000+
+./bin/xstep --break='file.php:42' --steps=50  # Instead of 1000+
 
 # Clean old trace files
 rm /tmp/trace.*.xt /tmp/cachegrind.out.*
@@ -218,26 +218,26 @@ rm /tmp/trace.*.xt /tmp/cachegrind.out.*
 **Common Problem - Script Output Mixing with JSON**:
 ```bash
 # ❌ Before v0.x.x: Script output breaks jq parsing
-./bin/xdebug-profile --json -- php script.php | jq '.'
+./bin/xprofile --json -- php script.php | jq '.'
 # parse error: Invalid numeric literal at line 1, column 8
 
 # ✅ Now: Clean JSON output (script stdout/stderr automatically suppressed)
-./bin/xdebug-profile --json -- php script.php | jq '.["🎯 bottleneck_functions"]'
+./bin/xprofile --json -- php script.php | jq '.["🎯 bottleneck_functions"]'
 ```
 
 **Format Solutions**:
 ```bash
 # Ensure JSON output for AI processing
-./bin/xdebug-profile --json -- php script.php
+./bin/xprofile --json -- php script.php
 
 # Pipe to jq for filtering
-./bin/xdebug-profile --json -- php script.php | jq '.["⏱️ execution_time_ms"]'
+./bin/xprofile --json -- php script.php | jq '.["⏱️ execution_time_ms"]'
 
 # Verify schema compliance
 ./bin/validate-profile-json profile-output.json
 
 # Check output structure
-./bin/xdebug-debug --json --break="test.php:1" --steps=1 -- php -r "echo 'test';" | jq '.'
+./bin/xstep --json --break="test.php:1" --steps=1 -- php -r "echo 'test';" | jq '.'
 ```
 
 ### 3. File Path Issues

--- a/docs/debug_guideline_for_ai.md
+++ b/docs/debug_guideline_for_ai.md
@@ -263,7 +263,7 @@ All Forward Trace tools output schema-validated JSON for consistent AI analysis:
 
 ```json
 {
-  "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+  "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
   "breaks": [
     {
       "step": 1,

--- a/docs/debug_guideline_for_humans.md
+++ b/docs/debug_guideline_for_humans.md
@@ -23,7 +23,7 @@ print_r($cart);
 die("HERE"); // Risk: accidentally commit debug code
 
 // ✅ NEW WAY: One command, complete analysis
-./bin/xdebug-debug --break='Auth.php:42:$user==null' --exit-on-break -- php app.php
+./bin/xstep --break='Auth.php:42:$user==null' --exit-on-break -- php app.php
 // Result: Complete execution trace when $user is null, no code changes
 ```
 
@@ -32,10 +32,10 @@ die("HERE"); // Risk: accidentally commit debug code
 ### 1. Variable Inspection (Replaces var_dump)
 ```bash
 # Instead of adding var_dump($variable) to your code
-./bin/xdebug-debug --break='file.php:line' --steps=1 --context="Checking variable state" -- php script.php
+./bin/xstep --break='file.php:line' --steps=1 --context="Checking variable state" -- php script.php
 
 # Example: Check what's in $user at line 42
-./bin/xdebug-debug --break='Auth.php:42' --steps=1 --context="User object inspection" -- php login.php
+./bin/xstep --break='Auth.php:42' --steps=1 --context="User object inspection" -- php login.php
 ```
 
 **Benefits**:
@@ -47,7 +47,7 @@ die("HERE"); // Risk: accidentally commit debug code
 ### 2. Loop Debugging (Replaces multiple var_dumps)
 ```bash
 # Instead of: foreach($items as $item) { var_dump($item); }
-./bin/xdebug-debug --break='DataProcessor.php:45' --steps=100 --context="Processing loop analysis" -- php import.php
+./bin/xstep --break='DataProcessor.php:45' --steps=100 --context="Processing loop analysis" -- php import.php
 
 # Watch variables evolve through 100 iterations
 # Memory usage, performance, variable states all captured
@@ -56,7 +56,7 @@ die("HERE"); // Risk: accidentally commit debug code
 ### 3. Intermittent Bug Hunting
 ```bash
 # For bugs that "sometimes happen"
-./bin/xdebug-debug --break='Payment.php:*:$total<0' --exit-on-break --context="Negative total bug hunt" -- php checkout.php
+./bin/xstep --break='Payment.php:*:$total<0' --exit-on-break --context="Negative total bug hunt" -- php checkout.php
 
 # Runs normally until the bug occurs, then captures complete trace
 # No more "I can't reproduce it" situations
@@ -65,7 +65,7 @@ die("HERE"); // Risk: accidentally commit debug code
 ### 4. Performance Investigation
 ```bash
 # Find bottlenecks in your code
-./bin/xdebug-profile --context="API endpoint performance analysis" -- php api.php
+./bin/xprofile --context="API endpoint performance analysis" -- php api.php
 
 # AI analyzes results:
 # "fetchUser() called 847 times (72% execution time). Add caching at line 42."
@@ -76,37 +76,37 @@ die("HERE"); // Risk: accidentally commit debug code
 ### Authentication & User Management
 ```bash
 # Null user debugging
-./bin/xdebug-debug --break='Auth.php:*:$user==null' --exit-on-break --context="Authentication failure analysis" -- php login.php
+./bin/xstep --break='Auth.php:*:$user==null' --exit-on-break --context="Authentication failure analysis" -- php login.php
 
 # Permission issues
-./bin/xdebug-debug --break='Security.php:15:!$hasPermission' --exit-on-break --context="Permission denied investigation" -- php dashboard.php
+./bin/xstep --break='Security.php:15:!$hasPermission' --exit-on-break --context="Permission denied investigation" -- php dashboard.php
 
 # Session problems
-./bin/xdebug-debug --break='Session.php:*:empty($_SESSION)' --exit-on-break --context="Session management debug" -- php app.php
+./bin/xstep --break='Session.php:*:empty($_SESSION)' --exit-on-break --context="Session management debug" -- php app.php
 ```
 
 ### Database & API Issues
 ```bash
 # Failed queries
-./bin/xdebug-debug --break='DB.php:*:$result===false' --exit-on-break --context="Database query failure" -- php data.php
+./bin/xstep --break='DB.php:*:$result===false' --exit-on-break --context="Database query failure" -- php data.php
 
 # Slow queries (>500ms)
-./bin/xdebug-debug --break='DB.php:*:$queryTime>0.5' --exit-on-break --context="Slow query identification" -- php reports.php
+./bin/xstep --break='DB.php:*:$queryTime>0.5' --exit-on-break --context="Slow query identification" -- php reports.php
 
 # API errors
-./bin/xdebug-debug --break='ApiClient.php:*:$response["error"]' --exit-on-break --context="API integration issues" -- php sync.php
+./bin/xstep --break='ApiClient.php:*:$response["error"]' --exit-on-break --context="API integration issues" -- php sync.php
 ```
 
 ### Data Processing & Validation
 ```bash
 # Invalid data detection
-./bin/xdebug-debug --break='Validator.php:*:count($errors)>0' --exit-on-break --context="Validation error analysis" -- php form.php
+./bin/xstep --break='Validator.php:*:count($errors)>0' --exit-on-break --context="Validation error analysis" -- php form.php
 
 # Memory leaks in loops
-./bin/xdebug-debug --break='Import.php:150' --steps=200 --context="Memory usage during data import" -- php import.php
+./bin/xstep --break='Import.php:150' --steps=200 --context="Memory usage during data import" -- php import.php
 
 # Array manipulation issues
-./bin/xdebug-debug --break='Transform.php:*:empty($result)' --exit-on-break --context="Data transformation problems" -- php process.php
+./bin/xstep --break='Transform.php:*:empty($result)' --exit-on-break --context="Data transformation problems" -- php process.php
 ```
 
 ## 🤝 Working with AI Analysis
@@ -120,7 +120,7 @@ die("HERE"); // Risk: accidentally commit debug code
 ### Example Collaboration
 ```bash
 # 1. Human sets up capture
-./bin/xdebug-debug --break='Cart.php:89:$total<0' --exit-on-break --context="Negative cart total investigation" -- php checkout.php
+./bin/xstep --break='Cart.php:89:$total<0' --exit-on-break --context="Negative cart total investigation" -- php checkout.php
 
 # 2. Forward Trace captures the problem moment
 # Output: Complete execution trace + JSON data
@@ -165,7 +165,7 @@ Target specific problem conditions, not normal flow:
 ### 3. Team Debug Session Sharing
 ```bash
 # Generate portable debug session
-./bin/xdebug-debug --break='bug.php:42' --steps=100 --json --context="Customer #12345 checkout failure" > debug-session.json
+./bin/xstep --break='bug.php:42' --steps=100 --json --context="Customer #12345 checkout failure" > debug-session.json
 
 # Share with team
 git add debug-session.json
@@ -186,7 +186,7 @@ claude --file debug-session.json "Analyze this debug session"
     {
       "label": "Debug Current File",
       "type": "shell",
-      "command": "./bin/xdebug-debug",
+      "command": "./bin/xstep",
       "args": [
         "--break=${file}:${lineNumber}",
         "--steps=10",
@@ -204,8 +204,8 @@ claude --file debug-session.json "Analyze this debug session"
 ### Command Line Aliases
 ```bash
 # Add to ~/.bashrc or ~/.zshrc
-alias xd-var='./bin/xdebug-debug --break'
-alias xd-profile='./bin/xdebug-profile --context'
+alias xd-var='./bin/xstep --break'
+alias xd-profile='./bin/xprofile --context'
 alias xd-trace='./bin/xdebug-trace --context'
 
 # Usage examples
@@ -258,7 +258,7 @@ ls -la /tmp/xdebug_trace*
 ### 3. Breakpoints Not Hitting
 ```bash
 # Verify file path is correct (use absolute paths)
-./bin/xdebug-debug --break='/full/path/to/file.php:42' -- php script.php
+./bin/xstep --break='/full/path/to/file.php:42' -- php script.php
 
 # Check if line number exists
 wc -l file.php  # Should be > your line number
@@ -274,7 +274,7 @@ php script.php                                     # Normal execution
 php -dzend_extension=xdebug.so script.php         # With Xdebug
 
 # Use specific conditions to limit scope
-./bin/xdebug-debug --break='file.php:line:$specific_condition' --exit-on-break
+./bin/xstep --break='file.php:line:$specific_condition' --exit-on-break
 ```
 
 ## 📊 Understanding Output
@@ -282,7 +282,7 @@ php -dzend_extension=xdebug.so script.php         # With Xdebug
 ### JSON Output Structure
 ```json
 {
-  "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+  "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
   "context": "User authentication analysis",
   "breaks": [
     {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Xdebug MCP Server - PHP Debugging Schemas & Documentation</title>
 
     <!-- JSON Schema Profile -->
-    <link rel="profile" href="schemas/xdebug-debug.json" type="application/schema+json" title="Xdebug Debug Schema Profile" />
+    <link rel="profile" href="schemas/xstep.json" type="application/schema+json" title="Xdebug Debug Schema Profile" />
     <!-- Semantic Portal CSS -->
     <link rel="stylesheet" href="css/semantic-portal.css" />
 </head>
@@ -21,7 +21,7 @@
             <p class="schema-description" style="margin: 10px 0; font-size: 14px;">
                 <strong>Forward Trace™:</strong> Captures execution from start until problems occur, eliminating need for var_dump() and code modifications.
             </p>
-            <a href="schemas/xdebug-debug.json" class="schema-reference">schemas/xdebug-debug.json</a>
+            <a href="schemas/xstep.json" class="schema-reference">schemas/xstep.json</a>
         </article>
 
         <article class="json-schema-resource">
@@ -30,7 +30,7 @@
             <p class="schema-description" style="margin: 10px 0; font-size: 14px;">
                 <strong>AI-optimized:</strong> Includes total_lines, unique_functions, max_call_depth, and database_queries for intelligent analysis strategies.
             </p>
-            <a href="schemas/xdebug-trace.json" class="schema-reference">schemas/xdebug-trace.json</a>
+            <a href="schemas/xtrace.json" class="schema-reference">schemas/xtrace.json</a>
         </article>
 
         <article class="json-schema-resource">
@@ -39,7 +39,7 @@
             <p class="schema-description" style="margin: 10px 0; font-size: 14px;">
                 <strong>Performance analysis:</strong> Bottleneck detection, execution timing, memory usage, and AI-generated optimization suggestions.
             </p>
-            <a href="schemas/xdebug-profile.json" class="schema-reference">schemas/xdebug-profile.json</a>
+            <a href="schemas/xprofile.json" class="schema-reference">schemas/xprofile.json</a>
         </article>
     </div>
 
@@ -114,24 +114,24 @@
         <h2 style="color: #2c3e50; margin-bottom: 20px;">CLI Tools</h2>
         <div class="tool-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px;">
             <div class="tool-item">
-                <strong>xdebug-debug</strong>
+                <strong>xstep</strong>
                 <p>Interactive debugging with conditional breakpoints and step recording</p>
             </div>
             <div class="tool-item">
-                <strong>xdebug-trace</strong>
+                <strong>xtrace</strong>
                 <p>Complete execution tracing with comprehensive statistics</p>
             </div>
             <div class="tool-item">
-                <strong>xdebug-profile</strong>
+                <strong>xprofile</strong>
                 <p>Performance profiling with bottleneck detection</p>
             </div>
             <div class="tool-item">
-                <strong>xdebug-coverage</strong>
+                <strong>xcoverage</strong>
                 <p>Code coverage analysis with multiple report formats</p>
             </div>
             <div class="tool-item">
-                <strong>xdebug-phpunit</strong>
-                <p>PHPUnit integration with Xdebug profiling and coverage</p>
+                <strong>xback</strong>
+                <p>Stack trace at specific breakpoints for debugging flow</p>
             </div>
             <div class="tool-item">
                 <strong>xdebug-mcp</strong>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -28,11 +28,11 @@ Universal PHP Xdebug MCP (Model Context Protocol) Server that enables AI assista
 - Automatic tool detection and usage by AI assistants
 
 ### CLI Tools
-- `xdebug-debug`: Interactive debugging with conditional breakpoints
-- `xdebug-trace`: Complete execution flow tracing  
-- `xdebug-profile`: Performance profiling with AI analysis
-- `xdebug-coverage`: Code coverage with multiple report formats
-- `xdebug-phpunit`: PHPUnit integration with profiling/coverage
+- `xstep`: Interactive debugging with conditional breakpoints
+- `xtrace`: Complete execution flow tracing
+- `xprofile`: Performance profiling with AI analysis
+- `xcoverage`: Code coverage with multiple report formats
+- `xback`: Stack trace at specific breakpoints
 - `xdebug-mcp`: MCP server entry point for AI integration
 
 ## Architecture
@@ -87,19 +87,19 @@ echo "@vendor/koriym/xdebug-mcp/docs/debug_guideline_for_ai.md" >> CLAUDE.md
 ### Conditional Debugging (Forward Trace™)
 ```bash
 # Catch null user bugs automatically
-./bin/xdebug-debug --break='User.php:42:$user==null' --exit-on-break -- php app.php
+./bin/xstep --break='User.php:42:$user==null' --exit-on-break -- php app.php
 
 # Record 100 steps of variable evolution  
-./bin/xdebug-debug --break='loop.php:15' --steps=100 --json -- php script.php
+./bin/xstep --break='loop.php:15' --steps=100 --json -- php script.php
 ```
 
 ### Performance Analysis
 ```bash
 # Profile with AI analysis
-./bin/xdebug-profile --context="API performance investigation" -- php api.php
+./bin/xprofile --context="API performance investigation" -- php api.php
 
 # Generate schema-compliant JSON
-./bin/xdebug-profile --json -- php slow-endpoint.php
+./bin/xprofile --json -- php slow-endpoint.php
 ```
 
 ### AI Integration (Claude Code)
@@ -148,22 +148,22 @@ When asked to debug, analyze, or understand PHP code, ALWAYS use appropriate Xde
 
 **For Performance Analysis:**
 ```bash
-./bin/xdebug-profile --context="Performance analysis" target_file.php
+./bin/xprofile --context="Performance analysis" target_file.php
 ```
 
 **For Execution Tracing:**
 ```bash
-./bin/xdebug-trace --context="Execution flow analysis" target_file.php
+./bin/xtrace --context="Execution flow analysis" target_file.php
 ```
 
 **For Interactive Debugging:**
 ```bash
-./bin/xdebug-debug --break="file.php:line:condition" --context="Bug investigation" target_file.php
+./bin/xstep --break="file.php:line:condition" --context="Bug investigation" target_file.php
 ```
 
 **For Code Coverage:**
 ```bash
-./bin/xdebug-coverage --context="Test coverage analysis" target_file.php
+./bin/xcoverage --context="Test coverage analysis" target_file.php
 ```
 
 ### MCP Integration

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,11 +28,11 @@ Universal PHP Xdebug MCP (Model Context Protocol) Server that enables AI assista
 - Automatic tool detection and usage by AI assistants
 
 ### CLI Tools
-- `xdebug-debug`: Interactive debugging with conditional breakpoints
-- `xdebug-trace`: Complete execution flow tracing  
-- `xdebug-profile`: Performance profiling with AI analysis
-- `xdebug-coverage`: Code coverage with multiple report formats
-- `xdebug-phpunit`: PHPUnit integration with profiling/coverage
+- `xstep`: Interactive debugging with conditional breakpoints
+- `xtrace`: Complete execution flow tracing
+- `xprofile`: Performance profiling with AI analysis
+- `xcoverage`: Code coverage with multiple report formats
+- `xback`: Stack trace at specific breakpoints
 - `xdebug-mcp`: MCP server entry point for AI integration
 
 ## Architecture
@@ -87,19 +87,19 @@ echo "@vendor/koriym/xdebug-mcp/docs/debug_guideline_for_ai.md" >> CLAUDE.md
 ### Conditional Debugging (Forward Trace™)
 ```bash
 # Catch null user bugs automatically
-./bin/xdebug-debug --break='User.php:42:$user==null' --exit-on-break -- php app.php
+./bin/xstep --break='User.php:42:$user==null' --exit-on-break -- php app.php
 
 # Record 100 steps of variable evolution  
-./bin/xdebug-debug --break='loop.php:15' --steps=100 --json -- php script.php
+./bin/xstep --break='loop.php:15' --steps=100 --json -- php script.php
 ```
 
 ### Performance Analysis
 ```bash
 # Profile with AI analysis
-./bin/xdebug-profile --context="API performance investigation" -- php api.php
+./bin/xprofile --context="API performance investigation" -- php api.php
 
 # Generate schema-compliant JSON
-./bin/xdebug-profile --json -- php slow-endpoint.php
+./bin/xprofile --json -- php slow-endpoint.php
 ```
 
 ### AI Integration (Claude Code)

--- a/docs/schemas/xback.json
+++ b/docs/schemas/xback.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xback.json",
   "title": "Xdebug Backtrace Result",
   "description": "AI-optimized stack trace data for PHP debugging. Shows call hierarchy at a specific breakpoint or execution point.",
   "type": "object",
   "properties": {
     "$schema": {
       "type": "string",
-      "const": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+      "const": "https://koriym.github.io/xdebug-mcp/schemas/xback.json",
       "description": "JSON Schema reference for this backtrace result"
     },
     "script": {
@@ -77,7 +77,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-backtrace.json",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xback.json",
       "title": "JSON Schema for Xdebug Backtrace Results"
     },
     {
@@ -87,7 +87,7 @@
     },
     {
       "rel": "command",
-      "href": "file:///bin/xdebug-backtrace",
+      "href": "file:///bin/xback",
       "title": "Command Line Tool"
     }
   ],

--- a/docs/schemas/xcoverage.json
+++ b/docs/schemas/xcoverage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
   "title": "Xdebug Coverage Result",
   "description": "Raw Xdebug code coverage data output from xdebug_get_code_coverage(). See https://xdebug.org/docs/code_coverage for complete coverage documentation and interpretation guidelines.",
   "type": "object",
@@ -48,7 +48,7 @@
     },
     {
       "rel": "self",
-      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
       "title": "JSON Schema for Xdebug Coverage Results",
       "description": "This schema definition for validating Xdebug coverage output"
     },
@@ -60,13 +60,13 @@
     },
     {
       "rel": "tool",
-      "href": "mcp://xdebug_start_coverage",
-      "title": "MCP Tool: Start Coverage",
+      "href": "mcp://xcoverage",
+      "title": "MCP Tool: Coverage",
       "description": "MCP tool to generate coverage data programmatically"
     },
     {
       "rel": "command",
-      "href": "file://bin/xdebug-coverage",
+      "href": "file://bin/xcoverage",
       "title": "CLI Coverage Tool",
       "description": "Command line tool that generates this coverage data format"
     }
@@ -74,7 +74,7 @@
 
   "examples": [
     {
-      "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-coverage.json",
+      "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
       "coverage": {
         "/path/to/src/Class.php": {
           "1": -2,

--- a/docs/schemas/xprofile.json
+++ b/docs/schemas/xprofile.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xprofile.json",
   "title": "Xdebug Profile Result",
   "description": "AI-optimized profiling data for PHP performance analysis. Designed for AI-first consumption with strategic metadata for bottleneck identification.",
   "type": "object",
@@ -16,7 +16,7 @@
       "description": "Total lines in profile file with unit. Use this to decide optimal analysis strategy for AI."
     },
     "💾 file_size_bytes": {
-      "type": "string", 
+      "type": "string",
       "pattern": "^\\d+ bytes$",
       "description": "Profile file size in bytes with unit for processing strategy decisions"
     },
@@ -88,7 +88,7 @@
     "🔗 schema": {
       "type": "string",
       "format": "uri",
-      "const": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json",
+      "const": "https://koriym.github.io/xdebug-mcp/schemas/xprofile.json",
       "description": "This schema URL"
     },
     "🎯 analysis_context": {
@@ -99,7 +99,7 @@
   },
   "required": ["📁 profile_file", "📊 total_lines", "💾 file_size_bytes", "📏 file_size_formatted", "📈 functions_count", "👤 user_functions", "⚙️ internal_functions", "📞 total_calls", "🎯 bottleneck_functions", "💡 optimization_suggestions", "📋 specification", "🔗 schema"],
   "additionalProperties": false,
-  
+
   "links": [
     {
       "rel": "specification",
@@ -115,7 +115,7 @@
     },
     {
       "rel": "self",
-      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xprofile.json",
       "title": "JSON Schema for Xdebug Profile Results",
       "description": "This schema definition with AI strategies and usage guidelines"
     },
@@ -134,13 +134,13 @@
     },
     {
       "rel": "tool",
-      "href": "mcp://xdebug_start_profiling",
-      "title": "MCP Tool: Start Profiling",
+      "href": "mcp://xprofile",
+      "title": "MCP Tool: Profile",
       "description": "MCP tool to generate profile data programmatically"
     },
     {
       "rel": "command",
-      "href": "file:///bin/xdebug-profile",
+      "href": "file:///bin/xprofile",
       "title": "Command Line Tool",
       "description": "CLI command to generate profile data with this schema"
     },
@@ -151,14 +151,14 @@
       "description": "Intelligent analysis strategies based on profile file characteristics"
     },
     {
-      "rel": "section", 
+      "rel": "section",
       "href": "#x-profile-format",
       "title": "Profile Format Guide",
       "description": "Detailed explanation of Cachegrind profile file structure"
     },
     {
       "rel": "section",
-      "href": "#x-performance-capabilities", 
+      "href": "#x-performance-capabilities",
       "title": "Performance Analysis Capabilities",
       "description": "Complete list of performance analysis and optimization capabilities"
     },
@@ -169,7 +169,7 @@
       "description": "How to use this schema with MCP tools and workflow"
     }
   ],
-  
+
   "x-ai-strategies": {
     "analysis_strategy": {
       "small_profiles": {
@@ -188,7 +188,7 @@
         "rationale": "Focus on highest-impact optimizations rather than exhaustive analysis"
       }
     },
-    
+
     "search_patterns": {
       "bottleneck_functions": {
         "description": "Find functions consuming the most execution time",
@@ -219,14 +219,14 @@
         ]
       }
     },
-    
+
     "optimization_workflow": {
       "step1": {
         "name": "Hotspot Identification",
         "action": "Parse profile to find functions with highest execution time/cost"
       },
       "step2": {
-        "name": "Call Analysis", 
+        "name": "Call Analysis",
         "action": "Analyze call frequency and relationships to understand bottlenecks"
       },
       "step3": {
@@ -239,7 +239,7 @@
       }
     }
   },
-  
+
   "x-profile-format": {
     "description": "Cachegrind profile format understanding for AI analysis",
     "format_type": "Cachegrind format - Function-based profiling data",
@@ -257,10 +257,10 @@
       "summary": "summary: TotalCost"
     }
   },
-  
+
   "x-performance-capabilities": {
     "execution_time": "Identify functions consuming the most CPU time",
-    "memory_analysis": "Track memory allocation and access patterns", 
+    "memory_analysis": "Track memory allocation and access patterns",
     "call_frequency": "Find frequently called functions that could benefit from optimization",
     "bottleneck_detection": "Pinpoint specific performance bottlenecks in code execution",
     "optimization_ranking": "Prioritize optimization targets by impact potential",
@@ -268,9 +268,9 @@
     "io_bottlenecks": "Identify file/database operations causing performance issues",
     "algorithm_efficiency": "Analyze algorithmic complexity through execution patterns"
   },
-  
+
   "x-mcp-integration": {
-    "tool_name": "xdebug_start_profiling",
+    "tool_name": "xprofile",
     "usage": "Call via MCP to generate profile data, then analyze returned profile_file",
     "workflow": "1. Generate profile via MCP, 2. Analyze returned file based on size/complexity, 3. Use optimization strategies for performance improvements"
   }

--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug-v1.json",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
   "title": "Xdebug Debug Result",
   "description": "Comprehensive debugging result combining breakpoint state ('crime scene photo') and execution trace ('surveillance footage') for AI-powered PHP debugging. Follows the principle: 'Error message is the crime photo. Trace is the crime footage.' - providing both the current state at breakpoints and the complete execution history in Xdebug .xt format.",
   "type": "object",
@@ -14,7 +14,7 @@
       "minItems": 1
     },
     "trace": {
-      "$ref": "xdebug-trace.json"
+      "$ref": "xtrace.json"
     },
     "analysis_context": {
       "type": "string",
@@ -78,7 +78,7 @@
     },
     {
       "rel": "self",
-      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
       "title": "JSON Schema for Xdebug Debug Results"
     },
     {

--- a/docs/schemas/xtrace.json
+++ b/docs/schemas/xtrace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-trace.json",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xtrace.json",
   "title": "Xdebug Trace Result",
   "description": "AI-optimized trace data for PHP debugging and execution flow analysis. Specialized for N+1 problem detection, recursion analysis, and database performance monitoring.",
   "type": "object",
@@ -73,7 +73,7 @@
     },
     {
       "rel": "self",
-      "href": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-trace.json",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xtrace.json",
       "title": "JSON Schema for Xdebug Trace Results",
       "description": "This schema definition with AI strategies and usage guidelines"
     },
@@ -92,13 +92,13 @@
     },
     {
       "rel": "tool",
-      "href": "mcp://xdebug_start_trace",
-      "title": "MCP Tool: Start Trace",
+      "href": "mcp://xtrace",
+      "title": "MCP Tool: Trace",
       "description": "MCP tool to generate trace data programmatically"
     },
     {
       "rel": "command",
-      "href": "file:///bin/xdebug-trace",
+      "href": "file:///bin/xtrace",
       "title": "Command Line Tool",
       "description": "CLI command to generate trace data with this schema"
     },
@@ -240,7 +240,7 @@
   },
 
   "x-mcp-integration": {
-    "tool_name": "xdebug_start_trace",
+    "tool_name": "xtrace",
     "usage": "Call via MCP to generate trace data, then analyze returned trace_file",
     "workflow": "1. Generate trace via MCP, 2. Analyze returned file path, 3. Use reading strategy based on total_lines"
   }

--- a/docs/slide/index-ja.html
+++ b/docs/slide/index-ja.html
@@ -205,7 +205,7 @@ var_dump($result);    // 繰り返し...削除もします...</code></pre>
                 <div class="fragment">
                     <h3>フォワードトレースアプローチ</h3>
                     <pre><code class="bash"># 条件ブレークポイント: 問題発生時に停止
-./vendor/bin/xdebug-debug --break='checkout.php:89:$total&lt;0' --steps=50 --exit-on-break -- php checkout.php
+./vendor/bin/xstep --break='checkout.php:89:$total&lt;0' --steps=50 --exit-on-break -- php checkout.php
 
 # AIが分析して報告:
 "発見: $50割引が$30のカートに適用され = -$20の合計
@@ -228,7 +228,7 @@ echo $result;
 ?&gt;' > test.php
 
 # 3. AIに実行を分析させる
-./vendor/bin/xdebug-trace --context="\$resultがnullになる理由を発見" -- php test.php
+./vendor/bin/xtrace --context="\$resultがnullになる理由を発見" -- php test.php
 
 # 4. 完全なAI統合を有効化
 claude mcp add xdebug php "$(pwd)/vendor/bin/xdebug-mcp"</code></pre>
@@ -283,7 +283,7 @@ claude mcp add xdebug php "$(pwd)/vendor/bin/xdebug-mcp"</code></pre>
                         <h3 style="color: #51cf66;">フォワードトレース</h3>
                         <p style="font-size: 0.8em; color: #51cf66; margin-bottom: 15px;">🎥 動画撮影<br>（完全記録）</p>
                         <pre><code class="bash" style="font-size: 0.6em;"># 単一コマンドで全体を記録
-./vendor/bin/xdebug-debug --break='script.php:10:$user==null' --steps=300 --exit-on-break -- php script.php
+./vendor/bin/xstep --break='script.php:10:$user==null' --steps=300 --exit-on-break -- php script.php
 
 # AIが完全な🎥映像を見る:
 # ステップ1: $id = getUserId() → 42を返す
@@ -483,7 +483,7 @@ if ($userId === 0) {
                 <div class="fragment">
                     <h4>条件トレース（スマート）:</h4>
                     <pre><code class="bash code-small"># 条件満たされるまで静かに待機、その後トレース開始
-./vendor/bin/xdebug-debug --break='User.php:85:$userId==0' --steps=100 --exit-on-break -- php app.php
+./vendor/bin/xstep --break='User.php:85:$userId==0' --steps=100 --exit-on-break -- php app.php
 
 # 完全実行履歴取得: どうやって$userId=0になったのか？
 # AIが条件に至る完全実行トレースを分析</code></pre>
@@ -500,7 +500,7 @@ if ($userId === 0) {
                 <h2>別の例: 「配列が空の時のみクラッシュ」</h2>
                 <div class="fragment">
                     <pre><code class="bash"># 条件固有の問題を確実に捕獲
-./vendor/bin/xdebug-debug --break='DataProcessor.php:42:empty($items)' --steps=200 --exit-on-break -- php batch.php
+./vendor/bin/xstep --break='DataProcessor.php:42:empty($items)' --steps=200 --exit-on-break -- php batch.php
 
 # AI分析で根本原因特定
 # 空配列条件への完全パス分析</code></pre>
@@ -516,10 +516,10 @@ if ($userId === 0) {
 
             <!-- Performance Profiling -->
             <section>
-                <h2>xdebug-profile: パフォーマンスを見よう 🔍</h2>
+                <h2>xprofile: パフォーマンスを見よう 🔍</h2>
                 <div class="fragment">
                     <pre><code class="bash"># マイクロ秒精度パフォーマンスプロファイリング
-./vendor/bin/xdebug-profile --context="API性能解析" -- php slow_api.php
+./vendor/bin/xprofile --context="API性能解析" -- php slow_api.php
 
 # AIがボトルネック分析と最適化提案を提供
 # 結果: ボトルネック特定付き完全性能プロファイル</code></pre>
@@ -534,10 +534,10 @@ if ($userId === 0) {
 
             <!-- Forward Trace Debugging -->
             <section>
-                <h2>xdebug-debug: 条件ブレークポイント付きフォワードトレース 🕵️</h2>
+                <h2>xstep: 条件ブレークポイント付きフォワードトレース 🕵️</h2>
                 <div class="fragment">
                     <pre><code class="bash"># 完全コンテキスト付きAI最適化デバッグ
-./vendor/bin/xdebug-debug --break='User.php:42:$user==null' --steps=150 --exit-on-break -- php app.php
+./vendor/bin/xstep --break='User.php:42:$user==null' --steps=150 --exit-on-break -- php app.php
 
 # AIが条件に至る完全実行履歴を取得
 # null userへのパス包括分析を提供</code></pre>
@@ -576,11 +576,11 @@ if ($userId === 0) {
 
             <!-- Coverage Intelligence -->
             <section>
-                <h2>xdebug-coverage: 生Xdebugカバレッジ - 任意のPHPスクリプト 📊</h2>
+                <h2>xcoverage: 生Xdebugカバレッジ - 任意のPHPスクリプト 📊</h2>
                 <div class="fragment">
                     <pre><code class="bash"># PHPUnitだけでなく任意のPHPスクリプトで動作
-./vendor/bin/xdebug-coverage -- php ./vendor/bin/phpunit  # PHPUnit
-./vendor/bin/xdebug-coverage -- php my-script.php         # 任意のスクリプト
+./vendor/bin/xcoverage -- php ./vendor/bin/phpunit  # PHPUnit
+./vendor/bin/xcoverage -- php my-script.php         # 任意のスクリプト
 
 # ネイティブXdebugフォーマット - AI理解が高速</code></pre>
                 </div>
@@ -598,7 +598,7 @@ if ($userId === 0) {
                 <h2>🌳 NEW: ブランチカバレッジ + GraphViz可視化</h2>
                 <div class="fragment">
                     <pre><code class="bash"># 新機能: ブランチ/パスカバレッジの視覚化
-./bin/xdebug-coverage --branch-coverage -- php app.php
+./bin/xcoverage --branch-coverage -- php app.php
 
 # 一度の実行で同時生成:
 # ✅ 詳細ブランチカバレッジJSON

--- a/docs/slide/index.html
+++ b/docs/slide/index.html
@@ -205,7 +205,7 @@ var_dump($result);    // Repeat... and cleanup...</code></pre>
                 <div class="fragment">
                     <h3>Forward Trace Approach</h3>
                     <pre><code class="bash"># Conditional breakpoint: Stop when problem occurs
-./vendor/bin/xdebug-debug --break='checkout.php:89:$total&lt;0' --steps=50 --exit-on-break -- php checkout.php
+./vendor/bin/xstep --break='checkout.php:89:$total&lt;0' --steps=50 --exit-on-break -- php checkout.php
 
 # AI analyzes and reports:
 "Found it: $50 discount applied to $30 cart = -$20 total
@@ -228,7 +228,7 @@ echo $result;
 ?&gt;' > test.php
 
 # 3. Let AI analyze execution
-./vendor/bin/xdebug-trace --context="Find why \$result becomes null" -- php test.php
+./vendor/bin/xtrace --context="Find why \$result becomes null" -- php test.php
 
 # 4. Enable full AI integration
 claude mcp add xdebug php "$(pwd)/vendor/bin/xdebug-mcp"</code></pre>
@@ -283,7 +283,7 @@ claude mcp add xdebug php "$(pwd)/vendor/bin/xdebug-mcp"</code></pre>
                         <h3 style="color: #51cf66;">ForwardTrace</h3>
                         <p style="font-size: 0.8em; color: #51cf66; margin-bottom: 15px;">🎥 Video Shooting<br>(Complete Recording)</p>
                         <pre><code class="bash" style="font-size: 0.6em;"># Single command records entire movie
-./vendor/bin/xdebug-debug --break='script.php:10:$user==null' --steps=300 --exit-on-break -- php script.php
+./vendor/bin/xstep --break='script.php:10:$user==null' --steps=300 --exit-on-break -- php script.php
 
 # AI sees the complete 🎥 movie:
 # Step 1: $id = getUserId() → returns 42
@@ -483,7 +483,7 @@ if ($userId === 0) {
                 <div class="fragment">
                     <h4>Conditional Tracing (Smart):</h4>
                     <pre><code class="bash code-small"># Wait silently until condition met, then start tracing
-./vendor/bin/xdebug-debug --break='User.php:85:$userId==0' --steps=100 --exit-on-break -- php app.php
+./vendor/bin/xstep --break='User.php:85:$userId==0' --steps=100 --exit-on-break -- php app.php
 
 # Get complete execution history: how did we get $userId=0?
 # AI analyzes complete execution trace leading to condition</code></pre>
@@ -500,7 +500,7 @@ if ($userId === 0) {
                 <h2>Another Example: "Crash Only When Array is Empty"</h2>
                 <div class="fragment">
                     <pre><code class="bash"># Catch condition-specific problems with certainty
-./vendor/bin/xdebug-debug --break='DataProcessor.php:42:empty($items)' --steps=200 --exit-on-break -- php batch.php
+./vendor/bin/xstep --break='DataProcessor.php:42:empty($items)' --steps=200 --exit-on-break -- php batch.php
 
 # AI analysis to identify root cause
 # Analyzes the complete path to empty array condition</code></pre>
@@ -516,10 +516,10 @@ if ($userId === 0) {
 
             <!-- Performance Profiling -->
             <section>
-                <h2>xdebug-profile: See Performance 🔍</h2>
+                <h2>xprofile: See Performance 🔍</h2>
                 <div class="fragment">
                     <pre><code class="bash"># Microsecond-precision performance profiling
-./vendor/bin/xdebug-profile --context="API performance analysis" -- php slow_api.php
+./vendor/bin/xprofile --context="API performance analysis" -- php slow_api.php
 
 # AI analyzes bottlenecks and provides optimization suggestions
 # Result: Complete performance profile with bottleneck identification</code></pre>
@@ -534,10 +534,10 @@ if ($userId === 0) {
 
             <!-- Forward Trace Debugging -->
             <section>
-                <h2>xdebug-debug: ForwardTrace with Conditional Breakpoints 🕵️</h2>
+                <h2>xstep: ForwardTrace with Conditional Breakpoints 🕵️</h2>
                 <div class="fragment">
                     <pre><code class="bash"># AI-optimized debugging with complete context
-./vendor/bin/xdebug-debug --break='User.php:42:$user==null' --steps=150 --exit-on-break -- php app.php
+./vendor/bin/xstep --break='User.php:42:$user==null' --steps=150 --exit-on-break -- php app.php
 
 # AI gets complete execution history leading to condition
 # Provides comprehensive analysis of path to null user</code></pre>
@@ -576,11 +576,11 @@ if ($userId === 0) {
 
             <!-- Coverage Intelligence -->
             <section>
-                <h2>xdebug-coverage: Raw Xdebug Coverage - Any PHP Script 📊</h2>
+                <h2>xcoverage: Raw Xdebug Coverage - Any PHP Script 📊</h2>
                 <div class="fragment">
                     <pre><code class="bash"># Works with any PHP script, not just PHPUnit
-./vendor/bin/xdebug-coverage -- php ./vendor/bin/phpunit  # PHPUnit
-./vendor/bin/xdebug-coverage -- php my-script.php         # Any script
+./vendor/bin/xcoverage -- php ./vendor/bin/phpunit  # PHPUnit
+./vendor/bin/xcoverage -- php my-script.php         # Any script
 
 # Native Xdebug format - fast AI understanding</code></pre>
                 </div>
@@ -598,7 +598,7 @@ if ($userId === 0) {
                 <h2>🌳 NEW: Branch Coverage + GraphViz Visualization</h2>
                 <div class="fragment">
                     <pre><code class="bash"># New feature: Visual branch/path coverage analysis
-./bin/xdebug-coverage --branch-coverage -- php app.php
+./bin/xcoverage --branch-coverage -- php app.php
 
 # Single execution, multiple AI-ready outputs:
 # ✅ Detailed branch coverage JSON

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -2148,7 +2148,7 @@ final class DebugServer
     private function outputStepRecordingResults(): void
     {
         $result = [
-            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json',
+            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xstep.json',
             'breaks' => $this->breaks,
         ];
 
@@ -2939,7 +2939,7 @@ final class DebugServer
     private function outputMultipleBreakResults(array $breaks): void
     {
         $debugState = [
-            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json',
+            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xstep.json',
             'breaks' => $breaks,
             'trace' => $this->getTraceInfo(),
         ];

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -68,9 +68,9 @@ final class McpServer
     private function initializeTools(): void
     {
         $this->tools = [
-            'x-trace' => [
-                'name' => 'x-trace',
-                'description' => 'Trace PHP execution flow | ex) ./x-trace "php test.php" "Debug login flow" | PHPUnit: ./x-trace "php vendor/bin/phpunit --filter testMethod TestClass.php" "Testing user auth"',
+            'xtrace' => [
+                'name' => 'xtrace',
+                'description' => 'Trace PHP execution flow | ex) ./xtrace "php test.php" "Debug login flow" | PHPUnit: ./xtrace "php vendor/bin/phpunit --filter testMethod TestClass.php" "Testing user auth"',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -87,9 +87,9 @@ final class McpServer
                     'required' => ['script'],
                 ],
             ],
-            'x-profile' => [
-                'name' => 'x-profile',
-                'description' => 'Profile performance bottlenecks | ex) ./x-profile "php slow-app.php" "API performance"',
+            'xprofile' => [
+                'name' => 'xprofile',
+                'description' => 'Profile performance bottlenecks | ex) ./xprofile "php slow-app.php" "API performance"',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -106,9 +106,9 @@ final class McpServer
                     'required' => ['script'],
                 ],
             ],
-            'x-debug' => [
-                'name' => 'x-debug',
-                'description' => 'Step debugging with breakpoints | ex) /x-debug --script="php test.php" --break="test.php:15:$user==null" --steps=100 --context="debug context"',
+            'xstep' => [
+                'name' => 'xstep',
+                'description' => 'Step debugging with breakpoints | ex) /xstep --script="php test.php" --break="test.php:15:$user==null" --steps=100 --context="debug context"',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -140,9 +140,9 @@ final class McpServer
                     'required' => ['script'],
                 ],
             ],
-            'x-coverage' => [
-                'name' => 'x-coverage',
-                'description' => 'Analyze test coverage | ex) ./x-coverage "php vendor/bin/phpunit UserTest.php"',
+            'xcoverage' => [
+                'name' => 'xcoverage',
+                'description' => 'Analyze test coverage | ex) ./xcoverage "php vendor/bin/phpunit UserTest.php"',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -164,9 +164,9 @@ final class McpServer
                     'required' => ['script'],
                 ],
             ],
-            'x-backtrace' => [
-                'name' => 'x-backtrace',
-                'description' => 'Get stack trace (backtrace) at breakpoint | ex) ./x-backtrace --break="app.php:50" "php app.php"',
+            'xback' => [
+                'name' => 'xback',
+                'description' => 'Get stack trace (backtrace) at breakpoint | ex) ./xback --break="app.php:50" "php app.php"',
                 'inputSchema' => [
                     'type' => 'object',
                     'properties' => [
@@ -387,8 +387,8 @@ final class McpServer
             'result' => [
                 'prompts' => [
                     [
-                        'name' => 'x-trace',
-                        'description' => 'Trace PHP execution flow | ex) /x-trace --script=test.php --context="Debug login flow" | PHPUnit: /x-trace --script="vendor/bin/phpunit --filter testMethod TestClass.php" --context="Testing user auth"',
+                        'name' => 'xtrace',
+                        'description' => 'Trace PHP execution flow | ex) /xtrace --script=test.php --context="Debug login flow" | PHPUnit: /xtrace --script="vendor/bin/phpunit --filter testMethod TestClass.php" --context="Testing user auth"',
                         'arguments' => [
                             [
                                 'name' => 'script',
@@ -408,8 +408,8 @@ final class McpServer
                         ],
                     ],
                     [
-                        'name' => 'x-debug',
-                        'description' => 'Step debugging with breakpoints | ex) /x-debug --script="php test.php" --break="test.php:15:$user==null" --steps=100 --context="debug context"',
+                        'name' => 'xstep',
+                        'description' => 'Step debugging with breakpoints | ex) /xstep --script="php test.php" --break="test.php:15:$user==null" --steps=100 --context="debug context"',
                         'arguments' => [
                             [
                                 'name' => 'script',
@@ -439,8 +439,8 @@ final class McpServer
                         ],
                     ],
                     [
-                        'name' => 'x-profile',
-                        'description' => 'Profile performance bottlenecks | ex) /x-profile --script=slow-app.php --context="API performance"',
+                        'name' => 'xprofile',
+                        'description' => 'Profile performance bottlenecks | ex) /xprofile --script=slow-app.php --context="API performance"',
                         'arguments' => [
                             [
                                 'name' => 'script',
@@ -460,8 +460,8 @@ final class McpServer
                         ],
                     ],
                     [
-                        'name' => 'x-coverage',
-                        'description' => 'Analyze test coverage | ex) /x-coverage --script="vendor/bin/phpunit UserTest.php"',
+                        'name' => 'xcoverage',
+                        'description' => 'Analyze test coverage | ex) /xcoverage --script="vendor/bin/phpunit UserTest.php"',
                         'arguments' => [
                             [
                                 'name' => 'script',
@@ -486,8 +486,8 @@ final class McpServer
                         ],
                     ],
                     [
-                        'name' => 'x-backtrace',
-                        'description' => 'Get stack trace (backtrace) at breakpoint | ex) /x-backtrace --script="app.php" --break="app.php:50"',
+                        'name' => 'xback',
+                        'description' => 'Get stack trace (backtrace) at breakpoint | ex) /xback --script="app.php" --break="app.php:50"',
                         'arguments' => [
                             [
                                 'name' => 'script',
@@ -545,19 +545,19 @@ final class McpServer
         $args = $this->normalizePositionalArgs($args, $promptName);
 
         switch ($promptName) {
-            case 'x-trace':
+            case 'xtrace':
                 return $this->executeXTrace($id, $args);
 
-            case 'x-debug':
+            case 'xstep':
                 return $this->executeXDebug($id, $args);
 
-            case 'x-profile':
+            case 'xprofile':
                 return $this->executeXProfile($id, $args);
 
-            case 'x-coverage':
+            case 'xcoverage':
                 return $this->executeXCoverage($id, $args);
 
-            case 'x-backtrace':
+            case 'xback':
                 return $this->executeXBacktrace($id, $args);
 
             default:
@@ -583,7 +583,7 @@ final class McpServer
         }
 
         switch ($promptName) {
-            case 'x-trace':
+            case 'xtrace':
                 if (isset($args[0])) {
                     $args['script'] = $args[0];
                 }
@@ -594,7 +594,7 @@ final class McpServer
 
                 break;
 
-            case 'x-debug':
+            case 'xstep':
                 if (isset($args[0])) {
                     $args['script'] = $args[0];
                 }
@@ -613,7 +613,7 @@ final class McpServer
 
                 break;
 
-            case 'x-profile':
+            case 'xprofile':
                 if (isset($args[0])) {
                     $args['script'] = $args[0];
                 }
@@ -624,7 +624,7 @@ final class McpServer
 
                 break;
 
-            case 'x-coverage':
+            case 'xcoverage':
                 if (isset($args[0])) {
                     $args['script'] = $args[0];
                 }
@@ -639,7 +639,7 @@ final class McpServer
 
                 break;
 
-            case 'x-backtrace':
+            case 'xback':
                 if (isset($args[0])) {
                     $args['script'] = $args[0];
                 }
@@ -752,27 +752,27 @@ final class McpServer
     private function executeToolCall(string $toolName, array $arguments): string
     {
         switch ($toolName) {
-            case 'x-trace':
+            case 'xtrace':
                 $result = $this->executeXTrace(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
 
-            case 'x-profile':
+            case 'xprofile':
                 $result = $this->executeXProfile(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
 
-            case 'x-debug':
+            case 'xstep':
                 $result = $this->executeXDebug(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
 
-            case 'x-coverage':
+            case 'xcoverage':
                 $result = $this->executeXCoverage(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
 
-            case 'x-backtrace':
+            case 'xback':
                 $result = $this->executeXBacktrace(null, $arguments);
 
                 return $result['result']['messages'][0]['content']['text'] ?? 'No result';
@@ -840,7 +840,7 @@ final class McpServer
                 'id' => $id,
                 'error' => [
                     'code' => -32000,
-                    'message' => 'x-trace execution failed: ' . $e->getMessage(),
+                    'message' => 'xtrace execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd
@@ -954,7 +954,7 @@ final class McpServer
                 'id' => $id,
                 'error' => [
                     'code' => -32000,
-                    'message' => 'x-debug execution failed: ' . $e->getMessage(),
+                    'message' => 'xstep execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd
@@ -1019,7 +1019,7 @@ final class McpServer
                 'id' => $id,
                 'error' => [
                     'code' => -32000,
-                    'message' => 'x-profile execution failed: ' . $e->getMessage(),
+                    'message' => 'xprofile execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd
@@ -1086,7 +1086,7 @@ final class McpServer
                 'id' => $id,
                 'error' => [
                     'code' => -32000,
-                    'message' => 'x-coverage execution failed: ' . $e->getMessage(),
+                    'message' => 'xcoverage execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd
@@ -1104,7 +1104,7 @@ final class McpServer
             $depth = $args['depth'] ?? 10;
 
             // Build command
-            $cmd = $this->binDir . '/xdebug-backtrace';
+            $cmd = $this->binDir . '/xback';
 
             // Add breakpoint if specified
             if (! empty($breakpoint)) {
@@ -1171,7 +1171,7 @@ final class McpServer
                 'id' => $id,
                 'error' => [
                     'code' => -32000,
-                    'message' => 'x-backtrace execution failed: ' . $e->getMessage(),
+                    'message' => 'xback execution failed: ' . $e->getMessage(),
                 ],
             ];
             // @codeCoverageIgnoreEnd

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -59,11 +59,11 @@ class McpServerIntegrationTest extends TestCase
         // Verify analysis tools are present
         $toolNames = array_column($toolsResponse['result']['tools'], 'name');
         $expectedTools = [
-            'x-trace',
-            'x-profile',
-            'x-debug',
-            'x-coverage',
-            'x-backtrace',
+            'xtrace',
+            'xprofile',
+            'xstep',
+            'xcoverage',
+            'xback',
         ];
 
         foreach ($expectedTools as $toolName) {

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -54,24 +54,24 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
         $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-mcp'));
     }
 
-    public function testXdebugTraceCommandExists(): void
+    public function testXtraceCommandExists(): void
     {
-        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-trace'));
-        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-trace'));
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xtrace'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xtrace'));
     }
 
-    public function testXdebugTraceHelp(): void
+    public function testXtraceHelp(): void
     {
-        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xdebug-trace --help 2>&1');
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xtrace --help 2>&1');
         $this->assertNotNull($output);
         $this->assertStringContainsString('Usage:', $output);
-        $this->assertStringContainsString('xdebug-trace', $output);
+        $this->assertStringContainsString('xtrace', $output);
     }
 
-    public function testXdebugTraceExecution(): void
+    public function testXtraceExecution(): void
     {
         $command = sprintf(
-            'cd %s && ./bin/xdebug-trace -- php %s 2>&1',
+            'cd %s && ./bin/xtrace -- php %s 2>&1',
             dirname(__DIR__, 2),
             $this->testScript,
         );
@@ -81,24 +81,24 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
         $this->assertStringContainsString('Computing factorial', $output);
     }
 
-    public function testXdebugProfileCommandExists(): void
+    public function testXprofileCommandExists(): void
     {
-        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-profile'));
-        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-profile'));
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xprofile'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xprofile'));
     }
 
-    public function testXdebugProfileHelp(): void
+    public function testXprofileHelp(): void
     {
-        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xdebug-profile --help 2>&1');
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xprofile --help 2>&1');
         $this->assertNotNull($output);
         $this->assertStringContainsString('Usage:', $output);
-        $this->assertStringContainsString('xdebug-profile', $output);
+        $this->assertStringContainsString('xprofile', $output);
     }
 
-    public function testXdebugProfileExecution(): void
+    public function testXprofileExecution(): void
     {
         $command = sprintf(
-            'cd %s && ./bin/xdebug-profile -- php %s 2>&1',
+            'cd %s && ./bin/xprofile -- php %s 2>&1',
             dirname(__DIR__, 2),
             $this->testScript,
         );
@@ -108,49 +108,49 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
         $this->assertStringContainsString('Computing factorial', $output);
     }
 
-    public function testXdebugCoverageCommandExists(): void
+    public function testXcoverageCommandExists(): void
     {
-        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-coverage'));
-        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-coverage'));
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xcoverage'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xcoverage'));
     }
 
-    public function testXdebugDebugCommandExists(): void
+    public function testXstepCommandExists(): void
     {
-        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-debug'));
-        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-debug'));
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xstep'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xstep'));
     }
 
-    public function testXdebugDebugHelp(): void
+    public function testXstepHelp(): void
     {
-        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xdebug-debug --help 2>&1');
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xstep --help 2>&1');
         $this->assertNotNull($output);
         $this->assertStringContainsString('Usage:', $output);
-        $this->assertStringContainsString('xdebug-debug', $output);
+        $this->assertStringContainsString('xstep', $output);
     }
 
-    public function testXdebugBacktraceCommandExists(): void
+    public function testXbackCommandExists(): void
     {
-        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xdebug-backtrace'));
-        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xdebug-backtrace'));
+        $this->assertTrue(file_exists(__DIR__ . '/../../bin/xback'));
+        $this->assertTrue(is_executable(__DIR__ . '/../../bin/xback'));
     }
 
-    public function testXdebugBacktraceHelp(): void
+    public function testXbackHelp(): void
     {
-        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xdebug-backtrace --help 2>&1');
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xback --help 2>&1');
         $this->assertNotNull($output);
         $this->assertStringContainsString('Usage:', $output);
-        $this->assertStringContainsString('xdebug-backtrace', $output);
+        $this->assertStringContainsString('xback', $output);
     }
 
     public function testAllCommandsAreExecutable(): void
     {
         $commands = [
             'xdebug-mcp',
-            'xdebug-trace',
-            'xdebug-profile',
-            'xdebug-coverage',
-            'xdebug-debug',
-            'xdebug-backtrace',
+            'xtrace',
+            'xprofile',
+            'xcoverage',
+            'xstep',
+            'xback',
         ];
 
         foreach ($commands as $command) {

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -63,11 +63,11 @@ class McpServerTest extends TestCase
 
         $toolNames = array_column($response['result']['tools'], 'name');
         // Test that execution tools are present
-        $this->assertContains('x-trace', $toolNames);
-        $this->assertContains('x-profile', $toolNames);
-        $this->assertContains('x-debug', $toolNames);
-        $this->assertContains('x-coverage', $toolNames);
-        $this->assertContains('x-backtrace', $toolNames);
+        $this->assertContains('xtrace', $toolNames);
+        $this->assertContains('xprofile', $toolNames);
+        $this->assertContains('xstep', $toolNames);
+        $this->assertContains('xcoverage', $toolNames);
+        $this->assertContains('xback', $toolNames);
 
         // Test that interactive debugging tools are removed
         $this->assertNotContains('xdebug_connect', $toolNames);
@@ -189,11 +189,11 @@ class McpServerTest extends TestCase
         $this->assertCount(5, $response['result']['prompts']);
 
         $promptNames = array_column($response['result']['prompts'], 'name');
-        $this->assertContains('x-trace', $promptNames);
-        $this->assertContains('x-debug', $promptNames);
-        $this->assertContains('x-profile', $promptNames);
-        $this->assertContains('x-coverage', $promptNames);
-        $this->assertContains('x-backtrace', $promptNames);
+        $this->assertContains('xtrace', $promptNames);
+        $this->assertContains('xstep', $promptNames);
+        $this->assertContains('xprofile', $promptNames);
+        $this->assertContains('xcoverage', $promptNames);
+        $this->assertContains('xback', $promptNames);
     }
 
     public function testNotificationsInitialized(): void
@@ -241,15 +241,15 @@ class McpServerTest extends TestCase
 
     public function testNormalizePositionalArgs(): void
     {
-        // Test x-trace normalization
+        // Test xtrace normalization
         $args = ['script.php', 'test context'];
-        $normalized = $this->invokePrivateMethod($this->server, 'normalizePositionalArgs', [$args, 'x-trace']);
+        $normalized = $this->invokePrivateMethod($this->server, 'normalizePositionalArgs', [$args, 'xtrace']);
         $this->assertEquals('script.php', $normalized['script']);
         $this->assertEquals('test context', $normalized['context']);
 
-        // Test x-debug normalization
+        // Test xstep normalization
         $args = ['script.php', 'file.php:10', '50', 'debug context'];
-        $normalized = $this->invokePrivateMethod($this->server, 'normalizePositionalArgs', [$args, 'x-debug']);
+        $normalized = $this->invokePrivateMethod($this->server, 'normalizePositionalArgs', [$args, 'xstep']);
         $this->assertEquals('script.php', $normalized['script']);
         $this->assertEquals('file.php:10', $normalized['breakpoints']);
         $this->assertEquals('50', $normalized['steps']);
@@ -306,7 +306,7 @@ class McpServerTest extends TestCase
         // Test executeToolCall method directly - it should handle exceptions and return formatted result
         // The method catches exceptions and handles them, so let's test it returns proper error content
         try {
-            $result = $this->invokePrivateMethod($this->server, 'executeToolCall', ['x-trace', ['script' => '']]);
+            $result = $this->invokePrivateMethod($this->server, 'executeToolCall', ['xtrace', ['script' => '']]);
             // executeToolCall should return a string result, not throw exception
             $this->assertIsString($result);
             $this->assertStringContainsString('No result', $result); // Default fallback when execution fails
@@ -339,16 +339,16 @@ class McpServerTest extends TestCase
 
     public function testToolsCallXDebug(): void
     {
-        // Test tools/call request with x-debug to hit executeToolCall case
+        // Test tools/call request with xstep to hit executeToolCall case
         $request = [
             'jsonrpc' => '2.0',
             'id' => 100,
             'method' => 'tools/call',
             'params' => [
-                'name' => 'x-debug',
+                'name' => 'xstep',
                 'arguments' => [
                     'script' => 'php tests/fake/loop-counter.php',
-                    'context' => 'Tools call x-debug test',
+                    'context' => 'Tools call xstep test',
                 ],
             ],
         ];
@@ -370,10 +370,10 @@ class McpServerTest extends TestCase
             'id' => 200,
             'method' => 'prompts/get',
             'params' => [
-                'name' => 'x-trace',
+                'name' => 'xtrace',
                 'arguments' => [
                     'script' => 'php tests/fake/loop-counter.php',
-                    'context' => 'Test x-trace prompt',
+                    'context' => 'Test xtrace prompt',
                 ],
             ],
         ];
@@ -394,10 +394,10 @@ class McpServerTest extends TestCase
             'id' => 201,
             'method' => 'prompts/get',
             'params' => [
-                'name' => 'x-debug',
+                'name' => 'xstep',
                 'arguments' => [
                     'script' => 'php tests/fake/loop-counter.php',
-                    'context' => 'Test x-debug prompt',
+                    'context' => 'Test xstep prompt',
                     'breakpoints' => 'tests/fake/loop-counter.php:10',
                 ],
             ],
@@ -414,7 +414,7 @@ class McpServerTest extends TestCase
         // Verify the response contains Forward Trace debugging output
         $message = $response['result']['messages'][0]['content']['text'];
         $this->assertStringContainsString('Forward Trace debugging completed', $message);
-        $this->assertStringContainsString('Context**: Test x-debug prompt', $message);
+        $this->assertStringContainsString('Context**: Test xstep prompt', $message);
         $this->assertStringContainsString('tests/fake/loop-counter.php', $message);
 
         // Verify debug_data structure
@@ -423,7 +423,7 @@ class McpServerTest extends TestCase
         $this->assertArrayHasKey('exit_code', $debugData);
         $this->assertArrayHasKey('context', $debugData);
         $this->assertStringContainsString('xstep', $debugData['command']);
-        $this->assertEquals('Test x-debug prompt', $debugData['context']);
+        $this->assertEquals('Test xstep prompt', $debugData['context']);
         $this->assertEquals(0, $debugData['exit_code']);
     }
 
@@ -434,10 +434,10 @@ class McpServerTest extends TestCase
             'id' => 202,
             'method' => 'prompts/get',
             'params' => [
-                'name' => 'x-profile',
+                'name' => 'xprofile',
                 'arguments' => [
                     'script' => 'php tests/fake/loop-counter.php',
-                    'context' => 'Test x-profile prompt',
+                    'context' => 'Test xprofile prompt',
                 ],
             ],
         ];

--- a/tests/fake/README.md
+++ b/tests/fake/README.md
@@ -11,7 +11,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 1. **loop-counter.php** - Loop Progression Pattern
 ```php
 // Tests: Counter incrementation, array iteration, result accumulation
-./bin/xdebug-debug --context="Testing loop counter progression" --break=tests/fake-script/loop-counter.php:8,13,17,24,29 --exit-on-break -- php tests/fake-script/loop-counter.php
+./bin/xstep --context="Testing loop counter progression" --break=tests/fake-script/loop-counter.php:8,13,17,24,29 --exit-on-break -- php tests/fake-script/loop-counter.php
 ```
 **Demonstrates:**
 - Variable progression through loop iterations
@@ -21,7 +21,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 2. **array-manipulation.php** - Array Filtering Pattern
 ```php
 // Tests: User filtering, statistical accumulation, conditional processing
-./bin/xdebug-debug --context="Array manipulation with user filtering" --break=tests/fake-script/array-manipulation.php:8,14,18,21,23,29,33 --exit-on-break -- php tests/fake-script/array-manipulation.php
+./bin/xstep --context="Array manipulation with user filtering" --break=tests/fake-script/array-manipulation.php:8,14,18,21,23,29,33 --exit-on-break -- php tests/fake-script/array-manipulation.php
 ```
 **Demonstrates:**
 - Dynamic array building based on conditions
@@ -31,7 +31,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 3. **object-state.php** - Object State Evolution
 ```php
 // Tests: Method chaining, object property changes, state tracking
-./bin/xdebug-debug --context="Object state tracking with method chaining" --break=tests/fake-script/object-state.php:12,19,23,32,34,38,40,42 --exit-on-break -- php tests/fake-script/object-state.php
+./bin/xstep --context="Object state tracking with method chaining" --break=tests/fake-script/object-state.php:12,19,23,32,34,38,40,42 --exit-on-break -- php tests/fake-script/object-state.php
 ```
 **Demonstrates:**
 - Object property evolution through method calls
@@ -41,7 +41,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 4. **conditional-logic.php** - Flag-Based Logic Pattern
 ```php
 // Tests: Boolean flag evolution, conditional branching, running totals
-./bin/xdebug-debug --context="Conditional logic with flag tracking" --break=tests/fake-script/conditional-logic.php:8,18,21,24,27,32,37 --exit-on-break -- php tests/fake-script/conditional-logic.php
+./bin/xstep --context="Conditional logic with flag tracking" --break=tests/fake-script/conditional-logic.php:8,18,21,24,27,32,37 --exit-on-break -- php tests/fake-script/conditional-logic.php
 ```
 **Demonstrates:**
 - Boolean flag state changes
@@ -51,7 +51,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 5. **nested-loops.php** - Complex Iteration Pattern
 ```php
 // Tests: Matrix processing, nested accumulation, pattern detection
-./bin/xdebug-debug --context="Nested loops matrix processing" --break=tests/fake-script/nested-loops.php:8,17,21,22,25,32,34,39,41 --exit-on-break -- php tests/fake-script/nested-loops.php
+./bin/xstep --context="Nested loops matrix processing" --break=tests/fake-script/nested-loops.php:8,17,21,22,25,32,34,39,41 --exit-on-break -- php tests/fake-script/nested-loops.php
 ```
 **Demonstrates:**
 - Multi-dimensional array processing
@@ -61,7 +61,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 ### 6. **error-simulation.php** - Error Handling Pattern
 ```php
 // Tests: Error collection, null/empty handling, edge cases
-./bin/xdebug-debug --context="Error handling simulation" --break=tests/fake-script/error-simulation.php:12,15,18,21,25,30,31,36 --exit-on-break -- php tests/fake-script/error-simulation.php
+./bin/xstep --context="Error handling simulation" --break=tests/fake-script/error-simulation.php:12,15,18,21,25,30,31,36 --exit-on-break -- php tests/fake-script/error-simulation.php
 ```
 **Demonstrates:**
 - Error state accumulation
@@ -72,7 +72,7 @@ These scripts showcase how Forward Trace debugging captures variable state evolu
 
 ### Individual Test
 ```bash
-./bin/xdebug-debug --context="Your description here" --break=file.php:line1,line2 --exit-on-break -- php tests/fake-script/pattern.php > output.json
+./bin/xstep --context="Your description here" --break=file.php:line1,line2 --exit-on-break -- php tests/fake-script/pattern.php > output.json
 ```
 
 ### All Tests (JSON Output)
@@ -82,16 +82,16 @@ php tests/fake-script/run.php > all_tests.json
 
 ### Schema Validation
 ```bash
-php bin/validate_schema.php docs/schemas/xdebug-debug.json output.json
+php bin/validate_schema.php docs/schemas/xstep.json output.json
 ```
 
 ## 📊 Expected Output
 
-Each test generates JSON conforming to the `xdebug-debug.json` schema:
+Each test generates JSON conforming to the `xstep.json` schema:
 
 ```json
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "context": "Your description here", 
     "breaks": [
         {

--- a/tests/fake/array-manipulation.json
+++ b/tests/fake/array-manipulation.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [],
     "trace": {
         "file": "/tmp/trace.1034012359.xt",

--- a/tests/fake/conditional-logic.json
+++ b/tests/fake/conditional-logic.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [
         {
             "step": 1,

--- a/tests/fake/error-simulation.json
+++ b/tests/fake/error-simulation.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [
         {
             "step": 1,

--- a/tests/fake/loop-counter.json
+++ b/tests/fake/loop-counter.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [
         {
             "step": 1,

--- a/tests/fake/nested-loops.json
+++ b/tests/fake/nested-loops.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [
         {
             "step": 1,

--- a/tests/fake/object-state.json
+++ b/tests/fake/object-state.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xdebug-debug.json",
+    "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
     "breaks": [],
     "trace": {
         "file": "/tmp/trace.1034012359.xt",


### PR DESCRIPTION
- Rename MCP tools to match CLI names:
  - x-trace → xtrace
  - x-profile → xprofile
  - x-debug → xstep
  - x-coverage → xcoverage
  - x-backtrace → xback

- Fix executeXBacktrace to call correct CLI command (xback)
- Update all related test files to use new tool names

## Summary by Sourcery

MCP サーバーのツール名およびプロンプト名を対応する CLI バイナリと揃え、`backtrace` コマンドの配線を修正しました。

バグ修正:
- 以前の `backtrace` 実行ファイル名ではなく、正しい `xback` CLI バイナリを呼び出すように、`backtrace` MCP コマンドを修正しました。

機能強化:
- MCP ツール、プロンプト、および内部識別子をダッシュ付きの名前から、CLI に揃えた名前（`xtrace`, `xprofile`, `xstep`, `xcoverage`, `xback`）に標準化しました。

テスト:
- すべての MCP ワークフローのカバレッジを維持しつつ、新しいツールおよび CLI コマンド名を参照するように結合テストおよび単体テストを更新しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align MCP server tool and prompt names with the corresponding CLI binaries and correct the backtrace command wiring.

Bug Fixes:
- Fix the backtrace MCP command to invoke the correct xback CLI binary instead of the previous backtrace executable name.

Enhancements:
- Standardize MCP tool, prompt, and internal identifiers from dashed names to CLI-aligned names (xtrace, xprofile, xstep, xcoverage, xback).

Tests:
- Update integration and unit tests to reference the new tool and CLI command names and keep coverage of all MCP workflows.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed core tool identifiers to shorter aliases: x-trace → xtrace, x-profile → xprofile, x-debug → xstep, x-coverage → xcoverage, x-backtrace → xback; adjusted command dispatching and related messages.

* **Tests**
  * Updated test names and expectations to reflect the renamed tool identifiers and command names.

* **Documentation**
  * Updated docs, examples, usage guides and schema references to use the new aliases and updated slash-command examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->