### PR TITLE
feat: Add MCP Tool Search optimization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,6 +442,22 @@ This project prioritizes **execution-time trace analysis** over traditional code
 
 These slash commands provide direct access to Xdebug functionality within Claude Code, making PHP debugging more efficient and accessible.
 
+#### Skills vs MCP Tools: Dual Interface Design
+
+This server provides **two complementary interfaces** for accessing Xdebug functionality:
+
+| Interface | Invocation | Use Case |
+|-----------|------------|----------|
+| **Skills (Prompts)** | User explicitly types `/xtrace` | When you want to explicitly debug |
+| **MCP Tools** | AI automatically calls based on context | Seamless AI-driven analysis |
+
+**How they work together:**
+- **Skills**: User-initiated. Type `/xtrace` when you want to trace PHP execution explicitly
+- **MCP Tools**: AI-initiated. When you say "this PHP code is slow", AI can automatically call `xprofile` without explicit command
+
+**Tool Search Optimization (Claude Code):**
+When MCP tools exceed 10% of context, Claude Code's Tool Search feature dynamically loads tools. This server includes optimized `instructions` in the initialize response to help Tool Search find relevant tools when users discuss PHP debugging, profiling, or coverage analysis.
+
 #### Automatic Tool Selection:
 
 **For Performance Analysis:**

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -358,6 +358,7 @@ final class McpServer
                 'name' => 'xdebug-mcp-server',
                 'version' => '2.0.0',
             ],
+            'instructions' => 'PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, or analyze coverage of PHP code. Tools: xtrace (execution flow), xstep (breakpoint debugging), xprofile (performance), xcoverage (test coverage), xback (stack traces).',
         ]));
     }
 


### PR DESCRIPTION
## Summary
- Add server-level `instructions` field to initialize response for Tool Search discoverability
- Document dual interface design (Skills vs MCP Tools) in CLAUDE.md
- Explain how Tool Search optimization works with this server

## Background
Claude Code recently rolled out [MCP Tool Search](https://www.anthropic.com/news) which dynamically loads tools when they exceed 10% of context. The `instructions` field in the initialize response helps Claude know when to search for tools.

## Changes

### `src/McpServer.php`
Added `instructions` field:
```
PHP debugging and analysis tools using Xdebug. Use when asked to trace, 
debug, profile, or analyze coverage of PHP code. Tools: xtrace (execution 
flow), xstep (breakpoint debugging), xprofile (performance), xcoverage 
(test coverage), xback (stack traces).
```

### `CLAUDE.md`
Added "Skills vs MCP Tools: Dual Interface Design" section explaining:
- Skills (Prompts): User-initiated via `/xtrace`, `/xstep`, etc.
- MCP Tools: AI-initiated based on context
- How Tool Search optimization works

## Test plan
- [x] PHPUnit tests pass
- [x] Verified `instructions` field appears in initialize response

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on dual-interface design for accessing debugging tools through two complementary workflows.
  * Enhanced server initialization with descriptive instructions for available debugging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->