### PR TITLE
fix: Support full path PHP binaries in XdebugRunner

### DIFF
--- a/src/XdebugRunner.php
+++ b/src/XdebugRunner.php
@@ -21,6 +21,7 @@ use function getenv;
 use function glob;
 use function implode;
 use function passthru;
+use function preg_match;
 use function trim;
 use function usort;
 
@@ -193,6 +194,23 @@ class XdebugRunner
     }
 
     /**
+     * Check if the given path is a PHP binary
+     *
+     * Matches:
+     * - php
+     * - php8.3, php8, php83
+     * - php-8.3, php@8.3
+     * - /usr/bin/php
+     * - /opt/homebrew/opt/php@8.3/bin/php
+     */
+    public static function isPhpBinary(string $path): bool
+    {
+        // Match 'php' optionally followed by version (with optional separator)
+        // e.g., php, php8.3, php-8.3, php@8.3, /usr/bin/php, /path/to/php83
+        return preg_match('#(?:^|/)php(?:[-@]?\d+(?:\.\d+)*)?$#', $path) === 1;
+    }
+
+    /**
      * Get the command parts after parsing
      *
      * @return string[]
@@ -230,8 +248,8 @@ class XdebugRunner
     {
         $workingParts = $parts;
 
-        // Skip 'php' if present
-        if (isset($workingParts[0]) && $workingParts[0] === 'php') {
+        // Skip PHP binary if present (handles full paths like /usr/bin/php or php8.3)
+        if (isset($workingParts[0]) && self::isPhpBinary($workingParts[0])) {
             array_shift($workingParts);
         }
 
@@ -246,15 +264,16 @@ class XdebugRunner
     private function buildLocalCommand(array $parts): string
     {
         $workingParts = $parts;
+        $phpBinary = 'php';
 
-        // Skip 'php' if present
-        if (isset($workingParts[0]) && $workingParts[0] === 'php') {
-            array_shift($workingParts);
+        // Use specified PHP binary if present (handles full paths like /usr/bin/php or php8.3)
+        if (isset($workingParts[0]) && self::isPhpBinary($workingParts[0])) {
+            $phpBinary = array_shift($workingParts);
         }
 
         $xdebugArgs = $this->generateXdebugArguments();
 
-        return 'php ' . implode(' ', $xdebugArgs) . ' ' . implode(' ', array_map(escapeshellarg(...), $workingParts));
+        return escapeshellarg($phpBinary) . ' ' . implode(' ', $xdebugArgs) . ' ' . implode(' ', array_map(escapeshellarg(...), $workingParts));
     }
 
     /**

--- a/src/XdebugRunner.php
+++ b/src/XdebugRunner.php
@@ -42,6 +42,17 @@ use const STDERR;
  */
 class XdebugRunner
 {
+    /**
+     * Regex pattern to match PHP binary executables
+     *
+     * Matches 'php' optionally followed by version number, with optional .exe suffix.
+     * Supports both Unix (/) and Windows (\) path separators.
+     *
+     * Note: This intentionally does NOT match php-fpm, php-cgi, or other PHP SAPI binaries,
+     * as those are server processes not suitable for CLI script execution.
+     */
+    private const PHP_BINARY_PATTERN = '#(?:^|[\\\\/])php(?:[-@]?\d+(?:\.\d+)*)?(?:\.exe)?$#i';
+
     private string $mode = 'trace';
 
     /** @var string[] */
@@ -196,18 +207,26 @@ class XdebugRunner
     /**
      * Check if the given path is a PHP binary
      *
-     * Matches:
-     * - php
+     * Matches (Unix):
+     * - php, php.exe
      * - php8.3, php8, php83
      * - php-8.3, php@8.3
      * - /usr/bin/php
      * - /opt/homebrew/opt/php@8.3/bin/php
+     *
+     * Matches (Windows):
+     * - php.exe
+     * - C:\php\php.exe
+     * - C:\Program Files\php8.3\php.exe
+     *
+     * Does NOT match (intentionally excluded):
+     * - php-fpm, php-cgi (server SAPIs, not CLI binaries)
+     * - phpunit, phpcs, phpstan (PHP tools, not interpreters)
+     * - script.php (PHP source files)
      */
     public static function isPhpBinary(string $path): bool
     {
-        // Match 'php' optionally followed by version (with optional separator)
-        // e.g., php, php8.3, php-8.3, php@8.3, /usr/bin/php, /path/to/php83
-        return preg_match('#(?:^|/)php(?:[-@]?\d+(?:\.\d+)*)?$#', $path) === 1;
+        return preg_match(self::PHP_BINARY_PATTERN, $path) === 1;
     }
 
     /**

--- a/tests/Unit/XdebugRunnerTest.php
+++ b/tests/Unit/XdebugRunnerTest.php
@@ -527,4 +527,112 @@ final class XdebugRunnerTest extends TestCase
         unlink($profileFile);
         rmdir($tempDir);
     }
+
+    #[Test]
+    #[DataProvider('phpBinaryProvider')]
+    public function isPhpBinaryDetectsVariousPhpPaths(string $path, bool $expected): void
+    {
+        $this->assertSame($expected, XdebugRunner::isPhpBinary($path));
+    }
+
+    /** @return array<string, array{string, bool}> */
+    public static function phpBinaryProvider(): array
+    {
+        return [
+            // Valid PHP binaries
+            'simple php' => ['php', true],
+            'php with major version' => ['php8', true],
+            'php with version' => ['php8.3', true],
+            'php with full version' => ['php8.3.12', true],
+            'php with dash version' => ['php-8.3', true],
+            'php with at version' => ['php@8.3', true],
+            'php with double digit version' => ['php83', true],
+            'absolute path php' => ['/usr/bin/php', true],
+            'absolute path versioned php' => ['/usr/bin/php8.3', true],
+            'homebrew php path' => ['/opt/homebrew/opt/php@8.3/bin/php', true],
+            'custom path php' => ['/custom/path/to/php', true],
+            'versioned in path' => ['/usr/local/bin/php8', true],
+
+            // Invalid - not PHP binaries
+            'phpunit' => ['phpunit', false],
+            'phpcbf' => ['phpcbf', false],
+            'phpcs' => ['phpcs', false],
+            'phpstan' => ['phpstan', false],
+            'php script file' => ['script.php', false],
+            'path to php script' => ['/path/to/script.php', false],
+            'vendor phpunit' => ['vendor/bin/phpunit', false],
+            'not php at all' => ['python', false],
+            'empty string' => ['', false],
+        ];
+    }
+
+    #[Test]
+    public function buildsCommandWithFullPathPhpBinary(): void
+    {
+        $runner = new XdebugRunner(['script', '--', '/usr/bin/php', __FILE__]);
+        $runner->setMode('trace');
+
+        $command = $runner->buildCommand();
+
+        // Should use the specified PHP binary path
+        $this->assertStringContainsString('/usr/bin/php', $command);
+        $this->assertStringContainsString('-dxdebug.mode=trace', $command);
+        $this->assertStringContainsString(__FILE__, $command);
+    }
+
+    #[Test]
+    public function buildsCommandWithVersionedPhpBinary(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php8.3', __FILE__]);
+        $runner->setMode('profile');
+
+        $command = $runner->buildCommand();
+
+        // Should use the specified versioned PHP binary
+        $this->assertStringContainsString('php8.3', $command);
+        $this->assertStringContainsString('-dxdebug.mode=profile', $command);
+    }
+
+    #[Test]
+    public function buildsCommandWithHomebrewPhpPath(): void
+    {
+        $runner = new XdebugRunner([
+            'script',
+            '--',
+            '/opt/homebrew/opt/php@8.3/bin/php',
+            __FILE__,
+        ]);
+        $runner->setMode('trace');
+
+        $command = $runner->buildCommand();
+
+        // Should use the Homebrew PHP path, properly escaped
+        $this->assertStringContainsString('/opt/homebrew/opt/php@8.3/bin/php', $command);
+        $this->assertStringContainsString('-dxdebug.mode=trace', $command);
+        // Should NOT have 'php' prepended
+        $this->assertStringNotContainsString("'php' ", $command);
+    }
+
+    #[Test]
+    public function buildsCommandWithPhpAtVersionPath(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php@8.3', __FILE__]);
+        $runner->setMode('coverage');
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('php@8.3', $command);
+        $this->assertStringContainsString('-dxdebug.mode=coverage', $command);
+    }
+
+    #[Test]
+    public function validateLocalFileWithFullPathPhpBinary(): void
+    {
+        // Should not throw when using full path PHP binary
+        $runner = new XdebugRunner(['script', '--', '/usr/bin/php', __FILE__]);
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString(__FILE__, $command);
+    }
 }

--- a/tests/Unit/XdebugRunnerTest.php
+++ b/tests/Unit/XdebugRunnerTest.php
@@ -539,7 +539,7 @@ final class XdebugRunnerTest extends TestCase
     public static function phpBinaryProvider(): array
     {
         return [
-            // Valid PHP binaries
+            // Valid PHP binaries (Unix)
             'simple php' => ['php', true],
             'php with major version' => ['php8', true],
             'php with version' => ['php8.3', true],
@@ -553,6 +553,15 @@ final class XdebugRunnerTest extends TestCase
             'custom path php' => ['/custom/path/to/php', true],
             'versioned in path' => ['/usr/local/bin/php8', true],
 
+            // Valid PHP binaries (Windows)
+            'windows php.exe' => ['php.exe', true],
+            'windows path php.exe' => ['C:\\php\\php.exe', true],
+            'windows program files php' => ['C:\\Program Files\\php\\php.exe', true],
+            'windows versioned php' => ['C:\\php8.3\\php.exe', true],
+            'windows php8.exe' => ['php8.exe', true],
+            'windows php83.exe' => ['php83.exe', true],
+            'unix php.exe' => ['/usr/bin/php.exe', true],
+
             // Invalid - not PHP binaries
             'phpunit' => ['phpunit', false],
             'phpcbf' => ['phpcbf', false],
@@ -563,6 +572,13 @@ final class XdebugRunnerTest extends TestCase
             'vendor phpunit' => ['vendor/bin/phpunit', false],
             'not php at all' => ['python', false],
             'empty string' => ['', false],
+
+            // Invalid - server SAPIs (intentionally excluded)
+            'php-fpm' => ['php-fpm', false],
+            'php-cgi' => ['php-cgi', false],
+            'php-fpm with path' => ['/usr/sbin/php-fpm', false],
+            'php-cgi with path' => ['/usr/bin/php-cgi', false],
+            'php8.3-fpm' => ['php8.3-fpm', false],
         ];
     }
 


### PR DESCRIPTION
Add isPhpBinary() helper to detect PHP binaries using regex pattern
matching. This fixes the issue where full paths like
`/opt/homebrew/opt/php@8.3/bin/php` were not recognized and caused
parse errors when prepended with the default 'php' command.

The fix handles:
- Simple 'php' command
- Versioned binaries: php8.3, php-8.3, php@8.3
- Full paths: /usr/bin/php, /opt/homebrew/opt/php@8.3/bin/php

Fixes #51

## Summary by Sourcery

XdebugRunner における PHP バイナリの扱いを改善し、コマンドの構築と検証の際に、指定された PHP 実行ファイルのパスを正しく検出して使用するようにします。

Bug Fixes:
- フルパスおよびバージョン付きの PHP バイナリが正しく認識され、XdebugRunner のコマンドを組み立てる際に、先頭に不要な `php` コマンドが追加されないようにします。

Tests:
- シンプルな実行ファイル、バージョン付き実行ファイル、フルパス指定の実行ファイルなど、さまざまな PHP バイナリの検出に対する包括的なテストを追加し、これらのバイナリを用いたコマンドの構築および検証についてもテストを追加します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve XdebugRunner handling of PHP binaries by correctly detecting and using provided PHP executable paths in command construction and validation.

Bug Fixes:
- Ensure full-path and versioned PHP binaries are recognized and not incorrectly prefixed with an additional 'php' command when building XdebugRunner commands.

Tests:
- Add comprehensive tests for PHP binary detection across simple, versioned, and full-path executables and for command building and validation using these binaries.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PHP binary detection supporting versions, aliases and full paths; validation now skips detected PHP binaries and command execution uses an explicitly detected PHP binary when present.

* **Tests**
  * Added comprehensive tests covering PHP binary detection and command construction with various binary formats and paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->