### PR TITLE
Skip legacy breakpointFile validation when --break= breakpoints

### DIFF
--- a/bin/xstep
+++ b/bin/xstep
@@ -380,7 +380,7 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
     }
 
     // Validate breakpoint file if specified
-    if ($breakpointFile !== null) {
+    if ($breakpointFile !== null && empty($breakpoints)) {
         if (!file_exists($breakpointFile)) {
             throw new RuntimeException("Breakpoint file not found: $breakpointFile");
         }

--- a/bin/xstep
+++ b/bin/xstep
@@ -338,7 +338,9 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
     }
 
     // Handle legacy format: script.php [breakpoint_file] [break_line]
-    if (count($command) >= 1 && !str_contains($command[0], ' ') && file_exists($command[0])) {
+    // Skip when --break= is used so positional args don't leak into $targetScript
+    // (e.g. `-- php main.php` with a `php/` directory in CWD would match file_exists).
+    if (empty($breakpoints) && count($command) >= 1 && !str_contains($command[0], ' ') && file_exists($command[0])) {
         $targetScript = $command[0];
         if (!isset($breakpointFile) && isset($command[1])) {
             $breakpointFile = $command[1];

--- a/src/XdebugTracer.php
+++ b/src/XdebugTracer.php
@@ -227,7 +227,7 @@ class XdebugTracer
         $entryExit = $parts[2]; // 0=Entry, 1=Exit, R=Return
         $time = (float) $parts[3];
         $memory = (int) $parts[4];
-        $function = $parts[5] ?? '';
+        $function = $parts[5];
 
         // Only count function entries (not exits or returns)
         if ($entryExit === '0') {


### PR DESCRIPTION
1st :clap: for your work, and thanks :pray: 

When using the new --break=file.php:line format, the legacy format detection block (which checks file_exists($command[0])) can incorrectly set $breakpointFile from positional args (e.g. when the command starts with 'php' and a 'php' directory exists in the working dir).

This caused a false 'Valid break line number is required' exception even though valid --break= breakpoints were already parsed.

Fix: only run the breakpointFile validation when $breakpoints is empty, i.e. the caller is using the legacy positional format, not --break=.

Keep up the great work :rocket: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breakpoint validation is now conditional: validation runs only when appropriate, reducing unnecessary errors and improving handling of breakpoint inputs.
  * Improved trace parsing behavior that affects detection of function calls and associated operation counts, leading to more accurate tracking and fewer spurious parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->