### PR TITLE
Add trigger phrases to xdebug skill description

### DIFF
--- a/skills/xdebug/SKILL.md
+++ b/skills/xdebug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xdebug
-description: PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, or analyze coverage of PHP code.
+description: PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, or analyze coverage of PHP code. Trigger phrases include "trace this function", "profile this code", "check coverage", "debug PHP", "set breakpoint", "find the bottleneck", "why is this slow", "トレース", "プロファイル", "カバレッジ".
 ---
 
 # Xdebug MCP Tools


### PR DESCRIPTION
## Summary

- Add English + Japanese trigger phrases to the xdebug skill description for better auto-triggering

## Test plan

- [ ] Verify skill triggers on phrases like "trace this function", "debug PHP", "トレース", "プロファイル"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with improved trigger phrases for better discoverability and clarity.
  * Added Japanese language support to documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->