### PR TITLE
feat(xcoverage): Add PHPUnit mode as default with @codeCoverageIgnore support

### DIFF
--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -1,108 +1,250 @@
 #!/usr/bin/env php
 <?php
 
+// Load autoloader
+require_once __DIR__ . '/autoload.php';
+use Koriym\XdebugMcp\XdebugFinder;
+
 // Show help if requested
 if (in_array('--help', $argv) || in_array('-h', $argv)) {
-    echo "Usage: " . $argv[0] . " [--include-vendor=PATTERNS] [--] [php script.php [args...]]\n";
+    echo "Usage: " . $argv[0] . " [OPTIONS] [--] [php script.php [args...]]\n";
     echo "\n";
-    echo "🎯 AI-Optimized PHP Code Coverage Collection Tool\n";
+    echo "AI-Optimized PHP Code Coverage Collection Tool\n";
     echo "\n";
     echo "PURPOSE:\n";
     echo "  Superior alternative to PHPUnit's HTML/XML coverage reports for AI analysis.\n";
     echo "  Provides streamlined JSON coverage data that AI can immediately analyze\n";
     echo "  without browser interaction or file navigation overhead.\n";
     echo "\n";
-    echo "KEY BENEFITS FOR AI DEVELOPMENT:\n";
-    echo "  ✅ Zero-config PHPUnit auto-detection (covers 80% of use cases)\n";
-    echo "  ✅ Mixed output: Test results + JSON coverage in single stream\n";
-    echo "  ✅ Conflict-free: Uses --no-coverage to avoid PHPUnit interference\n";
-    echo "  ✅ Universal: Works with any PHP script, not just PHPUnit\n";
-    echo "  ✅ Immediate AI consumption: No HTML files or XML parsing required\n";
-    echo "  ✅ TestDox format: Human-readable test descriptions for context\n";
+    echo "MODES:\n";
+    echo "  Default (PHPUnit mode):\n";
+    echo "    Uses PHPUnit's --coverage-clover for coverage collection.\n";
+    echo "    Respects @codeCoverageIgnore annotations and phpunit.xml settings.\n";
+    echo "\n";
+    echo "  --raw mode:\n";
+    echo "    Uses Xdebug directly for raw coverage data.\n";
+    echo "    Ignores PHPUnit annotations. Works with any PHP script.\n";
     echo "\n";
     echo "OPTIONS:\n";
-    echo "  --branch-coverage         Enable detailed branch/path coverage analysis with GraphViz\n";
-    echo "  --include-vendor=PATTERNS  Include vendor packages (e.g., \"bear/*,ray/di\")\n";
+    echo "  --raw                     Use raw Xdebug coverage (ignores @codeCoverageIgnore)\n";
+    echo "  --branch-coverage         Enable branch/path coverage (--raw mode only)\n";
+    echo "  --include-vendor=PATTERNS Include vendor packages (--raw mode only)\n";
     echo "  --help, -h                Show this help\n";
     echo "\n";
     echo "COMMON USAGE PATTERNS:\n";
-    echo "  # Most common: Auto-detect and run PHPUnit with coverage\n";
+    echo "  # Default: PHPUnit mode with @codeCoverageIgnore support\n";
     echo "  " . $argv[0] . "\n";
     echo "\n";
-    echo "  # Coverage for any PHP script (not just PHPUnit)\n";
-    echo "  " . $argv[0] . " -- php app.php\n";
+    echo "  # Raw mode: Xdebug direct coverage (any PHP script)\n";
+    echo "  " . $argv[0] . " --raw -- php app.php\n";
     echo "\n";
-    echo "  # Include specific vendor packages for framework debugging\n";
+    echo "  # Include specific vendor packages\n";
     echo "  " . $argv[0] . " --include-vendor=bear/resource,ray/di\n";
     echo "\n";
-    echo "  # Branch/path coverage with GraphViz visualization\n";
-    echo "  " . $argv[0] . " --branch-coverage -- php app.php\n";
-    echo "\n";
-    echo "  # Full vendor analysis (use sparingly - generates noise)\n";
-    echo "  " . $argv[0] . " --include-vendor=*/* -- php app.php\n";
-    echo "\n";
     echo "OUTPUT FORMAT:\n";
-    echo "  📊 Standard Mode (Token-optimized):\n";
-    echo "     - summary: {files, total_lines, covered_lines, uncovered_lines, coverage_percent}\n";
-    echo "     - uncovered: Ranges of uncovered lines, e.g., [10, \"15-20\", 25]\n";
-    echo "     - graphviz_dot_file: Path to GraphViz DOT file (content in file, not JSON)\n";
-    echo "  🌳 Branch Mode: Full branch coverage data + GraphViz dot file\n";
+    echo "  - summary: {files, total_lines, covered_lines, uncovered_lines, coverage_percent}\n";
+    echo "  - uncovered: Ranges of uncovered lines, e.g., [10, \"15-20\", 25]\n";
     echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json\n";
-    echo "  Benefits: Compact output reduces token consumption by 60-80%\n";
-    echo "\n";
-    echo "📋 JSON SCHEMA RESOURCES (Essential for AI):\n";
-    echo "  Schema Definition: https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json\n";
-    echo "  Branch Coverage Schema: https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json\n";
-    echo "  Xdebug Coverage Docs: https://xdebug.org/docs/code_coverage\n";
-    echo "  Function Reference: https://xdebug.org/docs/code_coverage#xdebug_get_code_coverage\n";
-    echo "  Branch Coverage: https://xdebug.org/docs/code_coverage#XDEBUG_CC_BRANCH_CHECK\n";
-    echo "  MCP Tool: mcp://xdebug_start_coverage\n";
-    echo "  GraphViz Integration: Generates /tmp/paths.dot for path visualization\n";
-    echo "  AI Analysis Tips: Schema includes x-interpretation-guide for optimal analysis\n";
-    echo "\n";
-    echo "AI WORKFLOW INTEGRATION:\n";
-    echo "  📊 Standard Mode:\n";
-    echo "    1. Run: ./bin/xdebug-coverage\n";
-    echo "    2. AI analyzes: Test results (success/failures) + Line coverage gaps\n";
-    echo "    3. AI identifies: Untested lines, missing test cases, code quality issues\n";
-    echo "    4. AI suggests: Specific improvements with line numbers\n";
-    echo "\n";
-    echo "  🌳 Branch Coverage Mode:\n";
-    echo "    1. Run: ./bin/xdebug-coverage --branch-coverage\n";
-    echo "    2. AI analyzes: Branch/path coverage + GraphViz visualization data\n";
-    echo "    3. AI identifies: Unexecuted code paths, branch coverage gaps\n";
-    echo "    4. AI visualizes: Code flow with dot file (use 'dot -Tpng /tmp/paths.dot')\n";
-    echo "    5. AI suggests: Path-specific test improvements and edge case coverage\n";
-    echo "\n";
-    echo "RECOMMENDED AI PROMPT:\n";
-    echo "  'Run xdebug-coverage --help first to understand this tool, then analyze my code coverage'\n";
     echo "\n";
     exit(0);
 }
 
-// Parse options using getopt (help handled above to keep single source of truth)
+// Parse options
 $optind = 0;
-$options = getopt('', ['include-vendor::', 'branch-coverage'], $optind);
+$options = getopt('', ['include-vendor::', 'branch-coverage', 'raw'], $optind);
 
 $includeVendor = $options['include-vendor'] ?? null;
 $branchCoverage = isset($options['branch-coverage']);
+$rawMode = isset($options['raw']);
 
-// Create shutdown script for coverage collection
+// Get remaining arguments
+$args = $optind !== null ? array_slice($argv, $optind) : [];
+
+// If first argument is 'php', remove it
+if (!empty($args) && $args[0] === 'php') {
+    $args = array_slice($args, 1);
+}
+
+// Debug mode
+$debug = getenv('COVERAGE_DEBUG');
+if ($debug) {
+    fwrite(STDERR, "[COVERAGE_DEBUG] Raw mode: " . ($rawMode ? 'true' : 'false') . "\n");
+    fwrite(STDERR, "[COVERAGE_DEBUG] Args: " . json_encode($args) . "\n");
+}
+
+// PHPUnit mode (default) - uses PHPUnit's coverage with @codeCoverageIgnore support
+if (!$rawMode) {
+    // Check if PHPUnit is available
+    if (!file_exists('./vendor/bin/phpunit')) {
+        fwrite(STDERR, "Error: PHPUnit not found. Use --raw mode for non-PHPUnit projects.\n");
+        fwrite(STDERR, "Example: " . $argv[0] . " --raw -- php script.php\n");
+        exit(1);
+    }
+
+    // Create temp file for coverage data (clover XML format for stability)
+    $coverageFile = tempnam(sys_get_temp_dir(), 'phpunit_coverage_') . '.xml';
+
+    // Get Xdebug flag for explicit loading
+    $xdebugFlag = XdebugFinder::getXdebugFlag();
+    $phpPath = PHP_BINARY;
+
+    // Build PHPUnit command with coverage-clover (stable XML format)
+    $phpunitArgs = ['--coverage-clover=' . $coverageFile, '--testdox', '--no-progress', '--colors=never'];
+
+    // Add any additional args
+    if (!empty($args)) {
+        $phpunitArgs = array_merge($phpunitArgs, $args);
+    }
+
+    echo "# Running PHPUnit with coverage (respects @codeCoverageIgnore)\n";
+
+    $escapedArgs = array_map('escapeshellarg', $phpunitArgs);
+    // Run PHPUnit via PHP with Xdebug enabled
+    $cmd = escapeshellarg($phpPath) . $xdebugFlag . ' -dxdebug.mode=coverage ' . escapeshellarg('./vendor/bin/phpunit') . ' ' . implode(' ', $escapedArgs);
+
+    if ($debug) {
+        fwrite(STDERR, "[COVERAGE_DEBUG] PHPUnit command: $cmd\n");
+    }
+
+    // Run PHPUnit and capture output
+    $lines = [];
+    $exitCode = 0;
+    exec($cmd . ' 2>&1', $lines, $exitCode);
+    $testOutput = implode("\n", $lines);
+
+    // Output test results
+    echo $testOutput . "\n";
+
+    // Check if coverage file was created
+    if (!file_exists($coverageFile)) {
+        fwrite(STDERR, "\nWarning: Coverage file was not created. Tests may have failed.\n");
+        exit($exitCode);
+    }
+
+    // Load and process clover XML coverage data
+    try {
+        $xml = simplexml_load_file($coverageFile);
+        if ($xml === false) {
+            throw new RuntimeException('Failed to parse clover XML');
+        }
+
+        // Convert clover XML to xcoverage format
+        $uncoveredOnly = [];
+        $totalFiles = 0;
+        $totalLines = 0;
+        $coveredLines = 0;
+        $uncoveredLines = 0;
+
+        // Handle empty coverage (no files)
+        if (!isset($xml->project->file)) {
+            $result = [
+                '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json',
+                'coverage_type' => 'line',
+                'mode' => 'phpunit',
+                'summary' => [
+                    'files' => 0,
+                    'total_lines' => 0,
+                    'covered_lines' => 0,
+                    'uncovered_lines' => 0,
+                    'coverage_percent' => 0
+                ],
+                'uncovered' => []
+            ];
+            echo json_encode($result, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";
+            unlink($coverageFile);
+            exit($exitCode);
+        }
+
+        foreach ($xml->project->file as $file) {
+            $filePath = (string)$file['name'];
+            $totalFiles++;
+            $uncoveredLineNums = [];
+
+            foreach ($file->line as $line) {
+                // Only process statement lines (skip method declarations)
+                if ((string)$line['type'] !== 'stmt') {
+                    continue;
+                }
+
+                $lineNum = (int)$line['num'];
+                $count = (int)$line['count'];
+                $totalLines++;
+
+                if ($count > 0) {
+                    $coveredLines++;
+                } else {
+                    $uncoveredLines++;
+                    $uncoveredLineNums[] = $lineNum;
+                }
+            }
+
+            if (!empty($uncoveredLineNums)) {
+                // Group consecutive lines into ranges
+                sort($uncoveredLineNums);
+                $ranges = [];
+                $start = $uncoveredLineNums[0];
+                $end = $start;
+
+                for ($i = 1; $i < count($uncoveredLineNums); $i++) {
+                    if ($uncoveredLineNums[$i] === $end + 1) {
+                        $end = $uncoveredLineNums[$i];
+                    } else {
+                        $ranges[] = ($start === $end) ? $start : "$start-$end";
+                        $start = $uncoveredLineNums[$i];
+                        $end = $start;
+                    }
+                }
+                $ranges[] = ($start === $end) ? $start : "$start-$end";
+                $uncoveredOnly[$filePath] = $ranges;
+            }
+        }
+
+        $coveragePercent = $totalLines > 0 ? round(($coveredLines / $totalLines) * 100, 1) : 0;
+
+        $result = [
+            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json',
+            'coverage_type' => 'line',
+            'mode' => 'phpunit',
+            'summary' => [
+                'files' => $totalFiles,
+                'total_lines' => $totalLines,
+                'covered_lines' => $coveredLines,
+                'uncovered_lines' => $uncoveredLines,
+                'coverage_percent' => $coveragePercent
+            ],
+            'uncovered' => $uncoveredOnly
+        ];
+
+        echo json_encode($result, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";
+
+    } catch (Throwable $e) {
+        fwrite(STDERR, "Error processing coverage: " . $e->getMessage() . "\n");
+        exit(1);
+    } finally {
+        // Cleanup
+        if (file_exists($coverageFile)) {
+            unlink($coverageFile);
+        }
+    }
+
+    exit($exitCode);
+}
+
+// Raw mode - uses Xdebug directly (original behavior)
 $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
 $branchFlag = $branchCoverage ? 'true' : 'false';
 $includeVendorRequire = '';
 if ($includeVendor !== null) {
     $filterPath = __DIR__ . '/../prepend_filter.php';
     $includeVendorRequire = 'require_once ' . var_export($filterPath, true) . ';';
-    // Pass include-vendor as environment variable for prepend_filter.php to access
     putenv('COVERAGE_INCLUDE_VENDOR=' . $includeVendor);
 }
+
 file_put_contents($shutdownScript, '<?php
 ' . $includeVendorRequire . '
 $tempDir = sys_get_temp_dir();
 $branchCoverage = ' . $branchFlag . ';
 if ($branchCoverage) {
-    // For branch coverage, be more permissive with filtering to capture test files
     xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, [getcwd() . "/vendor/", $tempDir]);
     xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK);
 } else {
@@ -111,19 +253,14 @@ if ($branchCoverage) {
 }
 register_shutdown_function(function() use ($tempDir, $branchCoverage) {
     $coverage = xdebug_get_code_coverage();
-    // Remove temp files from coverage
     $filtered = array_filter($coverage, function($path) use ($tempDir) {
         return strpos($path, $tempDir) === false;
     }, ARRAY_FILTER_USE_KEY);
-    
+
     if ($branchCoverage) {
-        // Generate GraphViz dot file from branch coverage data
-        $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_branch_coverage_");
-        $dotFilePath = $dotFilePath . ".dot";
-        $dotContent = "digraph coverage {\n";
-        $dotContent .= "  rankdir=TB;\n";
-        $dotContent .= "  node [shape=box];\n\n";
-        
+        $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_branch_coverage_") . ".dot";
+        $dotContent = "digraph coverage {\n  rankdir=TB;\n  node [shape=box];\n\n";
+
         foreach ($filtered as $file => $data) {
             if (isset($data["functions"])) {
                 foreach ($data["functions"] as $function => $funcData) {
@@ -134,10 +271,9 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                             $style = $branch["hit"] > 0 ? "filled,solid" : "filled,dashed";
                             $color = $branch["hit"] > 0 ? "lightgreen" : "lightcoral";
                             $dotContent .= "  \"$function-$branchId\" [label=\"$label\", style=\"$style\", fillcolor=\"$color\"];\n";
-                            
-                            // Add edges for branch connections
+
                             foreach ($branch["out"] as $i => $targetBranch) {
-                                if ($targetBranch !== 2147483645) { // Skip exit branches
+                                if ($targetBranch !== 2147483645) {
                                     $edgeStyle = ($branch["out_hit"][$i] ?? 0) > 0 ? "solid" : "dashed";
                                     $dotContent .= "  \"$function-$branchId\" -> \"$function-$targetBranch\" [style=\"$edgeStyle\"];\n";
                                 }
@@ -148,94 +284,20 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                 }
             }
         }
-        
+
         $dotContent .= "}\n";
         file_put_contents($dotFilePath, $dotContent);
-        
-        // Generate unique output PNG path
         $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
-        
+
         $result = [
             "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json",
             "coverage_type" => "branch",
+            "mode" => "raw",
             "coverage" => $filtered,
             "graphviz_dot_file" => $dotFilePath,
             "visualization_command" => "dot -Tpng " . escapeshellarg($dotFilePath) . " -o " . escapeshellarg($outputPath)
         ];
     } else {
-        // Generate GraphViz dot file for line coverage visualization
-        $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_line_coverage_");
-        $dotFilePath = $dotFilePath . ".dot";
-        $dotContent = "digraph line_coverage {\n";
-        $dotContent .= "  rankdir=TB;\n";
-        $dotContent .= "  node [shape=box];\n\n";
-
-        foreach ($filtered as $file => $lines) {
-            if (is_array($lines)) {
-                $fileName = basename($file);
-                $dotContent .= "  // File: $fileName\n";
-
-                // Group consecutive lines for better visualization
-                $lineGroups = [];
-                $currentGroup = [];
-                $lastLine = -1;
-
-                foreach ($lines as $lineNum => $hitCount) {
-                    if (is_numeric($lineNum)) {
-                        if ($lineNum == $lastLine + 1 && count($currentGroup) < 5) {
-                            $currentGroup[] = [$lineNum, $hitCount];
-                        } else {
-                            if (!empty($currentGroup)) {
-                                $lineGroups[] = $currentGroup;
-                            }
-                            $currentGroup = [[$lineNum, $hitCount]];
-                        }
-                        $lastLine = $lineNum;
-                    }
-                }
-                if (!empty($currentGroup)) {
-                    $lineGroups[] = $currentGroup;
-                }
-
-                foreach ($lineGroups as $groupIndex => $group) {
-                    $startLine = $group[0][0];
-                    $endLine = end($group)[0];
-                    $allHit = true;
-                    $anyHit = false;
-
-                    foreach ($group as [$line, $hit]) {
-                        if ($hit <= 0) $allHit = false;
-                        if ($hit > 0) $anyHit = true;
-                    }
-
-                    $label = $startLine == $endLine ? "Line $startLine" : "Lines $startLine-$endLine";
-                    if ($allHit) {
-                        $color = "lightgreen";
-                        $style = "filled,solid";
-                    } elseif ($anyHit) {
-                        $color = "lightyellow";
-                        $style = "filled,solid";
-                    } else {
-                        $color = "lightcoral";
-                        $style = "filled,dashed";
-                    }
-
-                    $nodeId = str_replace(["/", ".", " "], "_", $fileName) . "_group_" . $groupIndex;
-                    $dotContent .= "  \"$nodeId\" [label=\"$label\\n$fileName\", style=\"$style\", fillcolor=\"$color\"];\n";
-                }
-                $dotContent .= "\n";
-            }
-        }
-
-        $dotContent .= "}\n";
-        file_put_contents($dotFilePath, $dotContent);
-
-        // Generate unique output PNG path
-        $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
-
-        // Extract only uncovered lines (hit count <= 0) for compact output
-        // Group consecutive lines into ranges for readability (e.g., "10-15")
-        // Also calculate summary statistics
         $uncoveredOnly = [];
         $totalFiles = 0;
         $totalLines = 0;
@@ -258,7 +320,6 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                     }
                 }
                 if (!empty($uncoveredLineNums)) {
-                    // Group consecutive lines into ranges
                     sort($uncoveredLineNums);
                     $ranges = [];
                     $start = $uncoveredLineNums[0];
@@ -283,6 +344,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
         $result = [
             "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
             "coverage_type" => "line",
+            "mode" => "raw",
             "summary" => [
                 "files" => $totalFiles,
                 "total_lines" => $totalLines,
@@ -290,92 +352,46 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                 "uncovered_lines" => $uncoveredLines,
                 "coverage_percent" => $coveragePercent
             ],
-            "uncovered" => $uncoveredOnly,
-            "graphviz_dot_file" => $dotFilePath,
-            "visualization_command" => "dot -Tpng " . escapeshellarg($dotFilePath) . " -o " . escapeshellarg($outputPath)
+            "uncovered" => $uncoveredOnly
         ];
     }
     echo(json_encode($result, JSON_UNESCAPED_SLASHES));
 });
 ');
 
-// Debug: Check OPTIND and argv
-if (getenv('COVERAGE_DEBUG')) {
-    fwrite(STDERR, "[COVERAGE_DEBUG] OPTIND: " . ($GLOBALS['OPTIND'] ?? 'not set') . "\n");
-    fwrite(STDERR, "[COVERAGE_DEBUG] argv: " . json_encode($argv) . "\n");
-}
-
-// Use optind from getopt to get remaining arguments
-$args = $optind !== null ? array_slice($argv, $optind) : [];
-
-// If first argument is 'php', remove it (we're already using PHP_BINARY)
-if (!empty($args) && $args[0] === 'php') {
-    $args = array_slice($args, 1);
-}
-
-// Debug: Check parsed args
-if (getenv('COVERAGE_DEBUG')) {
-    fwrite(STDERR, "[COVERAGE_DEBUG] Parsed args: " . json_encode($args) . "\n");
-}
-
-// Use PHP_BINARY constant instead of which php
 $phpPath = PHP_BINARY;
-
-// Load autoloader and XdebugFinder for intelligent Xdebug detection
-require_once __DIR__ . '/autoload.php';
-use Koriym\XdebugMcp\XdebugFinder;
-
-// Get appropriate Xdebug flag (empty if already loaded)
 $xdebugFlag = XdebugFinder::getXdebugFlag();
-
 $escapedPrependFile = escapeshellarg($shutdownScript);
 
-// Default to PHPUnit if no arguments provided
+// Default to PHPUnit for raw mode if no args
 if (empty($args)) {
     if (file_exists('./vendor/bin/phpunit')) {
         $args = ['./vendor/bin/phpunit', '--no-coverage', '--testdox', '--no-progress', '--colors=never'];
-        if ($branchCoverage) {
-            echo "# Auto-detected: Running PHPUnit tests with branch coverage analysis + GraphViz visualization\n";
-        } else {
-            echo "# Auto-detected: Running PHPUnit tests with xdebug-mcp coverage (AI-optimized output)\n";
-        }
+        echo "# Raw mode: Running PHPUnit with Xdebug direct coverage\n";
     } else {
-        echo "Usage: " . $argv[0] . " [--branch-coverage] [--include-vendor=PATTERNS] [--] php script.php [args...]\n";
+        echo "Usage: " . $argv[0] . " --raw [--branch-coverage] [--include-vendor=PATTERNS] [--] php script.php [args...]\n";
         echo "No arguments provided and ./vendor/bin/phpunit not found.\n";
-        echo "Run with --help for more information.\n";
         exit(1);
     }
 }
 
-// Properly escape arguments after PHPUnit detection
 $escapedArgs = array_map('escapeshellarg', $args);
-
-// Execute PHP script with coverage enabled (keep output visible for troubleshooting)
-$cmd = escapeshellarg($phpPath) 
-     . $xdebugFlag 
-     . ' -dxdebug.mode=coverage -dauto_prepend_file=' 
-     . $escapedPrependFile 
-     . ' ' 
+$cmd = escapeshellarg($phpPath)
+     . $xdebugFlag
+     . ' -dxdebug.mode=coverage -dauto_prepend_file='
+     . $escapedPrependFile
+     . ' '
      . implode(' ', $escapedArgs);
-// Debug: Log command to stderr
-if (getenv('COVERAGE_DEBUG')) {
+
+if ($debug) {
     fwrite(STDERR, "[COVERAGE_DEBUG] Command: $cmd\n");
-    fwrite(STDERR, "[COVERAGE_DEBUG] Shutdown script content:\n" . file_get_contents($shutdownScript) . "\n");
 }
 
-// Capture both STDOUT and STDERR, and the exit code
 $lines = [];
 $exitCode = 0;
 exec($cmd . ' 2>&1', $lines, $exitCode);
 $output = implode("\n", $lines);
 
-// Debug: Log raw output
-if (getenv('COVERAGE_DEBUG')) {
-    fwrite(STDERR, "[COVERAGE_DEBUG] Raw output: " . ($output ?: '(empty)') . "\n");
-}
-
-// Output everything (PHPUnit output + JSON coverage data)
-// AI can distinguish between test output and JSON coverage
 echo $output;
-// Clean up temporary file
 unlink($shutdownScript);
+exit($exitCode);

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -38,8 +38,8 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "  # Raw mode: Xdebug direct coverage (any PHP script)\n";
     echo "  " . $argv[0] . " --raw -- php app.php\n";
     echo "\n";
-    echo "  # Include specific vendor packages\n";
-    echo "  " . $argv[0] . " --include-vendor=bear/resource,ray/di\n";
+    echo "  # Include specific vendor packages (raw mode)\n";
+    echo "  " . $argv[0] . " --raw --include-vendor=bear/resource,ray/di -- php script.php\n";
     echo "\n";
     echo "OUTPUT FORMAT:\n";
     echo "  - summary: {files, total_lines, covered_lines, uncovered_lines, coverage_percent}\n";
@@ -123,9 +123,13 @@ if (!$rawMode) {
 
     // Load and process clover XML coverage data
     try {
+        libxml_use_internal_errors(true);
         $xml = simplexml_load_file($coverageFile);
         if ($xml === false) {
-            throw new RuntimeException('Failed to parse clover XML');
+            $errors = libxml_get_errors();
+            $errorMsg = !empty($errors) ? $errors[0]->message : 'Unknown XML parsing error';
+            libxml_clear_errors();
+            throw new RuntimeException('Failed to parse clover XML: ' . trim($errorMsg));
         }
 
         // Convert clover XML to xcoverage format
@@ -273,6 +277,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                             $dotContent .= "  \"$function-$branchId\" [label=\"$label\", style=\"$style\", fillcolor=\"$color\"];\n";
 
                             foreach ($branch["out"] as $i => $targetBranch) {
+                                // 2147483645 is Xdebug's sentinel value for "exit" branch target
                                 if ($targetBranch !== 2147483645) {
                                     $edgeStyle = ($branch["out_hit"][$i] ?? 0) > 0 ? "solid" : "dashed";
                                     $dotContent .= "  \"$function-$branchId\" -> \"$function-$targetBranch\" [style=\"$edgeStyle\"];\n";

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -5,6 +5,9 @@
 require_once __DIR__ . '/autoload.php';
 use Koriym\XdebugMcp\XdebugFinder;
 
+// Xdebug's sentinel value for "exit" branch target in branch coverage data
+const XDEBUG_BRANCH_EXIT_SENTINEL = 2147483645;
+
 // Show help if requested
 if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "Usage: " . $argv[0] . " [OPTIONS] [--] [php script.php [args...]]\n";
@@ -277,8 +280,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
                             $dotContent .= "  \"$function-$branchId\" [label=\"$label\", style=\"$style\", fillcolor=\"$color\"];\n";
 
                             foreach ($branch["out"] as $i => $targetBranch) {
-                                // 2147483645 is Xdebug's sentinel value for "exit" branch target
-                                if ($targetBranch !== 2147483645) {
+                                if ($targetBranch !== ' . XDEBUG_BRANCH_EXIT_SENTINEL . ') {
                                     $edgeStyle = ($branch["out_hit"][$i] ?? 0) > 0 ? "solid" : "dashed";
                                     $dotContent .= "  \"$function-$branchId\" -> \"$function-$targetBranch\" [style=\"$edgeStyle\"];\n";
                                 }


### PR DESCRIPTION
## Summary

- Default mode now uses PHPUnit's `--coverage-clover` for stable coverage collection
- Respects `@codeCoverageIgnore` annotations and `phpunit.xml` settings
- Uses clover XML format for better PHPUnit version compatibility (no php-code-coverage dependency)
- Add `--raw` option to preserve original Xdebug direct coverage behavior

## Changes

| Before | After |
|--------|-------|
| Xdebug direct coverage (default) | PHPUnit mode with clover XML (default) |
| No `@codeCoverageIgnore` support | Full annotation support |
| `--coverage-php` (version dependent) | `--coverage-clover` (stable XML) |
| - | `--raw` for original behavior |

## Usage

```bash
# Default: PHPUnit mode (respects @codeCoverageIgnore)
./bin/xcoverage

# Raw mode: Xdebug direct (any PHP script)
./bin/xcoverage --raw -- php script.php
```

## Test plan

- [x] PHPUnit mode produces correct coverage JSON
- [x] `--raw` mode preserves original behavior
- [x] Empty coverage case handled
- [x] All existing tests pass

## Summary by Sourcery

デフォルトでは xcoverage が PHPUnit の Clover ベースのカバレッジ収集を使用するように切り替えつつ、従来の生の Xdebug ベースのモードもフラグによって利用できるように維持します。

新機能:
- `--coverage-clover` と Clover 形式の XML 出力を使用する、PHPUnit ベースのデフォルトカバレッジモードを導入。
- `@codeCoverageIgnore` アノテーションおよび `phpunit.xml` のカバレッジ設定をサポート。
- `--raw` オプションを追加し、従来の Xdebug 直接カバレッジモードで xcoverage を実行できるようにする。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch xcoverage to use PHPUnit clover-based coverage collection by default while preserving the previous raw Xdebug-based mode behind a flag.

New Features:
- Introduce a PHPUnit-based default coverage mode using --coverage-clover and clover XML output.
- Add support for @codeCoverageIgnore annotations and phpunit.xml coverage configuration.
- Add a --raw option to run xcoverage in the original Xdebug direct coverage mode.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --raw option to enable raw Xdebug coverage alongside the default PHPUnit mode.
  * Two-mode UX (default PHPUnit mode and raw Xdebug mode) with unified JSON output including summary and per-file uncovered line ranges; supports branch and line modes.
  * Optional debug traces via an environment variable; handles empty coverage gracefully.

* **Documentation**
  * Expanded help text with mode-specific guidance and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->