### PR TITLE
feat: Add xcompare breakpoint comparison tool

### DIFF
--- a/.claude/skills/xcompare.md
+++ b/.claude/skills/xcompare.md
@@ -9,14 +9,23 @@ Use this skill when the user wants to:
 - Debug edge cases by comparing normal vs problematic inputs
 - Analyze differences between success and failure executions
 - Understand how code behaves with different conditions
+- **Compare current code vs another git branch/commit**
 
 ## Usage
+
+### Mode 1: Compare different commands
 
 ```bash
 ./bin/xcompare --break=FILE:LINE --run-a="CMD" --run-b="CMD" [options]
 ```
 
-### Required Arguments
+### Mode 2: Compare with another git ref
+
+```bash
+./bin/xcompare --break=FILE:LINE --run="CMD" --compare-with=REF [options]
+```
+
+### Mode 1 Arguments
 
 | Argument | Description | Example |
 |----------|-------------|---------|
@@ -24,12 +33,20 @@ Use this skill when the user wants to:
 | `--run-a` | First execution command | `php calc.php 10` |
 | `--run-b` | Second execution command | `php calc.php 0` |
 
+### Mode 2 Arguments
+
+| Argument | Description | Example |
+|----------|-------------|---------|
+| `--break` | Breakpoint location | `src/Calculator.php:25` |
+| `--run` | Command to run on both refs | `php calc.php 10` |
+| `--compare-with` | Git ref to compare against | `main`, `v1.0`, `abc123` |
+
 ### Optional Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `--label-a` | Label for run A (default: command string) |
-| `--label-b` | Label for run B (default: command string) |
+| `--label-a` | Label for run A (default: command or 'HEAD') |
+| `--label-b` | Label for run B (default: command or ref name) |
 | `--context` | Context description for AI analysis |
 | `--steps` | Steps to record after breakpoint (default: 1) |
 | `--include-vendor` | Include vendor packages in trace |
@@ -66,6 +83,26 @@ Use this skill when the user wants to:
   --run-a="php loop.php 1" \
   --run-b="php loop.php 100" \
   --context="Compare first vs last iteration"
+```
+
+### Compare current code vs main branch
+
+```bash
+./bin/xcompare \
+  --break=src/Calculator.php:25 \
+  --run="php calc.php 10" \
+  --compare-with=main \
+  --context="Compare current implementation vs main"
+```
+
+### Compare before/after a specific commit
+
+```bash
+./bin/xcompare \
+  --break=src/Auth.php:42 \
+  --run="php login.php user" \
+  --compare-with=abc123^ \
+  --context="Compare before the bugfix commit"
 ```
 
 ## Output

--- a/.claude/skills/xcompare.md
+++ b/.claude/skills/xcompare.md
@@ -1,0 +1,87 @@
+# xcompare - Breakpoint Comparison Tool
+
+Compare variable states at the same breakpoint across two different PHP executions.
+
+## When to Use
+
+Use this skill when the user wants to:
+- Compare how different inputs affect variable states
+- Debug edge cases by comparing normal vs problematic inputs
+- Analyze differences between success and failure executions
+- Understand how code behaves with different conditions
+
+## Usage
+
+```bash
+./bin/xcompare --break=FILE:LINE --run-a="CMD" --run-b="CMD" [options]
+```
+
+### Required Arguments
+
+| Argument | Description | Example |
+|----------|-------------|---------|
+| `--break` | Breakpoint location | `src/Calculator.php:25` |
+| `--run-a` | First execution command | `php calc.php 10` |
+| `--run-b` | Second execution command | `php calc.php 0` |
+
+### Optional Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `--label-a` | Label for run A (default: command string) |
+| `--label-b` | Label for run B (default: command string) |
+| `--context` | Context description for AI analysis |
+| `--steps` | Steps to record after breakpoint (default: 1) |
+| `--include-vendor` | Include vendor packages in trace |
+
+## Examples
+
+### Compare normal vs edge case input
+
+```bash
+./bin/xcompare \
+  --break=src/Calculator.php:25 \
+  --run-a="php calc.php 10" \
+  --run-b="php calc.php 0" \
+  --label-a="Normal input" \
+  --label-b="Edge case (zero)" \
+  --context="Compare division behavior with normal vs zero input"
+```
+
+### Compare authentication success vs failure
+
+```bash
+./bin/xcompare \
+  --break=src/Auth.php:42 \
+  --run-a="php login.php valid_user" \
+  --run-b="php login.php invalid_user" \
+  --context="Compare authentication flow"
+```
+
+### Compare loop iterations
+
+```bash
+./bin/xcompare \
+  --break=src/Loop.php:15 \
+  --run-a="php loop.php 1" \
+  --run-b="php loop.php 100" \
+  --context="Compare first vs last iteration"
+```
+
+## Output
+
+JSON with the following structure:
+
+- `breakpoint`: Location being compared
+- `run_a`: First execution result with variables
+- `run_b`: Second execution result with variables
+- `diff`: Computed differences
+  - `changed`: Variables with different values
+  - `unchanged`: Variables with same values
+  - `only_in_a`: Variables only in first run
+  - `only_in_b`: Variables only in second run
+- `analysis_hints`: Human/AI-readable summary
+
+## Schema
+
+Full JSON schema: https://koriym.github.io/xdebug-mcp/schemas/xcompare.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **xcompare**: Compare variable states at breakpoint across two different executions
+  - Runs xstep twice with different commands/inputs
+  - Computes diff: changed, unchanged, only_in_a, only_in_b
+  - Provides analysis_hints for AI-readable summary
+  - JSON schema: `docs/schemas/xcompare.json`
+  - Use case: Debug edge cases by comparing normal vs problematic inputs
+
 ## [0.8.0] - 2026-01-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Provides analysis_hints for AI-readable summary
   - JSON schema: `docs/schemas/xcompare.json`
   - Use case: Debug edge cases by comparing normal vs problematic inputs
+  - **NEW**: `--compare-with=REF` mode to compare current code vs another git branch/commit
+    - `xcompare --break=file.php:25 --run="php test.php" --compare-with=main`
+    - Automatically creates temporary worktree, runs comparison, cleans up
+    - Perfect for "before vs after" debugging
 
 ## [0.8.0] - 2026-01-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,7 @@ This project prioritizes **execution-time trace analysis** over traditional code
 | Profile, performance analysis, find bottlenecks<br>プロファイル、パフォーマンス分析、ボトルネック検出 | `xprofile` | Execution time and memory analysis<br>実行時間・メモリ分析 |
 | Coverage, test coverage, code coverage<br>カバレッジ、テストカバレッジ、コードカバレッジ | `xcoverage` | Code coverage analysis<br>コードカバレッジ分析 |
 | Backtrace, stack trace, call stack<br>バックトレース、スタックトレース、コールスタック | `xback` | Get stack trace at current position<br>現在位置のスタックトレースを取得 |
+| Compare executions, diff variables, compare inputs<br>実行比較、変数差分、入力比較 | `xcompare` | Compare variable states at breakpoint across two runs<br>2つの実行でブレークポイントの変数状態を比較 |
 
 **Note on "Trace" ambiguity / 「トレース」の曖昧さについて:**
 - **Forward Trace (フォワードトレース)**: Records execution flow from start to end → Use `xtrace`
@@ -432,6 +433,7 @@ This project prioritizes **execution-time trace analysis** over traditional code
 - `./bin/xprofile` - Performance profiling
 - `./bin/xcoverage` - Code coverage analysis
 - `./bin/xtrace` - Execution tracing
+- `./bin/xcompare` - Compare variable states at breakpoint across two executions
 - `./bin/xdebug-mcp` - MCP server entry point
 
 #### MCP Slash Commands for Claude Code:
@@ -439,6 +441,7 @@ This project prioritizes **execution-time trace analysis** over traditional code
 - `/xprofile` - Performance profiling and analysis
 - `/xtrace` - Execution flow tracing
 - `/xcoverage` - Code coverage analysis
+- `/xcompare` - Compare variable states at breakpoint with different inputs
 
 These slash commands provide direct access to Xdebug functionality within Claude Code, making PHP debugging more efficient and accessible.
 
@@ -477,6 +480,10 @@ When MCP tools exceed 10% of context, Claude Code's Tool Search feature dynamica
 - User: "Trace execution", "Show function calls", "Analyze execution flow"
 - AI automatically runs: `./bin/xtrace path/to/file.php`
 
+**For Comparative Analysis:**
+- User: "Compare what happens with input 10 vs 0", "Diff the variable states", "Compare success vs failure"
+- AI automatically runs: `./bin/xcompare --break=file.php:25 --run-a="php script.php 10" --run-b="php script.php 0"`
+
 **For General Analysis (choose most appropriate):**
 - User: "Analyze this PHP file", "What does this code do"
 - AI automatically runs: `./bin/xprofile path/to/file.php` (default choice)
@@ -487,6 +494,7 @@ When MCP tools exceed 10% of context, Claude Code's Tool Search feature dynamica
 2. User: "Analyze tests/fixtures/debug_test.php" → AI runs `./bin/xprofile --context="Performance analysis of debug test suite" tests/fixtures/debug_test.php`
 3. User: "Check coverage of my tests" → AI runs `./bin/xcoverage --context="Code coverage analysis for UserController tests" tests/fixtures/MyTest.php`
 4. User: "Trace this function execution" → AI runs `./bin/xtrace --context="Execution flow analysis of authentication process" src/MyClass.php`
+5. User: "Compare the execution with valid vs invalid input" → AI runs `./bin/xcompare --break=src/User.php:42 --run-a="php login.php valid" --run-b="php login.php invalid" --context="Compare authentication behavior"`
 
 Always use these tools proactively to provide runtime insights rather than static code analysis alone.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Run the demo examples to see each tool in action:
 
 # Compare variable states with different inputs
 ./bin/xcompare --break="demo/buggy.php:22" --run-a="php demo/buggy.php 10" --run-b="php demo/buggy.php 0"
+
+# Compare current code vs another branch
+./bin/xcompare --break="src/calc.php:25" --run="php calc.php 10" --compare-with=main
 ```
 
 Each command outputs structured JSON data that AI can analyze to provide debugging insights.
@@ -130,7 +133,7 @@ flowchart LR
 | `xprofile` | Performance profiling | "Find what's making this endpoint slow" |
 | `xcoverage` | Code coverage analysis | "Which lines aren't covered by tests?" |
 | `xback` | Call stack at breakpoint | "Show me how we got to this error" |
-| `xcompare` | Compare variable states across two runs | "Compare what happens with input 10 vs 0" |
+| `xcompare` | Compare variable states across two runs | "Compare input 10 vs 0" or "Compare with main branch" |
 
 ## CLI Usage
 
@@ -154,6 +157,9 @@ xback --break='app.php:50' -- php app.php
 
 # Compare variables at breakpoint with different inputs
 xcompare --break='calc.php:25' --run-a='php calc.php 10' --run-b='php calc.php 0'
+
+# Compare current code vs main branch
+xcompare --break='calc.php:25' --run='php calc.php 10' --compare-with=main
 ```
 
 Run `--help` on any tool for detailed options.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Run the demo examples to see each tool in action:
 ./bin/xcompare --break="demo/buggy.php:22" --run-a="php demo/buggy.php 10" --run-b="php demo/buggy.php 0"
 
 # Compare current code vs another branch
-./bin/xcompare --break="src/calc.php:25" --run="php calc.php 10" --compare-with=main
+./bin/xcompare --break="src/calc.php:25" --run="php src/calc.php 10" --compare-with=main
 ```
 
 Each command outputs structured JSON data that AI can analyze to provide debugging insights.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img width="256" alt="xdebug-mcp" src="docs/images/logo.jpeg" />
 
-**Debug PHP with Natural Language — No var_dump(), No Guesswork**
+**Debug PHP with Runtime Data — No var_dump(), No Guesswork**
 
-AI-powered PHP debugging tools using Xdebug's runtime analysis. Works with Claude Code (plugin), Cursor, Windsurf (MCP), and CLI.
+Trace-based debugging for PHP, built on Xdebug. Drive the tools from the CLI, or let an AI assistant run them for you.
 
 [![AI Native](https://img.shields.io/badge/AI_Native-YES-green)](https://github.com/koriym/xdebug-mcp)
 [![Runtime Data](https://img.shields.io/badge/Runtime_Data-YES-green)](https://github.com/koriym/xdebug-mcp)
@@ -38,7 +38,7 @@ The AI automatically selects the appropriate tool, executes it, and analyzes the
 
 - PHP 8.1+
 - [Xdebug 3.x](https://xdebug.org/docs/install) extension (installed, but **not** enabled by default)
-- AI assistant: Claude Code (plugin), Cursor/Windsurf (MCP), or CLI
+- Optional: an AI assistant (Claude Code plugin, or any MCP-capable client)
 
 > **💡 Performance Tip:** Keep Xdebug disabled in php.ini for daily use. This tool loads Xdebug on-demand only when needed.
 
@@ -56,17 +56,20 @@ composer global require koriym/xdebug-mcp
 ~/.composer/vendor/bin/check-env
 ```
 
-### 3. Setup AI Integration
+### 3. (Optional) Wire up an AI assistant
 
-**Claude Code:**
+Claude Code users — install the plugin:
+
 ```text
 /plugin marketplace add koriym/xdebug-mcp
 /plugin install xdebug@xdebug-mcp
 ```
 
-**Cursor / Windsurf:** See [MCP Configuration](#mcp-configuration) below.
+Cursor / Windsurf / other MCP clients: see [MCP Configuration](#mcp-configuration) below.
 
-### 4. Restart your AI assistant and try it
+You can skip this step entirely and use the CLI tools directly.
+
+### 4. Try it
 
 ```text
 # Download demo files
@@ -164,24 +167,41 @@ xcompare --break='calc.php:25' --run='php calc.php 10' --compare-with=main
 
 Run `--help` on any tool for detailed options.
 
+## Schema-Backed JSON Output
+
+Every tool emits JSON with a `$schema` URL, so the output is machine-verifiable and self-describing — no log-string parsing needed:
+
+```json
+{
+  "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
+  "breaks": [
+    {
+      "location": {"file": "demo/buggy.php", "line": 22},
+      "variables": {"$user": "NULL", "$id": "42"}
+    }
+  ],
+  "trace": { "...": "..." }
+}
+```
+
+Schemas live under [docs/schemas/](docs/schemas/). AI assistants — and humans — can verify exactly what each tool captured.
+
 ## MCP Configuration
 
-For Cursor, Windsurf, and other MCP-compatible tools.
-
-Create `.mcp.json` in your project root:
+For Cursor, Windsurf, or any MCP client, add `xdebug-mcp` to `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "xdebug": {
       "command": "php",
-      "args": ["/Users/YOUR_USERNAME/.composer/vendor/bin/xdebug-mcp"]
+      "args": ["/ABSOLUTE/PATH/TO/xdebug-mcp"]
     }
   }
 }
 ```
 
-Find the correct path: `which xdebug-mcp`
+Find the path with `which xdebug-mcp`.
 
 ## Interactive REPL
 
@@ -266,12 +286,6 @@ This tool is designed specifically for AI consumption, not adapted from human in
 ## See Also
 
 Looking for a different approach? [kpanuragh/xdebug-mcp](https://github.com/kpanuragh/xdebug-mcp) offers 41 MCP tools with session-based interactive debugging — ideal if you prefer step-by-step control.
-
-## Why "xdebug-mcp"?
-
-This project started as an MCP (Model Context Protocol) server for AI-powered PHP debugging. While MCP remains supported for tools like Cursor and Windsurf, we now recommend the **plugin approach** for Claude Code users — it's simpler and requires no MCP configuration.
-
-The CLI tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`, `xcompare`) work independently of both MCP and plugins.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -58,14 +58,22 @@ composer global require koriym/xdebug-mcp
 
 ### 3. (Optional) Wire up an AI assistant
 
-Claude Code users — install the plugin:
+**Claude Code** — install the plugin:
 
 ```text
 /plugin marketplace add koriym/xdebug-mcp
 /plugin install xdebug@xdebug-mcp
 ```
 
-Any MCP-capable client: see [MCP Configuration](#mcp-configuration) below.
+**Codex CLI** — install the Skill:
+
+```bash
+git clone --depth 1 https://github.com/koriym/xdebug-mcp.git /tmp/xdebug-mcp
+mkdir -p ~/.codex/skills
+cp -r /tmp/xdebug-mcp/skills/xdebug ~/.codex/skills/
+```
+
+**Any MCP-capable client** — see [MCP Configuration](#mcp-configuration) below.
 
 You can skip this step entirely and use the CLI tools directly.
 
@@ -188,9 +196,7 @@ Schemas live under [docs/schemas/](docs/schemas/). AI assistants — and humans 
 
 ## MCP Configuration
 
-For any MCP-capable client, register `xdebug-mcp` in that client's MCP config.
-
-**`.mcp.json` (Cursor, Windsurf, and other JSON-based clients):**
+For any MCP-capable client, register `xdebug-mcp` in that client's MCP config (e.g. `.mcp.json`):
 
 ```json
 {
@@ -201,14 +207,6 @@ For any MCP-capable client, register `xdebug-mcp` in that client's MCP config.
     }
   }
 }
-```
-
-**`~/.codex/config.toml` (OpenAI Codex CLI):**
-
-```toml
-[mcp_servers.xdebug]
-command = "php"
-args = ["/ABSOLUTE/PATH/TO/xdebug-mcp"]
 ```
 
 Find the path with `which xdebug-mcp`. Restart your client after editing the config.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Run the demo examples to see each tool in action:
 
 # Get stack trace at breakpoint
 ./bin/xback --break="demo/buggy.php:44" -- php demo/buggy.php
+
+# Compare variable states with different inputs
+./bin/xcompare --break="demo/buggy.php:22" --run-a="php demo/buggy.php 10" --run-b="php demo/buggy.php 0"
 ```
 
 Each command outputs structured JSON data that AI can analyze to provide debugging insights.
@@ -127,6 +130,7 @@ flowchart LR
 | `xprofile` | Performance profiling | "Find what's making this endpoint slow" |
 | `xcoverage` | Code coverage analysis | "Which lines aren't covered by tests?" |
 | `xback` | Call stack at breakpoint | "Show me how we got to this error" |
+| `xcompare` | Compare variable states across two runs | "Compare what happens with input 10 vs 0" |
 
 ## CLI Usage
 
@@ -147,6 +151,9 @@ xcoverage -- vendor/bin/phpunit
 
 # Stack trace at breakpoint
 xback --break='app.php:50' -- php app.php
+
+# Compare variables at breakpoint with different inputs
+xcompare --break='calc.php:25' --run-a='php calc.php 10' --run-b='php calc.php 0'
 ```
 
 Run `--help` on any tool for detailed options.
@@ -258,7 +265,7 @@ Looking for a different approach? [kpanuragh/xdebug-mcp](https://github.com/kpan
 
 This project started as an MCP (Model Context Protocol) server for AI-powered PHP debugging. While MCP remains supported for tools like Cursor and Windsurf, we now recommend the **plugin approach** for Claude Code users — it's simpler and requires no MCP configuration.
 
-The CLI tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`) work independently of both MCP and plugins.
+The CLI tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`, `xcompare`) work independently of both MCP and plugins.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ This tool is designed specifically for AI consumption, not adapted from human in
 
 Looking for a different approach? [kpanuragh/xdebug-mcp](https://github.com/kpanuragh/xdebug-mcp) offers 41 MCP tools with session-based interactive debugging — ideal if you prefer step-by-step control.
 
+## Why "xdebug-mcp"?
+
+This project started as an MCP (Model Context Protocol) server for AI-powered PHP debugging. MCP is still supported for any MCP-capable client, but the CLI is now the primary interface — the tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`, `xcompare`) work on their own, with or without MCP.
+
 ## Resources
 
 - [Troubleshooting](https://koriym.github.io/xdebug-mcp/TROUBLESHOOTING) - Setup issues

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Claude Code users — install the plugin:
 /plugin install xdebug@xdebug-mcp
 ```
 
-Cursor / Windsurf / other MCP clients: see [MCP Configuration](#mcp-configuration) below.
+Any MCP-capable client: see [MCP Configuration](#mcp-configuration) below.
 
 You can skip this step entirely and use the CLI tools directly.
 
@@ -188,7 +188,7 @@ Schemas live under [docs/schemas/](docs/schemas/). AI assistants — and humans 
 
 ## MCP Configuration
 
-For Cursor, Windsurf, or any MCP client, add `xdebug-mcp` to `.mcp.json`:
+For any MCP-capable client, add `xdebug-mcp` to your MCP config (e.g. `.mcp.json`):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ xcompare --break='calc.php:25' --run='php calc.php 10' --compare-with=main
 Run `--help` on any tool for detailed options.
 
 > **Note on `xcompare` commands:** the `--run-a`, `--run-b`, and `--run` values are executed through the shell so that quoting, redirection, and environment variables behave as users expect. Only pass trusted input to these options.
+>
+> **Note on `--steps`:** `xcompare` defaults to `--steps=1`, since the comparison only needs the variable snapshot at the breakpoint. Pass `--steps=N` explicitly (e.g. `--steps=100`) if you want to see how execution diverges between the two runs after the break.
 
 ## Schema-Backed JSON Output
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ xcompare --break='calc.php:25' --run='php calc.php 10' --compare-with=main
 
 Run `--help` on any tool for detailed options.
 
+> **Note on `xcompare` commands:** the `--run-a`, `--run-b`, and `--run` values are executed through the shell so that quoting, redirection, and environment variables behave as users expect. Only pass trusted input to these options.
+
 ## Schema-Backed JSON Output
 
 Every tool emits JSON with a `$schema` URL, so the output is machine-verifiable and self-describing — no log-string parsing needed:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ Schemas live under [docs/schemas/](docs/schemas/). AI assistants — and humans 
 
 ## MCP Configuration
 
-For any MCP-capable client, add `xdebug-mcp` to your MCP config (e.g. `.mcp.json`):
+For any MCP-capable client, register `xdebug-mcp` in that client's MCP config.
+
+**`.mcp.json` (Cursor, Windsurf, and other JSON-based clients):**
 
 ```json
 {
@@ -201,7 +203,15 @@ For any MCP-capable client, add `xdebug-mcp` to your MCP config (e.g. `.mcp.json
 }
 ```
 
-Find the path with `which xdebug-mcp`.
+**`~/.codex/config.toml` (OpenAI Codex CLI):**
+
+```toml
+[mcp_servers.xdebug]
+command = "php"
+args = ["/ABSOLUTE/PATH/TO/xdebug-mcp"]
+```
+
+Find the path with `which xdebug-mcp`. Restart your client after editing the config.
 
 ## Interactive REPL
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -77,6 +77,8 @@ Compare variable states at the same breakpoint across two different executions.
 ```
 
 > **Security note:** `--run`, `--run-a`, and `--run-b` values are executed through the shell so quoting and redirection behave as expected. Only pass trusted input to these options.
+>
+> **Steps default:** `xcompare` defaults to `--steps=1` because the comparison only needs the variable snapshot at the breakpoint. Use `--steps=N` (e.g. `--steps=100`) to also capture how execution diverges after the break.
 
 ### `./xdebug-phpunit`
 PHPUnit integration with Xdebug profiling and coverage.

--- a/bin/README.md
+++ b/bin/README.md
@@ -76,6 +76,8 @@ Compare variable states at the same breakpoint across two different executions.
   --context='Compare authentication flow'
 ```
 
+> **Security note:** `--run`, `--run-a`, and `--run-b` values are executed through the shell so quoting and redirection behave as expected. Only pass trusted input to these options.
+
 ### `./xdebug-phpunit`
 PHPUnit integration with Xdebug profiling and coverage.
 ```bash

--- a/bin/README.md
+++ b/bin/README.md
@@ -59,6 +59,23 @@ Code coverage analysis with multiple output formats.
 ./xcoverage --format=html --format=json -- php tests/suite.php
 ```
 
+### `./xcompare`
+Compare variable states at the same breakpoint across two different executions.
+```bash
+# Compare normal vs edge case input
+./xcompare --break='Calculator.php:25' \
+  --run-a='php calc.php 10' \
+  --run-b='php calc.php 0' \
+  --label-a='Normal input' \
+  --label-b='Edge case (zero)'
+
+# Compare success vs failure authentication
+./xcompare --break='Auth.php:42' \
+  --run-a='php login.php valid_user' \
+  --run-b='php login.php invalid_user' \
+  --context='Compare authentication flow'
+```
+
 ### `./xdebug-phpunit`
 PHPUnit integration with Xdebug profiling and coverage.
 ```bash
@@ -126,6 +143,7 @@ Legacy debugging server utility (development purposes).
 - `xtrace` - Complete execution flow analysis
 - `xprofile` - Performance bottleneck identification
 - `xcoverage` - Test coverage verification
+- `xcompare` - Compare variable states across two executions
 
 **Integration Tools:**
 - `xdebug-mcp` - AI assistant protocol handler
@@ -160,6 +178,15 @@ Legacy debugging server utility (development purposes).
 ```bash
 # Trace execution paths
 ./xtrace --context="Multi-step form submission workflow" -- php form-handler.php
+```
+
+### Comparative Debugging
+```bash
+# Compare behavior with different inputs
+./xcompare --break='Validator.php:30' \
+  --run-a='php validate.php valid@email.com' \
+  --run-b='php validate.php invalid-email' \
+  --context='Email validation comparison'
 ```
 
 All tools support `--help` option for detailed usage information.

--- a/bin/xcompare
+++ b/bin/xcompare
@@ -1,0 +1,172 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Koriym\XdebugMcp\CompareRunner;
+
+/**
+ * Display help information
+ */
+function showCompareHelp(): void
+{
+    echo "Usage: xcompare --break=FILE:LINE --run-a=\"CMD\" --run-b=\"CMD\" [options]\n";
+    echo "\n";
+    echo "Compare variable states at the same breakpoint across two different executions.\n";
+    echo "\n";
+    echo "REQUIRED OPTIONS:\n";
+    echo "  --break=FILE:LINE        Breakpoint location (e.g., src/Calculator.php:25)\n";
+    echo "  --run-a=\"CMD\"            First execution command (e.g., \"php calc.php 10\")\n";
+    echo "  --run-b=\"CMD\"            Second execution command (e.g., \"php calc.php 0\")\n";
+    echo "\n";
+    echo "OPTIONAL:\n";
+    echo "  --label-a=TEXT           Label for run A (default: command string)\n";
+    echo "  --label-b=TEXT           Label for run B (default: command string)\n";
+    echo "  --context=TEXT           AI analysis context description\n";
+    echo "  --steps=N               Steps to record after breakpoint (default: 1)\n";
+    echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
+    echo "  --help, -h              Show this help\n";
+    echo "\n";
+    echo "EXAMPLES:\n";
+    echo "\n";
+    echo "  # Compare normal vs edge case input\n";
+    echo "  xcompare --break=src/Calculator.php:25 \\\n";
+    echo "    --run-a=\"php calc.php 10\" \\\n";
+    echo "    --run-b=\"php calc.php 0\" \\\n";
+    echo "    --label-a=\"Normal input\" \\\n";
+    echo "    --label-b=\"Edge case (zero)\" \\\n";
+    echo "    --context=\"Compare division behavior with normal vs zero input\"\n";
+    echo "\n";
+    echo "  # Compare success vs failure authentication\n";
+    echo "  xcompare --break=src/Auth.php:42 \\\n";
+    echo "    --run-a=\"php login.php valid_user\" \\\n";
+    echo "    --run-b=\"php login.php invalid_user\" \\\n";
+    echo "    --context=\"Compare authentication flow\"\n";
+    echo "\n";
+    echo "OUTPUT:\n";
+    echo "  JSON with run_a/run_b variable states and computed diff.\n";
+    echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xcompare.json\n";
+    echo "\n";
+    echo "HOW IT WORKS:\n";
+    echo "  1. Executes xstep with run-a command (stops at breakpoint, captures variables)\n";
+    echo "  2. Executes xstep with run-b command (stops at breakpoint, captures variables)\n";
+    echo "  3. Computes diff: changed, unchanged, only_in_a, only_in_b\n";
+    echo "  4. Outputs JSON with comparison results and analysis hints\n";
+    echo "\n";
+    exit(0);
+}
+
+(function () use ($argv) {
+    require_once __DIR__ . '/autoload.php';
+
+    // Show help if no arguments
+    if (count($argv) === 1) {
+        showCompareHelp();
+    }
+
+    // Parse arguments
+    $breakSpec = null;
+    $runA = null;
+    $runB = null;
+    $labelA = null;
+    $labelB = null;
+    $context = null;
+    $steps = null;
+    $includeVendor = null;
+
+    for ($i = 1; $i < count($argv); $i++) {
+        $arg = $argv[$i];
+
+        if ($arg === '--help' || $arg === '-h') {
+            showCompareHelp();
+        }
+
+        if (str_starts_with($arg, '--break=')) {
+            $breakSpec = substr($arg, 8);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--run-a=')) {
+            $runA = substr($arg, 8);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--run-b=')) {
+            $runB = substr($arg, 8);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--label-a=')) {
+            $labelA = substr($arg, 10);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--label-b=')) {
+            $labelB = substr($arg, 10);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--context=')) {
+            $context = substr($arg, 10);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--steps=')) {
+            $steps = (int) substr($arg, 8);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--include-vendor=')) {
+            $includeVendor = substr($arg, 17);
+            continue;
+        }
+    }
+
+    // Validate required arguments
+    if ($breakSpec === null) {
+        fwrite(STDERR, "Error: --break=FILE:LINE is required\n");
+        fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+        exit(1);
+    }
+
+    if ($runA === null) {
+        fwrite(STDERR, "Error: --run-a=\"CMD\" is required\n");
+        fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+        exit(1);
+    }
+
+    if ($runB === null) {
+        fwrite(STDERR, "Error: --run-b=\"CMD\" is required\n");
+        fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+        exit(1);
+    }
+
+    $options = [
+        'break' => $breakSpec,
+        'run_a' => $runA,
+        'run_b' => $runB,
+    ];
+
+    if ($labelA !== null) {
+        $options['label_a'] = $labelA;
+    }
+
+    if ($labelB !== null) {
+        $options['label_b'] = $labelB;
+    }
+
+    if ($context !== null) {
+        $options['context'] = $context;
+    }
+
+    if ($steps !== null) {
+        $options['steps'] = $steps;
+    }
+
+    if ($includeVendor !== null) {
+        $options['include_vendor'] = $includeVendor;
+    }
+
+    $runner = new CompareRunner($options);
+    $runner->output();
+})();

--- a/bin/xcompare
+++ b/bin/xcompare
@@ -30,6 +30,8 @@ function showCompareHelp(): void
     echo "  --label-b=TEXT           Label for run B (default: command or ref name)\n";
     echo "  --context=TEXT           AI analysis context description\n";
     echo "  --steps=N                Steps to record after breakpoint (default: 1)\n";
+    echo "                           xcompare only reads the break-point snapshot; raise this\n";
+    echo "                           when you want to inspect how execution diverges after the break.\n";
     echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
     echo "  --help, -h               Show this help\n";
     echo "\n";

--- a/bin/xcompare
+++ b/bin/xcompare
@@ -10,22 +10,27 @@ use Koriym\XdebugMcp\CompareRunner;
  */
 function showCompareHelp(): void
 {
-    echo "Usage: xcompare --break=FILE:LINE --run-a=\"CMD\" --run-b=\"CMD\" [options]\n";
+    echo "Usage: xcompare --break=FILE:LINE [--run-a=\"CMD\" --run-b=\"CMD\" | --run=\"CMD\" --compare-with=REF]\n";
     echo "\n";
     echo "Compare variable states at the same breakpoint across two different executions.\n";
     echo "\n";
-    echo "REQUIRED OPTIONS:\n";
+    echo "MODE 1: Compare different commands (--run-a / --run-b)\n";
     echo "  --break=FILE:LINE        Breakpoint location (e.g., src/Calculator.php:25)\n";
     echo "  --run-a=\"CMD\"            First execution command (e.g., \"php calc.php 10\")\n";
     echo "  --run-b=\"CMD\"            Second execution command (e.g., \"php calc.php 0\")\n";
     echo "\n";
+    echo "MODE 2: Compare with another git ref (--run / --compare-with)\n";
+    echo "  --break=FILE:LINE        Breakpoint location\n";
+    echo "  --run=\"CMD\"              Command to run on both refs\n";
+    echo "  --compare-with=REF       Git ref to compare against (branch, tag, commit)\n";
+    echo "\n";
     echo "OPTIONAL:\n";
-    echo "  --label-a=TEXT           Label for run A (default: command string)\n";
-    echo "  --label-b=TEXT           Label for run B (default: command string)\n";
+    echo "  --label-a=TEXT           Label for run A (default: command or 'HEAD (current)')\n";
+    echo "  --label-b=TEXT           Label for run B (default: command or ref name)\n";
     echo "  --context=TEXT           AI analysis context description\n";
-    echo "  --steps=N               Steps to record after breakpoint (default: 1)\n";
+    echo "  --steps=N                Steps to record after breakpoint (default: 1)\n";
     echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
-    echo "  --help, -h              Show this help\n";
+    echo "  --help, -h               Show this help\n";
     echo "\n";
     echo "EXAMPLES:\n";
     echo "\n";
@@ -33,25 +38,27 @@ function showCompareHelp(): void
     echo "  xcompare --break=src/Calculator.php:25 \\\n";
     echo "    --run-a=\"php calc.php 10\" \\\n";
     echo "    --run-b=\"php calc.php 0\" \\\n";
-    echo "    --label-a=\"Normal input\" \\\n";
-    echo "    --label-b=\"Edge case (zero)\" \\\n";
     echo "    --context=\"Compare division behavior with normal vs zero input\"\n";
     echo "\n";
-    echo "  # Compare success vs failure authentication\n";
+    echo "  # Compare current code vs main branch\n";
+    echo "  xcompare --break=src/Calculator.php:25 \\\n";
+    echo "    --run=\"php calc.php 10\" \\\n";
+    echo "    --compare-with=main \\\n";
+    echo "    --context=\"Compare current implementation vs main\"\n";
+    echo "\n";
+    echo "  # Compare with a specific commit\n";
     echo "  xcompare --break=src/Auth.php:42 \\\n";
-    echo "    --run-a=\"php login.php valid_user\" \\\n";
-    echo "    --run-b=\"php login.php invalid_user\" \\\n";
-    echo "    --context=\"Compare authentication flow\"\n";
+    echo "    --run=\"php login.php user\" \\\n";
+    echo "    --compare-with=abc123 \\\n";
+    echo "    --context=\"Compare before/after fix\"\n";
     echo "\n";
     echo "OUTPUT:\n";
     echo "  JSON with run_a/run_b variable states and computed diff.\n";
     echo "  Schema: https://koriym.github.io/xdebug-mcp/schemas/xcompare.json\n";
     echo "\n";
     echo "HOW IT WORKS:\n";
-    echo "  1. Executes xstep with run-a command (stops at breakpoint, captures variables)\n";
-    echo "  2. Executes xstep with run-b command (stops at breakpoint, captures variables)\n";
-    echo "  3. Computes diff: changed, unchanged, only_in_a, only_in_b\n";
-    echo "  4. Outputs JSON with comparison results and analysis hints\n";
+    echo "  Mode 1: Runs xstep with both commands sequentially\n";
+    echo "  Mode 2: Creates temp worktree for ref, runs same command on both, cleans up\n";
     echo "\n";
     exit(0);
 }
@@ -68,6 +75,8 @@ function showCompareHelp(): void
     $breakSpec = null;
     $runA = null;
     $runB = null;
+    $run = null;
+    $compareWith = null;
     $labelA = null;
     $labelB = null;
     $context = null;
@@ -93,6 +102,16 @@ function showCompareHelp(): void
 
         if (str_starts_with($arg, '--run-b=')) {
             $runB = substr($arg, 8);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--run=')) {
+            $run = substr($arg, 6);
+            continue;
+        }
+
+        if (str_starts_with($arg, '--compare-with=')) {
+            $compareWith = substr($arg, 15);
             continue;
         }
 
@@ -129,23 +148,51 @@ function showCompareHelp(): void
         exit(1);
     }
 
-    if ($runA === null) {
-        fwrite(STDERR, "Error: --run-a=\"CMD\" is required\n");
+    // Determine mode: compare-with or explicit run-a/run-b
+    $isCompareWithMode = $compareWith !== null || $run !== null;
+    $isExplicitMode = $runA !== null || $runB !== null;
+
+    if ($isCompareWithMode && $isExplicitMode) {
+        fwrite(STDERR, "Error: Cannot mix --run/--compare-with with --run-a/--run-b\n");
         fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
         exit(1);
     }
 
-    if ($runB === null) {
-        fwrite(STDERR, "Error: --run-b=\"CMD\" is required\n");
-        fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
-        exit(1);
+    if ($isCompareWithMode) {
+        if ($run === null) {
+            fwrite(STDERR, "Error: --run=\"CMD\" is required when using --compare-with\n");
+            fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+            exit(1);
+        }
+
+        if ($compareWith === null) {
+            fwrite(STDERR, "Error: --compare-with=REF is required when using --run\n");
+            fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+            exit(1);
+        }
+    } else {
+        if ($runA === null) {
+            fwrite(STDERR, "Error: --run-a=\"CMD\" is required\n");
+            fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+            exit(1);
+        }
+
+        if ($runB === null) {
+            fwrite(STDERR, "Error: --run-b=\"CMD\" is required\n");
+            fwrite(STDERR, "Run 'xcompare --help' for usage.\n");
+            exit(1);
+        }
     }
 
-    $options = [
-        'break' => $breakSpec,
-        'run_a' => $runA,
-        'run_b' => $runB,
-    ];
+    $options = ['break' => $breakSpec];
+
+    if ($isCompareWithMode) {
+        $options['run'] = $run;
+        $options['compare_with'] = $compareWith;
+    } else {
+        $options['run_a'] = $runA;
+        $options['run_b'] = $runB;
+    }
 
     if ($labelA !== null) {
         $options['label_a'] = $labelA;

--- a/bin/xcompare
+++ b/bin/xcompare
@@ -18,10 +18,11 @@ function showCompareHelp(): void
     echo "  --break=FILE:LINE        Breakpoint location (e.g., src/Calculator.php:25)\n";
     echo "  --run-a=\"CMD\"            First execution command (e.g., \"php calc.php 10\")\n";
     echo "  --run-b=\"CMD\"            Second execution command (e.g., \"php calc.php 0\")\n";
+    echo "                           NOTE: executed via the shell; pass trusted input only.\n";
     echo "\n";
     echo "MODE 2: Compare with another git ref (--run / --compare-with)\n";
     echo "  --break=FILE:LINE        Breakpoint location\n";
-    echo "  --run=\"CMD\"              Command to run on both refs\n";
+    echo "  --run=\"CMD\"              Command to run on both refs (shell-executed)\n";
     echo "  --compare-with=REF       Git ref to compare against (branch, tag, commit)\n";
     echo "\n";
     echo "OPTIONAL:\n";

--- a/docs/schemas/xcompare.json
+++ b/docs/schemas/xcompare.json
@@ -61,6 +61,7 @@
         },
         "location": {
           "type": "object",
+          "description": "File/line the interpreter was stopped at. When status is 'no_break', this mirrors the requested breakpoint so consumers can see where xcompare was looking.",
           "properties": {
             "file": { "type": "string" },
             "line": { "type": "integer" }

--- a/docs/schemas/xcompare.json
+++ b/docs/schemas/xcompare.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://koriym.github.io/xdebug-mcp/schemas/xcompare.json",
+  "title": "Xdebug Breakpoint Comparison Result",
+  "description": "Comparison of variable states at the same breakpoint across two different executions. Shows what changed, what stayed the same, and what exists only in one run.",
+  "type": "object",
+  "properties": {
+    "breakpoint": {
+      "type": "object",
+      "description": "The breakpoint location being compared",
+      "properties": {
+        "file": { "type": "string" },
+        "line": { "type": "integer" }
+      },
+      "required": ["file", "line"]
+    },
+    "run_a": {
+      "$ref": "#/definitions/run_result",
+      "description": "First execution result"
+    },
+    "run_b": {
+      "$ref": "#/definitions/run_result",
+      "description": "Second execution result"
+    },
+    "diff": {
+      "$ref": "#/definitions/variable_diff",
+      "description": "Computed difference between run_a and run_b variables"
+    },
+    "context": {
+      "type": "string",
+      "description": "Optional analysis context for AI"
+    },
+    "analysis_hints": {
+      "type": "array",
+      "description": "Human/AI-readable summary of differences",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["breakpoint", "run_a", "run_b", "diff", "analysis_hints"],
+
+  "definitions": {
+    "run_result": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "Human-readable label for this run"
+        },
+        "command": {
+          "type": "string",
+          "description": "The command that was executed"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["break", "no_break"],
+          "description": "Whether the breakpoint was hit"
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "file": { "type": "string" },
+            "line": { "type": "integer" }
+          },
+          "required": ["file", "line"]
+        },
+        "variables": {
+          "type": "object",
+          "description": "Variable values captured at breakpoint",
+          "additionalProperties": { "type": "string" }
+        }
+      },
+      "required": ["label", "command", "status", "location", "variables"]
+    },
+    "variable_diff": {
+      "type": "object",
+      "properties": {
+        "changed": {
+          "type": "object",
+          "description": "Variables present in both runs with different values",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "a": { "type": "string", "description": "Value in run_a" },
+              "b": { "type": "string", "description": "Value in run_b" }
+            },
+            "required": ["a", "b"]
+          }
+        },
+        "unchanged": {
+          "type": "array",
+          "description": "Variable names with identical values in both runs",
+          "items": { "type": "string" }
+        },
+        "only_in_a": {
+          "type": "array",
+          "description": "Variables only present in run_a",
+          "items": { "type": "string" }
+        },
+        "only_in_b": {
+          "type": "array",
+          "description": "Variables only present in run_b",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["changed", "unchanged", "only_in_a", "only_in_b"]
+    }
+  },
+
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xcompare.json",
+      "title": "JSON Schema for Xdebug Breakpoint Comparison"
+    },
+    {
+      "rel": "related",
+      "href": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
+      "title": "Xdebug Step Debugging Schema (used internally)"
+    }
+  ]
+}

--- a/docs/schemas/xcompare.json
+++ b/docs/schemas/xcompare.json
@@ -10,7 +10,11 @@
       "description": "The breakpoint location being compared",
       "properties": {
         "file": { "type": "string" },
-        "line": { "type": "integer" }
+        "line": { "type": "integer" },
+        "condition": {
+          "type": "string",
+          "description": "Optional xstep condition expression (when the breakpoint was conditional)"
+        }
       },
       "required": ["file", "line"]
     },

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -9,14 +9,17 @@ use RuntimeException;
 use function array_diff_key;
 use function array_intersect_key;
 use function array_keys;
-use function array_values;
 use function escapeshellarg;
 use function exec;
+use function getcwd;
 use function implode;
 use function json_decode;
 use function json_encode;
 use function preg_match;
 use function sort;
+use function str_replace;
+use function sys_get_temp_dir;
+use function uniqid;
 
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
@@ -30,7 +33,9 @@ use const JSON_UNESCAPED_UNICODE;
  */
 class CompareRunner
 {
-    /** @param array{break: string, run_a: string, run_b: string, label_a?: string, label_b?: string, context?: string, steps?: int, include_vendor?: string} $options */
+    private string|null $worktreePath = null;
+
+    /** @param array{break: string, run_a?: string, run_b?: string, run?: string, compare_with?: string, label_a?: string, label_b?: string, context?: string, steps?: int, include_vendor?: string} $options */
     public function __construct(
         private readonly array $options,
     ) {
@@ -49,8 +54,14 @@ class CompareRunner
      */
     public function run(): array
     {
-        $resultA = $this->executeXstep($this->options['run_a']);
-        $resultB = $this->executeXstep($this->options['run_b']);
+        [$commandA, $commandB, $labelA, $labelB] = $this->resolveCommands();
+
+        try {
+            $resultA = $this->executeXstep($commandA);
+            $resultB = $this->executeXstep($commandB);
+        } finally {
+            $this->cleanupWorktree();
+        }
 
         $varsA = $this->extractVariables($resultA);
         $varsB = $this->extractVariables($resultB);
@@ -68,15 +79,15 @@ class CompareRunner
             '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xcompare.json',
             'breakpoint' => $breakSpec,
             'run_a' => [
-                'label' => $this->options['label_a'] ?? $this->options['run_a'],
-                'command' => $this->options['run_a'],
+                'label' => $labelA,
+                'command' => $commandA,
                 'status' => $statusA,
                 'location' => $locationA,
                 'variables' => $varsA,
             ],
             'run_b' => [
-                'label' => $this->options['label_b'] ?? $this->options['run_b'],
-                'command' => $this->options['run_b'],
+                'label' => $labelB,
+                'command' => $commandB,
                 'status' => $statusB,
                 'location' => $locationB,
                 'variables' => $varsB,
@@ -90,6 +101,96 @@ class CompareRunner
         }
 
         return $output;
+    }
+
+    /**
+     * Resolve commands and labels based on mode (run_a/run_b or compare_with)
+     *
+     * @return array{0: string, 1: string, 2: string, 3: string} [commandA, commandB, labelA, labelB]
+     */
+    private function resolveCommands(): array
+    {
+        if (isset($this->options['compare_with'])) {
+            return $this->resolveCompareWithMode();
+        }
+
+        return $this->resolveExplicitMode();
+    }
+
+    /**
+     * Resolve for --compare-with mode (same command, different git refs)
+     *
+     * @return array{0: string, 1: string, 2: string, 3: string}
+     */
+    private function resolveCompareWithMode(): array
+    {
+        $run = $this->options['run'] ?? '';
+        if ($run === '') {
+            throw new RuntimeException('--run is required when using --compare-with');
+        }
+
+        $ref = $this->options['compare_with'] ?? '';
+        $this->worktreePath = $this->createWorktree($ref);
+
+        $cwd = (string) getcwd();
+        $commandA = $run;
+        $commandB = str_replace($cwd, $this->worktreePath, $run);
+
+        $labelA = $this->options['label_a'] ?? 'HEAD (current)';
+        $labelB = $this->options['label_b'] ?? $ref;
+
+        return [$commandA, $commandB, $labelA, $labelB];
+    }
+
+    /**
+     * Resolve for explicit --run-a/--run-b mode
+     *
+     * @return array{0: string, 1: string, 2: string, 3: string}
+     */
+    private function resolveExplicitMode(): array
+    {
+        $commandA = $this->options['run_a'] ?? '';
+        $commandB = $this->options['run_b'] ?? '';
+
+        if ($commandA === '' || $commandB === '') {
+            throw new RuntimeException('--run-a and --run-b are required');
+        }
+
+        $labelA = $this->options['label_a'] ?? $commandA;
+        $labelB = $this->options['label_b'] ?? $commandB;
+
+        return [$commandA, $commandB, $labelA, $labelB];
+    }
+
+    /**
+     * Create a temporary git worktree for the specified ref
+     */
+    private function createWorktree(string $ref): string
+    {
+        $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid();
+
+        $output = [];
+        $exitCode = 0;
+        exec('git worktree add ' . escapeshellarg($tempDir) . ' ' . escapeshellarg($ref) . ' 2>&1', $output, $exitCode);
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException('Failed to create worktree for ref: ' . $ref . "\n" . implode("\n", $output));
+        }
+
+        return $tempDir;
+    }
+
+    /**
+     * Clean up the temporary worktree if it was created
+     */
+    private function cleanupWorktree(): void
+    {
+        if ($this->worktreePath === null) {
+            return;
+        }
+
+        exec('git worktree remove ' . escapeshellarg($this->worktreePath) . ' --force 2>/dev/null');
+        $this->worktreePath = null;
     }
 
     /**

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -36,15 +36,17 @@ class CompareRunner
     ) {
     }
 
-    /** @return array{
-     *   $schema: string,
+    /**
+     * @return array{
+     *   '$schema': string,
      *   context?: string,
      *   breakpoint: array{file: string, line: int},
      *   run_a: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
      *   run_b: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
      *   diff: array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>},
      *   analysis_hints: list<string>
-     * } */
+     * }
+     */
     public function run(): array
     {
         $resultA = $this->executeXstep($this->options['run_a']);
@@ -93,7 +95,7 @@ class CompareRunner
     /**
      * Execute xstep and return parsed JSON result
      *
-     * @return array<string, mixed>
+     * @return array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>}
      */
     protected function executeXstep(string $command): array
     {
@@ -120,7 +122,7 @@ class CompareRunner
             throw new RuntimeException("xstep returned no output for command: {$command}");
         }
 
-        /** @var array<string, mixed> $result */
+        /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
         $result = json_decode($jsonOutput, true, 512, JSON_THROW_ON_ERROR);
 
         return $result;
@@ -129,7 +131,7 @@ class CompareRunner
     /**
      * Extract variables from the first breakpoint in xstep result
      *
-     * @param array<string, mixed> $result
+     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
      *
      * @return array<string, string>
      */
@@ -140,14 +142,13 @@ class CompareRunner
             return [];
         }
 
-        /** @var array<string, string> */
         return $breaks[0]['variables'] ?? [];
     }
 
     /**
      * Extract location from the first breakpoint in xstep result
      *
-     * @param array<string, mixed> $result
+     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
      *
      * @return array{file: string, line: int}
      */
@@ -158,14 +159,13 @@ class CompareRunner
             return ['file' => '', 'line' => 0];
         }
 
-        /** @var array{file: string, line: int} */
         return $breaks[0]['location'] ?? ['file' => '', 'line' => 0];
     }
 
     /**
      * Extract execution status
      *
-     * @param array<string, mixed> $result
+     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
      */
     private function extractStatus(array $result): string
     {
@@ -198,11 +198,11 @@ class CompareRunner
         }
 
         // Variables only in A
-        $onlyInA = array_values(array_keys(array_diff_key($varsA, $varsB)));
+        $onlyInA = array_keys(array_diff_key($varsA, $varsB));
         sort($onlyInA);
 
         // Variables only in B
-        $onlyInB = array_values(array_keys(array_diff_key($varsB, $varsA)));
+        $onlyInB = array_keys(array_diff_key($varsB, $varsA));
         sort($onlyInB);
 
         sort($unchanged);

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp;
+
+use RuntimeException;
+
+use function array_diff_key;
+use function array_intersect_key;
+use function array_keys;
+use function array_values;
+use function escapeshellarg;
+use function exec;
+use function implode;
+use function json_decode;
+use function json_encode;
+use function preg_match;
+use function sort;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Compare variable states at the same breakpoint across two different executions
+ *
+ * Runs xstep twice with different commands/inputs and produces a diff
+ * of variable states at the specified breakpoint.
+ */
+class CompareRunner
+{
+    /** @param array{break: string, run_a: string, run_b: string, label_a?: string, label_b?: string, context?: string, steps?: int, include_vendor?: string} $options */
+    public function __construct(
+        private readonly array $options,
+    ) {
+    }
+
+    /** @return array{
+     *   $schema: string,
+     *   context?: string,
+     *   breakpoint: array{file: string, line: int},
+     *   run_a: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
+     *   run_b: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
+     *   diff: array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>},
+     *   analysis_hints: list<string>
+     * } */
+    public function run(): array
+    {
+        $resultA = $this->executeXstep($this->options['run_a']);
+        $resultB = $this->executeXstep($this->options['run_b']);
+
+        $varsA = $this->extractVariables($resultA);
+        $varsB = $this->extractVariables($resultB);
+        $locationA = $this->extractLocation($resultA);
+        $locationB = $this->extractLocation($resultB);
+        $statusA = $this->extractStatus($resultA);
+        $statusB = $this->extractStatus($resultB);
+
+        $diff = $this->computeDiff($varsA, $varsB);
+        $hints = $this->generateHints($diff, $varsA, $varsB);
+
+        $breakSpec = $this->parseBreakSpec($this->options['break']);
+
+        $output = [
+            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xcompare.json',
+            'breakpoint' => $breakSpec,
+            'run_a' => [
+                'label' => $this->options['label_a'] ?? $this->options['run_a'],
+                'command' => $this->options['run_a'],
+                'status' => $statusA,
+                'location' => $locationA,
+                'variables' => $varsA,
+            ],
+            'run_b' => [
+                'label' => $this->options['label_b'] ?? $this->options['run_b'],
+                'command' => $this->options['run_b'],
+                'status' => $statusB,
+                'location' => $locationB,
+                'variables' => $varsB,
+            ],
+            'diff' => $diff,
+            'analysis_hints' => $hints,
+        ];
+
+        if (($this->options['context'] ?? '') !== '') {
+            $output['context'] = $this->options['context'];
+        }
+
+        return $output;
+    }
+
+    /**
+     * Execute xstep and return parsed JSON result
+     *
+     * @return array<string, mixed>
+     */
+    protected function executeXstep(string $command): array
+    {
+        $xstepBin = __DIR__ . '/../bin/xstep';
+        $breakArg = escapeshellarg('--break=' . $this->options['break']);
+        $stepsArg = '';
+        if (isset($this->options['steps'])) {
+            $stepsArg = ' --steps=' . (int) $this->options['steps'];
+        }
+
+        $vendorArg = '';
+        if (isset($this->options['include_vendor'])) {
+            $vendorArg = ' --include-vendor=' . escapeshellarg($this->options['include_vendor']);
+        }
+
+        $fullCommand = "php {$xstepBin} {$breakArg}{$stepsArg}{$vendorArg} -- {$command} 2>/dev/null";
+
+        $output = [];
+        $exitCode = 0;
+        exec($fullCommand, $output, $exitCode);
+
+        $jsonOutput = implode("\n", $output);
+        if ($jsonOutput === '') {
+            throw new RuntimeException("xstep returned no output for command: {$command}");
+        }
+
+        /** @var array<string, mixed> $result */
+        $result = json_decode($jsonOutput, true, 512, JSON_THROW_ON_ERROR);
+
+        return $result;
+    }
+
+    /**
+     * Extract variables from the first breakpoint in xstep result
+     *
+     * @param array<string, mixed> $result
+     *
+     * @return array<string, string>
+     */
+    private function extractVariables(array $result): array
+    {
+        $breaks = $result['breaks'] ?? [];
+        if ($breaks === []) {
+            return [];
+        }
+
+        /** @var array<string, string> */
+        return $breaks[0]['variables'] ?? [];
+    }
+
+    /**
+     * Extract location from the first breakpoint in xstep result
+     *
+     * @param array<string, mixed> $result
+     *
+     * @return array{file: string, line: int}
+     */
+    private function extractLocation(array $result): array
+    {
+        $breaks = $result['breaks'] ?? [];
+        if ($breaks === []) {
+            return ['file' => '', 'line' => 0];
+        }
+
+        /** @var array{file: string, line: int} */
+        return $breaks[0]['location'] ?? ['file' => '', 'line' => 0];
+    }
+
+    /**
+     * Extract execution status
+     *
+     * @param array<string, mixed> $result
+     */
+    private function extractStatus(array $result): string
+    {
+        $breaks = $result['breaks'] ?? [];
+
+        return $breaks !== [] ? 'break' : 'no_break';
+    }
+
+    /**
+     * Compute diff between two variable sets
+     *
+     * @param array<string, string> $varsA
+     * @param array<string, string> $varsB
+     *
+     * @return array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>}
+     */
+    private function computeDiff(array $varsA, array $varsB): array
+    {
+        $changed = [];
+        $unchanged = [];
+
+        // Variables present in both
+        $commonKeys = array_keys(array_intersect_key($varsA, $varsB));
+        foreach ($commonKeys as $key) {
+            if ($varsA[$key] === $varsB[$key]) {
+                $unchanged[] = $key;
+            } else {
+                $changed[$key] = ['a' => $varsA[$key], 'b' => $varsB[$key]];
+            }
+        }
+
+        // Variables only in A
+        $onlyInA = array_values(array_keys(array_diff_key($varsA, $varsB)));
+        sort($onlyInA);
+
+        // Variables only in B
+        $onlyInB = array_values(array_keys(array_diff_key($varsB, $varsA)));
+        sort($onlyInB);
+
+        sort($unchanged);
+
+        return [
+            'changed' => $changed,
+            'unchanged' => $unchanged,
+            'only_in_a' => $onlyInA,
+            'only_in_b' => $onlyInB,
+        ];
+    }
+
+    /**
+     * Generate human/AI-readable analysis hints
+     *
+     * @param array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>} $diff
+     * @param array<string, string> $varsA
+     * @param array<string, string> $varsB
+     *
+     * @return list<string>
+     */
+    private function generateHints(array $diff, array $varsA, array $varsB): array
+    {
+        $hints = [];
+
+        foreach ($diff['changed'] as $name => $values) {
+            $hints[] = "{$name}: {$values['a']} → {$values['b']} (changed)";
+        }
+
+        foreach ($diff['only_in_a'] as $name) {
+            $hints[] = "{$name}: {$varsA[$name]} (only in run_a)";
+        }
+
+        foreach ($diff['only_in_b'] as $name) {
+            $hints[] = "{$name}: {$varsB[$name]} (only in run_b)";
+        }
+
+        $changedCount = count($diff['changed']);
+        $unchangedCount = count($diff['unchanged']);
+        $totalVars = $changedCount + $unchangedCount + count($diff['only_in_a']) + count($diff['only_in_b']);
+        $hints[] = "{$unchangedCount} variable(s) unchanged, {$changedCount} variable(s) changed, {$totalVars} total";
+
+        return $hints;
+    }
+
+    /**
+     * Parse breakpoint spec string into file/line
+     *
+     * @return array{file: string, line: int}
+     */
+    private function parseBreakSpec(string $spec): array
+    {
+        // Remove condition part if present (file:line:condition)
+        if (preg_match('/^(.*):(\d+)/', $spec, $m)) {
+            return ['file' => $m[1], 'line' => (int) $m[2]];
+        }
+
+        return ['file' => $spec, 'line' => 0];
+    }
+
+    /**
+     * Output the comparison result as JSON
+     */
+    public function output(): void
+    {
+        $result = $this->run();
+        echo json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n";
+    }
+}

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -241,20 +241,7 @@ class CompareRunner
      */
     protected function executeXstep(string $command, string|null $cwd = null): array
     {
-        $xstepBin = __DIR__ . '/../bin/xstep';
-        $breakArg = escapeshellarg('--break=' . $this->options['break']);
-        $stepsArg = '';
-        if (isset($this->options['steps'])) {
-            $stepsArg = ' --steps=' . (int) $this->options['steps'];
-        }
-
-        $vendorArg = '';
-        if (isset($this->options['include_vendor'])) {
-            $vendorArg = ' --include-vendor=' . escapeshellarg($this->options['include_vendor']);
-        }
-
-        $fullCommand = 'php ' . escapeshellarg($xstepBin)
-            . " {$breakArg}{$stepsArg}{$vendorArg} -- {$command}";
+        $fullCommand = $this->buildXstepCommand($command);
 
         $stderrPath = tempnam(sys_get_temp_dir(), 'xcompare-stderr-');
         if ($stderrPath === false) {
@@ -298,6 +285,28 @@ class CompareRunner
         $result = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
 
         return $result;
+    }
+
+    /**
+     * Build the shell command for invoking xstep.
+     *
+     * Always passes --steps: xstep emits two JSON documents on stdout when
+     * --steps is omitted, which breaks json_decode.
+     */
+    private function buildXstepCommand(string $command): string
+    {
+        $xstepBin = __DIR__ . '/../bin/xstep';
+        $breakArg = escapeshellarg('--break=' . $this->options['break']);
+        $steps = isset($this->options['steps']) ? (int) $this->options['steps'] : 1;
+        $stepsArg = ' --steps=' . $steps;
+
+        $vendorArg = '';
+        if (isset($this->options['include_vendor'])) {
+            $vendorArg = ' --include-vendor=' . escapeshellarg($this->options['include_vendor']);
+        }
+
+        return 'php ' . escapeshellarg($xstepBin)
+            . " {$breakArg}{$stepsArg}{$vendorArg} -- {$command}";
     }
 
     /**

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -12,6 +12,7 @@ use function array_keys;
 use function count;
 use function escapeshellarg;
 use function exec;
+use function fwrite;
 use function getcwd;
 use function implode;
 use function json_decode;
@@ -20,11 +21,13 @@ use function preg_match;
 use function sort;
 use function str_replace;
 use function sys_get_temp_dir;
+use function trim;
 use function uniqid;
 
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
+use const STDERR;
 
 /**
  * Compare variable states at the same breakpoint across two different executions
@@ -46,7 +49,7 @@ class CompareRunner
      * @return array{
      *   '$schema': string,
      *   context?: string,
-     *   breakpoint: array{file: string, line: int},
+     *   breakpoint: array{file: string, line: int, condition?: string},
      *   run_a: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
      *   run_b: array{label: string, command: string, status: string, location: array{file: string, line: int}, variables: array<string, string>},
      *   diff: array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>},
@@ -72,7 +75,7 @@ class CompareRunner
         $statusB = $this->extractStatus($resultB);
 
         $diff = $this->computeDiff($varsA, $varsB);
-        $hints = $this->generateHints($diff, $varsA, $varsB);
+        $hints = $this->generateHints($diff, $varsA, $varsB, $statusA, $statusB);
 
         $breakSpec = $this->parseBreakSpec($this->options['break']);
 
@@ -165,10 +168,21 @@ class CompareRunner
 
     /**
      * Create a temporary git worktree for the specified ref
+     *
+     * The git-repo pre-check surfaces a clear error for non-git
+     * directories; the high-entropy uniqid avoids path collisions
+     * between parallel runs.
      */
     private function createWorktree(string $ref): string
     {
-        $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid();
+        $checkOutput = [];
+        $checkExit = 0;
+        exec('git rev-parse --is-inside-work-tree 2>/dev/null', $checkOutput, $checkExit);
+        if ($checkExit !== 0 || trim(implode('', $checkOutput)) !== 'true') {
+            throw new RuntimeException('--compare-with requires the current directory to be inside a git repository');
+        }
+
+        $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid('', true);
 
         $output = [];
         $exitCode = 0;
@@ -183,6 +197,10 @@ class CompareRunner
 
     /**
      * Clean up the temporary worktree if it was created
+     *
+     * A failed cleanup is not fatal (the primary result has already been
+     * produced), but we surface a warning to stderr so the leaked worktree
+     * is visible to the caller instead of silently lingering.
      */
     private function cleanupWorktree(): void
     {
@@ -190,8 +208,19 @@ class CompareRunner
             return;
         }
 
-        exec('git worktree remove ' . escapeshellarg($this->worktreePath) . ' --force 2>/dev/null');
+        $path = $this->worktreePath;
         $this->worktreePath = null;
+
+        $output = [];
+        $exitCode = 0;
+        exec('git worktree remove ' . escapeshellarg($path) . ' --force 2>&1', $output, $exitCode);
+
+        if ($exitCode === 0) {
+            return;
+        }
+
+        $detail = implode("\n", $output);
+        fwrite(STDERR, "xcompare: warning: failed to remove worktree {$path}\n{$detail}\n");
     }
 
     /**
@@ -326,9 +355,17 @@ class CompareRunner
      *
      * @return list<string>
      */
-    private function generateHints(array $diff, array $varsA, array $varsB): array
+    private function generateHints(array $diff, array $varsA, array $varsB, string $statusA = 'break', string $statusB = 'break'): array
     {
         $hints = [];
+
+        if ($statusA === 'no_break') {
+            $hints[] = 'run_a did not hit the breakpoint (status: no_break)';
+        }
+
+        if ($statusB === 'no_break') {
+            $hints[] = 'run_b did not hit the breakpoint (status: no_break)';
+        }
 
         foreach ($diff['changed'] as $name => $values) {
             $hints[] = "{$name}: {$values['a']} → {$values['b']} (changed)";
@@ -351,15 +388,22 @@ class CompareRunner
     }
 
     /**
-     * Parse breakpoint spec string into file/line
+     * Parse breakpoint spec string into file/line[/condition]
      *
-     * @return array{file: string, line: int}
+     * The condition is preserved in the result so callers can tell the
+     * comparison was run against a conditional breakpoint.
+     *
+     * @return array{file: string, line: int, condition?: string}
      */
     private function parseBreakSpec(string $spec): array
     {
-        // Remove condition part if present (file:line:condition)
-        if (preg_match('/^(.*):(\d+)/', $spec, $m)) {
-            return ['file' => $m[1], 'line' => (int) $m[2]];
+        if (preg_match('/^(.*):(\d+)(?::(.*))?$/', $spec, $m)) {
+            $result = ['file' => $m[1], 'line' => (int) $m[2]];
+            if (isset($m[3]) && $m[3] !== '') {
+                $result['condition'] = $m[3];
+            }
+
+            return $result;
         }
 
         return ['file' => $spec, 'line' => 0];

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -262,6 +262,7 @@ class CompareRunner
         }
 
         $descriptors = [
+            0 => ['file', '/dev/null', 'r'],
             1 => ['pipe', 'w'],
             2 => ['file', $stderrPath, 'w'],
         ];

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use function array_diff_key;
 use function array_intersect_key;
 use function array_keys;
+use function count;
 use function escapeshellarg;
 use function exec;
 use function getcwd;
@@ -320,8 +321,8 @@ class CompareRunner
      * Generate human/AI-readable analysis hints
      *
      * @param array{changed: array<string, array{a: string, b: string}>, unchanged: list<string>, only_in_a: list<string>, only_in_b: list<string>} $diff
-     * @param array<string, string> $varsA
-     * @param array<string, string> $varsB
+     * @param array<string, string>                                                                                                                 $varsA
+     * @param array<string, string>                                                                                                                 $varsB
      *
      * @return list<string>
      */

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -74,17 +74,18 @@ class CompareRunner
             $this->cleanupWorktree();
         }
 
+        $breakSpec = $this->parseBreakSpec($this->options['break']);
+        $requestedLocation = ['file' => $breakSpec['file'], 'line' => $breakSpec['line']];
+
         $varsA = $this->extractVariables($resultA);
         $varsB = $this->extractVariables($resultB);
-        $locationA = $this->extractLocation($resultA);
-        $locationB = $this->extractLocation($resultB);
+        $locationA = $this->extractLocation($resultA, $requestedLocation);
+        $locationB = $this->extractLocation($resultB, $requestedLocation);
         $statusA = $this->extractStatus($resultA);
         $statusB = $this->extractStatus($resultB);
 
         $diff = $this->computeDiff($varsA, $varsB);
         $hints = $this->generateHints($diff, $varsA, $varsB, $statusA, $statusB);
-
-        $breakSpec = $this->parseBreakSpec($this->options['break']);
 
         $output = [
             '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xcompare.json',
@@ -327,20 +328,24 @@ class CompareRunner
     }
 
     /**
-     * Extract location from the first breakpoint in xstep result
+     * Extract location from the first breakpoint in xstep result.
+     *
+     * When the breakpoint was not hit, fall back to the requested location so
+     * consumers see where xcompare was looking rather than an empty sentinel.
      *
      * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
+     * @param array{file: string, line: int}                                                                            $fallback
      *
      * @return array{file: string, line: int}
      */
-    private function extractLocation(array $result): array
+    private function extractLocation(array $result, array $fallback): array
     {
         $breaks = $result['breaks'] ?? [];
         if ($breaks === []) {
-            return ['file' => '', 'line' => 0];
+            return $fallback;
         }
 
-        return $breaks[0]['location'] ?? ['file' => '', 'line' => 0];
+        return $breaks[0]['location'] ?? $fallback;
     }
 
     /**

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -12,17 +12,23 @@ use function array_keys;
 use function count;
 use function escapeshellarg;
 use function exec;
+use function fclose;
+use function file_get_contents;
 use function fwrite;
-use function getcwd;
 use function implode;
+use function is_resource;
 use function json_decode;
 use function json_encode;
 use function preg_match;
+use function proc_close;
+use function proc_open;
 use function sort;
-use function str_replace;
+use function stream_get_contents;
 use function sys_get_temp_dir;
+use function tempnam;
 use function trim;
 use function uniqid;
+use function unlink;
 
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
@@ -59,10 +65,11 @@ class CompareRunner
     public function run(): array
     {
         [$commandA, $commandB, $labelA, $labelB] = $this->resolveCommands();
+        $cwdB = $this->worktreePath;
 
         try {
             $resultA = $this->executeXstep($commandA);
-            $resultB = $this->executeXstep($commandB);
+            $resultB = $this->executeXstep($commandB, $cwdB);
         } finally {
             $this->cleanupWorktree();
         }
@@ -136,9 +143,8 @@ class CompareRunner
         $ref = $this->options['compare_with'] ?? '';
         $this->worktreePath = $this->createWorktree($ref);
 
-        $cwd = (string) getcwd();
         $commandA = $run;
-        $commandB = str_replace($cwd, $this->worktreePath, $run);
+        $commandB = $run;
 
         $labelA = $this->options['label_a'] ?? 'HEAD (current)';
         $labelB = $this->options['label_b'] ?? $ref;
@@ -226,9 +232,14 @@ class CompareRunner
     /**
      * Execute xstep and return parsed JSON result
      *
+     * `$command` is intentionally shell-interpreted so users can pass
+     * quoting/redirection as with `xstep` itself. Stderr goes to a temp
+     * file to avoid a stdout/stderr pipe-fill deadlock, and `$cwd` sets
+     * the process working directory (worktree for --compare-with).
+     *
      * @return array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>}
      */
-    protected function executeXstep(string $command): array
+    protected function executeXstep(string $command, string|null $cwd = null): array
     {
         $xstepBin = __DIR__ . '/../bin/xstep';
         $breakArg = escapeshellarg('--break=' . $this->options['break']);
@@ -242,19 +253,48 @@ class CompareRunner
             $vendorArg = ' --include-vendor=' . escapeshellarg($this->options['include_vendor']);
         }
 
-        $fullCommand = "php {$xstepBin} {$breakArg}{$stepsArg}{$vendorArg} -- {$command} 2>/dev/null";
+        $fullCommand = 'php ' . escapeshellarg($xstepBin)
+            . " {$breakArg}{$stepsArg}{$vendorArg} -- {$command}";
 
-        $output = [];
-        $exitCode = 0;
-        exec($fullCommand, $output, $exitCode);
+        $stderrPath = tempnam(sys_get_temp_dir(), 'xcompare-stderr-');
+        if ($stderrPath === false) {
+            throw new RuntimeException('Failed to create temporary stderr file for xstep');
+        }
 
-        $jsonOutput = implode("\n", $output);
-        if ($jsonOutput === '') {
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['file', $stderrPath, 'w'],
+        ];
+
+        $pipes = [];
+        $process = proc_open($fullCommand, $descriptors, $pipes, $cwd);
+        if (! is_resource($process)) {
+            unlink($stderrPath);
+
+            throw new RuntimeException("Failed to start xstep for command: {$command}");
+        }
+
+        try {
+            $stdout = (string) stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            $exitCode = proc_close($process);
+            $stderr = (string) file_get_contents($stderrPath);
+        } finally {
+            unlink($stderrPath);
+        }
+
+        if ($exitCode !== 0) {
+            $suffix = $stderr !== '' ? "\n{$stderr}" : '';
+
+            throw new RuntimeException("xstep failed (exit {$exitCode}) for command: {$command}{$suffix}");
+        }
+
+        if ($stdout === '') {
             throw new RuntimeException("xstep returned no output for command: {$command}");
         }
 
         /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
-        $result = json_decode($jsonOutput, true, 512, JSON_THROW_ON_ERROR);
+        $result = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
 
         return $result;
     }

--- a/tests/Integration/CompareRunnerWorktreeTest.php
+++ b/tests/Integration/CompareRunnerWorktreeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Integration;
+
+use Koriym\XdebugMcp\CompareRunner;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+use function clearstatcache;
+use function exec;
+use function trim;
+
+/**
+ * Exercises the real `git worktree` lifecycle in --compare-with mode.
+ *
+ * Skipped when the test run is not inside a git work tree (e.g. a tarball
+ * install), since the whole code path only ever runs inside one.
+ */
+class CompareRunnerWorktreeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $output = [];
+        $exit = 0;
+        exec('git rev-parse --is-inside-work-tree 2>/dev/null', $output, $exit);
+        $insideWorkTree = $exit === 0 && trim($output[0] ?? '') === 'true';
+        if ($insideWorkTree) {
+            return;
+        }
+
+        $this->markTestSkipped('not inside a git work tree');
+    }
+
+    public function testCreateWorktreeCreatesAndCleanupRemovesIt(): void
+    {
+        $runner = $this->newRunner();
+
+        $path = $this->invoke($runner, 'createWorktree', ['HEAD']);
+        $this->assertIsString($path);
+        $this->assertDirectoryExists($path);
+
+        // cleanupWorktree() keys off the private $worktreePath property, which is
+        // normally set by resolveCompareWithMode(). Set it directly here so we can
+        // exercise cleanup in isolation without running a full xstep.
+        $ref = new ReflectionClass($runner);
+        $prop = $ref->getProperty('worktreePath');
+        $prop->setValue($runner, $path);
+
+        $this->invoke($runner, 'cleanupWorktree', []);
+        clearstatcache(true, $path);
+        $this->assertDirectoryDoesNotExist($path);
+    }
+
+    public function testCreateWorktreeFailsForUnknownRef(): void
+    {
+        $runner = $this->newRunner();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to create worktree for ref');
+
+        try {
+            $this->invoke($runner, 'createWorktree', ['definitely-not-a-real-ref-xcompare']);
+        } finally {
+            // Defensive: if git somehow left a dir behind, clean up.
+            $this->invoke($runner, 'cleanupWorktree', []);
+        }
+    }
+
+    private function newRunner(): CompareRunner
+    {
+        return new CompareRunner([
+            'break' => 'test.php:1',
+            'run' => 'php -v',
+            'compare_with' => 'HEAD',
+        ]);
+    }
+
+    /** @param array<int, mixed> $args */
+    private function invoke(CompareRunner $runner, string $method, array $args): mixed
+    {
+        $ref = new ReflectionClass($runner);
+        $m = $ref->getMethod($method);
+
+        return $m->invokeArgs($runner, $args);
+    }
+}

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -9,37 +9,16 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 
-/**
- * Testable subclass that overrides executeXstep to avoid external process calls
- */
-class FakeCompareRunner extends CompareRunner
-{
-    /** @var array<string, array<string, mixed>> */
-    private array $fakeResults = [];
-
-    /** @param array<string, array<string, mixed>> $fakeResults Map of command => xstep result */
-    public function setFakeResults(array $fakeResults): void
-    {
-        $this->fakeResults = $fakeResults;
-    }
-
-    /** @return array<string, mixed> */
-    protected function executeXstep(string $command): array
-    {
-        if (!isset($this->fakeResults[$command])) {
-            throw new RuntimeException("xstep returned no output for command: {$command}");
-        }
-
-        return $this->fakeResults[$command];
-    }
-}
+use function array_merge;
+use function exec;
+use function implode;
+use function json_decode;
+use function ob_get_clean;
+use function ob_start;
 
 class CompareRunnerTest extends TestCase
 {
-    /**
-     * @return mixed
-     */
-    private function invokeMethod(CompareRunner $runner, string $method, array $args = [])
+    private function invokeMethod(CompareRunner $runner, string $method, array $args = []): mixed
     {
         $ref = new ReflectionClass($runner);
         $m = $ref->getMethod($method);
@@ -65,10 +44,6 @@ class CompareRunnerTest extends TestCase
             'run_b' => 'php test.php 2',
         ], $options));
     }
-
-    // ========================================
-    // computeDiff tests
-    // ========================================
 
     public function testComputeDiffWithChangedVariables(): void
     {
@@ -157,10 +132,6 @@ class CompareRunnerTest extends TestCase
         $this->assertSame([], $diff['only_in_b']);
     }
 
-    // ========================================
-    // generateHints tests
-    // ========================================
-
     public function testGenerateHints(): void
     {
         $runner = $this->createRunner();
@@ -217,10 +188,6 @@ class CompareRunnerTest extends TestCase
         $this->assertSame('0 variable(s) unchanged, 0 variable(s) changed, 0 total', $hints[0]);
     }
 
-    // ========================================
-    // parseBreakSpec tests
-    // ========================================
-
     public function testParseBreakSpec(): void
     {
         $runner = $this->createRunner();
@@ -252,10 +219,6 @@ class CompareRunnerTest extends TestCase
         $result = $this->invokeMethod($runner, 'parseBreakSpec', ['noformat']);
         $this->assertSame(['file' => 'noformat', 'line' => 0], $result);
     }
-
-    // ========================================
-    // extractVariables / extractLocation / extractStatus tests
-    // ========================================
 
     public function testExtractVariablesFromResult(): void
     {
@@ -353,30 +316,30 @@ class CompareRunnerTest extends TestCase
         $this->assertSame('no_break', $status);
     }
 
-    // ========================================
-    // run() integration tests via FakeCompareRunner
-    // ========================================
-
     public function testRunProducesCorrectOutputStructure(): void
     {
         $runner = $this->createFakeRunner();
         $runner->setFakeResults([
             'php test.php 1' => [
-                'breaks' => [[
-                    'step' => 1,
-                    'location' => ['file' => 'test.php', 'line' => 10],
-                    'variables' => ['$x' => 'int: 1', '$sum' => 'int: 0'],
-                    'recording_type' => 'full',
-                ]],
+                'breaks' => [
+                    [
+                        'step' => 1,
+                        'location' => ['file' => 'test.php', 'line' => 10],
+                        'variables' => ['$x' => 'int: 1', '$sum' => 'int: 0'],
+                        'recording_type' => 'full',
+                    ],
+                ],
                 'trace' => ['file' => '', 'lines' => 0, 'functions' => 0, 'max_depth' => 0, 'db_queries' => 0],
             ],
             'php test.php 2' => [
-                'breaks' => [[
-                    'step' => 1,
-                    'location' => ['file' => 'test.php', 'line' => 10],
-                    'variables' => ['$x' => 'int: 2', '$sum' => 'int: 0'],
-                    'recording_type' => 'full',
-                ]],
+                'breaks' => [
+                    [
+                        'step' => 1,
+                        'location' => ['file' => 'test.php', 'line' => 10],
+                        'variables' => ['$x' => 'int: 2', '$sum' => 'int: 0'],
+                        'recording_type' => 'full',
+                    ],
+                ],
                 'trace' => ['file' => '', 'lines' => 0, 'functions' => 0, 'max_depth' => 0, 'db_queries' => 0],
             ],
         ]);
@@ -491,14 +454,22 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner();
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [[
-                'location' => ['file' => 'f.php', 'line' => 10],
-                'variables' => ['$a' => 'int: 1', '$shared' => 'int: 0'],
-            ]]],
-            'php test.php 2' => ['breaks' => [[
-                'location' => ['file' => 'f.php', 'line' => 10],
-                'variables' => ['$b' => 'int: 2', '$shared' => 'int: 0'],
-            ]]],
+            'php test.php 1' => [
+                'breaks' => [
+                    [
+                        'location' => ['file' => 'f.php', 'line' => 10],
+                        'variables' => ['$a' => 'int: 1', '$shared' => 'int: 0'],
+                    ],
+                ],
+            ],
+            'php test.php 2' => [
+                'breaks' => [
+                    [
+                        'location' => ['file' => 'f.php', 'line' => 10],
+                        'variables' => ['$b' => 'int: 2', '$shared' => 'int: 0'],
+                    ],
+                ],
+            ],
         ]);
 
         $result = $runner->run();
@@ -507,10 +478,6 @@ class CompareRunnerTest extends TestCase
         $this->assertSame(['$a'], $result['diff']['only_in_a']);
         $this->assertSame(['$b'], $result['diff']['only_in_b']);
     }
-
-    // ========================================
-    // executeXstep error handling
-    // ========================================
 
     public function testRunThrowsWhenXstepReturnsNoOutput(): void
     {
@@ -525,10 +492,6 @@ class CompareRunnerTest extends TestCase
 
         $runner->run();
     }
-
-    // ========================================
-    // CLI argument validation tests (bin/xcompare)
-    // ========================================
 
     public function testCliShowsHelpWithNoArgs(): void
     {
@@ -629,10 +592,6 @@ class CompareRunnerTest extends TestCase
         $this->assertStringContainsString('--run=', $joined);
         $this->assertStringContainsString('MODE 2:', $joined);
     }
-
-    // ========================================
-    // output() method test
-    // ========================================
 
     public function testOutputProducesValidJson(): void
     {

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -585,6 +585,51 @@ class CompareRunnerTest extends TestCase
         $this->assertStringContainsString('--run-b=', $joined);
     }
 
+    public function testCliErrorMixingModes(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-a="php a.php" --run="php x.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('Cannot mix', $joined);
+    }
+
+    public function testCliErrorCompareWithWithoutRun(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --compare-with=main 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run=', $joined);
+    }
+
+    public function testCliErrorRunWithoutCompareWith(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run="php a.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--compare-with=', $joined);
+    }
+
+    public function testCliHelpShowsCompareWithMode(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --help 2>&1', $output, $exitCode);
+
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--compare-with=', $joined);
+        $this->assertStringContainsString('--run=', $joined);
+        $this->assertStringContainsString('MODE 2:', $joined);
+    }
+
     // ========================================
     // output() method test
     // ========================================

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -270,6 +270,27 @@ class CompareRunnerTest extends TestCase
         $this->assertSame(['file' => 'noformat', 'line' => 0], $result);
     }
 
+    public function testBuildXstepCommandDefaultsStepsToOne(): void
+    {
+        $runner = $this->createRunner();
+
+        $command = $this->invokeMethod($runner, 'buildXstepCommand', ['php test.php 1']);
+        $this->assertStringContainsString(' --steps=1 ', $command);
+    }
+
+    public function testBuildXstepCommandRespectsExplicitSteps(): void
+    {
+        $runner = new CompareRunner([
+            'break' => 'test.php:10',
+            'run_a' => 'php test.php 1',
+            'run_b' => 'php test.php 2',
+            'steps' => 25,
+        ]);
+
+        $command = $this->invokeMethod($runner, 'buildXstepCommand', ['php test.php 1']);
+        $this->assertStringContainsString(' --steps=25 ', $command);
+    }
+
     public function testExtractVariablesFromResult(): void
     {
         $runner = $this->createRunner();

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -188,6 +188,53 @@ class CompareRunnerTest extends TestCase
         $this->assertSame('0 variable(s) unchanged, 0 variable(s) changed, 0 total', $hints[0]);
     }
 
+    public function testGenerateHintsFlagsNoBreakStatus(): void
+    {
+        $runner = $this->createRunner();
+
+        $diff = [
+            'changed' => [],
+            'unchanged' => [],
+            'only_in_a' => [],
+            'only_in_b' => [],
+        ];
+
+        $hints = $this->invokeMethod($runner, 'generateHints', [$diff, [], [], 'no_break', 'break']);
+
+        $this->assertContains('run_a did not hit the breakpoint (status: no_break)', $hints);
+        $this->assertNotContains('run_b did not hit the breakpoint (status: no_break)', $hints);
+    }
+
+    public function testRunEmitsNoBreakHintsForMissedBreakpoints(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => []],
+            'php test.php 2' => ['breaks' => []],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertContains('run_a did not hit the breakpoint (status: no_break)', $result['analysis_hints']);
+        $this->assertContains('run_b did not hit the breakpoint (status: no_break)', $result['analysis_hints']);
+    }
+
+    public function testRunIncludesConditionInBreakpoint(): void
+    {
+        $runner = $this->createFakeRunner(['break' => 'calc.php:25:$x>0']);
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'calc.php', 'line' => 25], 'variables' => ['$x' => 'int: 5']]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'calc.php', 'line' => 25], 'variables' => ['$x' => 'int: 5']]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame('calc.php', $result['breakpoint']['file']);
+        $this->assertSame(25, $result['breakpoint']['line']);
+        $this->assertArrayHasKey('condition', $result['breakpoint']);
+        $this->assertSame('$x>0', $result['breakpoint']['condition']);
+    }
+
     public function testParseBreakSpec(): void
     {
         $runner = $this->createRunner();
@@ -201,7 +248,10 @@ class CompareRunnerTest extends TestCase
         $runner = $this->createRunner();
 
         $result = $this->invokeMethod($runner, 'parseBreakSpec', ['src/Calculator.php:25:$x>0']);
-        $this->assertSame(['file' => 'src/Calculator.php', 'line' => 25], $result);
+        $this->assertSame(
+            ['file' => 'src/Calculator.php', 'line' => 25, 'condition' => '$x>0'],
+            $result,
+        );
     }
 
     public function testParseBreakSpecWithAbsolutePath(): void

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -1,0 +1,610 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Unit;
+
+use Koriym\XdebugMcp\CompareRunner;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * Testable subclass that overrides executeXstep to avoid external process calls
+ */
+class FakeCompareRunner extends CompareRunner
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $fakeResults = [];
+
+    /** @param array<string, array<string, mixed>> $fakeResults Map of command => xstep result */
+    public function setFakeResults(array $fakeResults): void
+    {
+        $this->fakeResults = $fakeResults;
+    }
+
+    /** @return array<string, mixed> */
+    protected function executeXstep(string $command): array
+    {
+        if (!isset($this->fakeResults[$command])) {
+            throw new RuntimeException("xstep returned no output for command: {$command}");
+        }
+
+        return $this->fakeResults[$command];
+    }
+}
+
+class CompareRunnerTest extends TestCase
+{
+    /**
+     * @return mixed
+     */
+    private function invokeMethod(CompareRunner $runner, string $method, array $args = [])
+    {
+        $ref = new ReflectionClass($runner);
+        $m = $ref->getMethod($method);
+        $m->setAccessible(true);
+
+        return $m->invokeArgs($runner, $args);
+    }
+
+    private function createRunner(): CompareRunner
+    {
+        return new CompareRunner([
+            'break' => 'test.php:10',
+            'run_a' => 'php test.php 1',
+            'run_b' => 'php test.php 2',
+        ]);
+    }
+
+    private function createFakeRunner(array $options = []): FakeCompareRunner
+    {
+        return new FakeCompareRunner(array_merge([
+            'break' => 'test.php:10',
+            'run_a' => 'php test.php 1',
+            'run_b' => 'php test.php 2',
+        ], $options));
+    }
+
+    // ========================================
+    // computeDiff tests
+    // ========================================
+
+    public function testComputeDiffWithChangedVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $varsA = ['$x' => 'int: 10', '$y' => 'int: 20', '$name' => 'string: hello'];
+        $varsB = ['$x' => 'int: 99', '$y' => 'int: 20', '$name' => 'string: world'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$varsA, $varsB]);
+
+        $this->assertSame(['a' => 'int: 10', 'b' => 'int: 99'], $diff['changed']['$x']);
+        $this->assertSame(['a' => 'string: hello', 'b' => 'string: world'], $diff['changed']['$name']);
+        $this->assertSame(['$y'], $diff['unchanged']);
+        $this->assertSame([], $diff['only_in_a']);
+        $this->assertSame([], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffWithOnlyInA(): void
+    {
+        $runner = $this->createRunner();
+
+        $varsA = ['$x' => 'int: 10', '$extra' => 'string: only_a'];
+        $varsB = ['$x' => 'int: 10'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$varsA, $varsB]);
+
+        $this->assertSame([], $diff['changed']);
+        $this->assertSame(['$x'], $diff['unchanged']);
+        $this->assertSame(['$extra'], $diff['only_in_a']);
+        $this->assertSame([], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffWithOnlyInB(): void
+    {
+        $runner = $this->createRunner();
+
+        $varsA = ['$x' => 'int: 10'];
+        $varsB = ['$x' => 'int: 10', '$new_var' => 'string: only_b'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$varsA, $varsB]);
+
+        $this->assertSame([], $diff['changed']);
+        $this->assertSame(['$x'], $diff['unchanged']);
+        $this->assertSame([], $diff['only_in_a']);
+        $this->assertSame(['$new_var'], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffWithEmptyVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [[], []]);
+
+        $this->assertSame([], $diff['changed']);
+        $this->assertSame([], $diff['unchanged']);
+        $this->assertSame([], $diff['only_in_a']);
+        $this->assertSame([], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffWithCompletelyDifferentVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $varsA = ['$a' => 'int: 1', '$b' => 'int: 2'];
+        $varsB = ['$c' => 'int: 3', '$d' => 'int: 4'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$varsA, $varsB]);
+
+        $this->assertSame([], $diff['changed']);
+        $this->assertSame([], $diff['unchanged']);
+        $this->assertSame(['$a', '$b'], $diff['only_in_a']);
+        $this->assertSame(['$c', '$d'], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffWithAllIdenticalVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $vars = ['$x' => 'int: 10', '$y' => 'string: hello', '$z' => 'array: [3 items]'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$vars, $vars]);
+
+        $this->assertSame([], $diff['changed']);
+        $this->assertSame(['$x', '$y', '$z'], $diff['unchanged']);
+        $this->assertSame([], $diff['only_in_a']);
+        $this->assertSame([], $diff['only_in_b']);
+    }
+
+    // ========================================
+    // generateHints tests
+    // ========================================
+
+    public function testGenerateHints(): void
+    {
+        $runner = $this->createRunner();
+
+        $diff = [
+            'changed' => ['$x' => ['a' => 'int: 10', 'b' => 'int: 99']],
+            'unchanged' => ['$y'],
+            'only_in_a' => ['$extra'],
+            'only_in_b' => [],
+        ];
+        $varsA = ['$x' => 'int: 10', '$y' => 'int: 20', '$extra' => 'string: test'];
+        $varsB = ['$x' => 'int: 99', '$y' => 'int: 20'];
+
+        $hints = $this->invokeMethod($runner, 'generateHints', [$diff, $varsA, $varsB]);
+
+        $this->assertContains('$x: int: 10 → int: 99 (changed)', $hints);
+        $this->assertContains('$extra: string: test (only in run_a)', $hints);
+        $this->assertContains('1 variable(s) unchanged, 1 variable(s) changed, 3 total', $hints);
+    }
+
+    public function testGenerateHintsWithOnlyInB(): void
+    {
+        $runner = $this->createRunner();
+
+        $diff = [
+            'changed' => [],
+            'unchanged' => ['$x'],
+            'only_in_a' => [],
+            'only_in_b' => ['$error'],
+        ];
+        $varsA = ['$x' => 'int: 10'];
+        $varsB = ['$x' => 'int: 10', '$error' => 'string: Division by zero'];
+
+        $hints = $this->invokeMethod($runner, 'generateHints', [$diff, $varsA, $varsB]);
+
+        $this->assertContains('$error: string: Division by zero (only in run_b)', $hints);
+        $this->assertContains('1 variable(s) unchanged, 0 variable(s) changed, 2 total', $hints);
+    }
+
+    public function testGenerateHintsWithNoVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $diff = [
+            'changed' => [],
+            'unchanged' => [],
+            'only_in_a' => [],
+            'only_in_b' => [],
+        ];
+
+        $hints = $this->invokeMethod($runner, 'generateHints', [$diff, [], []]);
+
+        $this->assertCount(1, $hints);
+        $this->assertSame('0 variable(s) unchanged, 0 variable(s) changed, 0 total', $hints[0]);
+    }
+
+    // ========================================
+    // parseBreakSpec tests
+    // ========================================
+
+    public function testParseBreakSpec(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['src/Calculator.php:25']);
+        $this->assertSame(['file' => 'src/Calculator.php', 'line' => 25], $result);
+    }
+
+    public function testParseBreakSpecWithCondition(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['src/Calculator.php:25:$x>0']);
+        $this->assertSame(['file' => 'src/Calculator.php', 'line' => 25], $result);
+    }
+
+    public function testParseBreakSpecWithAbsolutePath(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['/home/user/project/src/File.php:100']);
+        $this->assertSame(['file' => '/home/user/project/src/File.php', 'line' => 100], $result);
+    }
+
+    public function testParseBreakSpecWithInvalidFormat(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['noformat']);
+        $this->assertSame(['file' => 'noformat', 'line' => 0], $result);
+    }
+
+    // ========================================
+    // extractVariables / extractLocation / extractStatus tests
+    // ========================================
+
+    public function testExtractVariablesFromResult(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = [
+            'breaks' => [
+                [
+                    'step' => 1,
+                    'location' => ['file' => 'test.php', 'line' => 10],
+                    'variables' => ['$x' => 'int: 10', '$y' => 'int: 20'],
+                    'recording_type' => 'full',
+                ],
+            ],
+        ];
+
+        $vars = $this->invokeMethod($runner, 'extractVariables', [$result]);
+        $this->assertSame(['$x' => 'int: 10', '$y' => 'int: 20'], $vars);
+    }
+
+    public function testExtractVariablesFromEmptyResult(): void
+    {
+        $runner = $this->createRunner();
+
+        $vars = $this->invokeMethod($runner, 'extractVariables', [['breaks' => []]]);
+        $this->assertSame([], $vars);
+    }
+
+    public function testExtractVariablesFromResultWithMissingBreaksKey(): void
+    {
+        $runner = $this->createRunner();
+
+        $vars = $this->invokeMethod($runner, 'extractVariables', [[]]);
+        $this->assertSame([], $vars);
+    }
+
+    public function testExtractVariablesFromBreakWithNoVariablesKey(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = [
+            'breaks' => [
+                ['location' => ['file' => 'test.php', 'line' => 10]],
+            ],
+        ];
+
+        $vars = $this->invokeMethod($runner, 'extractVariables', [$result]);
+        $this->assertSame([], $vars);
+    }
+
+    public function testExtractLocationFromResult(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = [
+            'breaks' => [
+                [
+                    'location' => ['file' => 'src/test.php', 'line' => 42],
+                    'variables' => [],
+                ],
+            ],
+        ];
+
+        $location = $this->invokeMethod($runner, 'extractLocation', [$result]);
+        $this->assertSame(['file' => 'src/test.php', 'line' => 42], $location);
+    }
+
+    public function testExtractLocationFromEmptyBreaks(): void
+    {
+        $runner = $this->createRunner();
+
+        $location = $this->invokeMethod($runner, 'extractLocation', [['breaks' => []]]);
+        $this->assertSame(['file' => '', 'line' => 0], $location);
+    }
+
+    public function testExtractStatusBreak(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = [
+            'breaks' => [
+                ['location' => ['file' => 'test.php', 'line' => 1], 'variables' => []],
+            ],
+        ];
+
+        $status = $this->invokeMethod($runner, 'extractStatus', [$result]);
+        $this->assertSame('break', $status);
+    }
+
+    public function testExtractStatusNoBreak(): void
+    {
+        $runner = $this->createRunner();
+
+        $status = $this->invokeMethod($runner, 'extractStatus', [['breaks' => []]]);
+        $this->assertSame('no_break', $status);
+    }
+
+    // ========================================
+    // run() integration tests via FakeCompareRunner
+    // ========================================
+
+    public function testRunProducesCorrectOutputStructure(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => [
+                'breaks' => [[
+                    'step' => 1,
+                    'location' => ['file' => 'test.php', 'line' => 10],
+                    'variables' => ['$x' => 'int: 1', '$sum' => 'int: 0'],
+                    'recording_type' => 'full',
+                ]],
+                'trace' => ['file' => '', 'lines' => 0, 'functions' => 0, 'max_depth' => 0, 'db_queries' => 0],
+            ],
+            'php test.php 2' => [
+                'breaks' => [[
+                    'step' => 1,
+                    'location' => ['file' => 'test.php', 'line' => 10],
+                    'variables' => ['$x' => 'int: 2', '$sum' => 'int: 0'],
+                    'recording_type' => 'full',
+                ]],
+                'trace' => ['file' => '', 'lines' => 0, 'functions' => 0, 'max_depth' => 0, 'db_queries' => 0],
+            ],
+        ]);
+
+        $result = $runner->run();
+
+        // Schema
+        $this->assertSame('https://koriym.github.io/xdebug-mcp/schemas/xcompare.json', $result['$schema']);
+
+        // Breakpoint
+        $this->assertSame('test.php', $result['breakpoint']['file']);
+        $this->assertSame(10, $result['breakpoint']['line']);
+
+        // Run A
+        $this->assertSame('php test.php 1', $result['run_a']['command']);
+        $this->assertSame('break', $result['run_a']['status']);
+        $this->assertSame(['$x' => 'int: 1', '$sum' => 'int: 0'], $result['run_a']['variables']);
+
+        // Run B
+        $this->assertSame('php test.php 2', $result['run_b']['command']);
+        $this->assertSame('break', $result['run_b']['status']);
+        $this->assertSame(['$x' => 'int: 2', '$sum' => 'int: 0'], $result['run_b']['variables']);
+
+        // Diff
+        $this->assertSame(['a' => 'int: 1', 'b' => 'int: 2'], $result['diff']['changed']['$x']);
+        $this->assertSame(['$sum'], $result['diff']['unchanged']);
+        $this->assertSame([], $result['diff']['only_in_a']);
+        $this->assertSame([], $result['diff']['only_in_b']);
+
+        // Hints
+        $this->assertNotEmpty($result['analysis_hints']);
+
+        // Context should not be present when not provided
+        $this->assertArrayNotHasKey('context', $result);
+    }
+
+    public function testRunWithContext(): void
+    {
+        $runner = $this->createFakeRunner(['context' => 'Testing context output']);
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertArrayHasKey('context', $result);
+        $this->assertSame('Testing context output', $result['context']);
+    }
+
+    public function testRunWithEmptyContextIsOmitted(): void
+    {
+        $runner = $this->createFakeRunner(['context' => '']);
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertArrayNotHasKey('context', $result);
+    }
+
+    public function testRunWithCustomLabels(): void
+    {
+        $runner = $this->createFakeRunner([
+            'label_a' => 'Normal input',
+            'label_b' => 'Edge case',
+        ]);
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame('Normal input', $result['run_a']['label']);
+        $this->assertSame('Edge case', $result['run_b']['label']);
+    }
+
+    public function testRunDefaultLabelsAreCommandStrings(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame('php test.php 1', $result['run_a']['label']);
+        $this->assertSame('php test.php 2', $result['run_b']['label']);
+    }
+
+    public function testRunWhenNoBreakpointHit(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => []],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 10], 'variables' => ['$x' => 'int: 1']]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame('no_break', $result['run_a']['status']);
+        $this->assertSame([], $result['run_a']['variables']);
+        $this->assertSame('break', $result['run_b']['status']);
+        $this->assertSame(['$x'], $result['diff']['only_in_b']);
+    }
+
+    public function testRunWithVariablesOnlyInEachRun(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [[
+                'location' => ['file' => 'f.php', 'line' => 10],
+                'variables' => ['$a' => 'int: 1', '$shared' => 'int: 0'],
+            ]]],
+            'php test.php 2' => ['breaks' => [[
+                'location' => ['file' => 'f.php', 'line' => 10],
+                'variables' => ['$b' => 'int: 2', '$shared' => 'int: 0'],
+            ]]],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame(['$shared'], $result['diff']['unchanged']);
+        $this->assertSame(['$a'], $result['diff']['only_in_a']);
+        $this->assertSame(['$b'], $result['diff']['only_in_b']);
+    }
+
+    // ========================================
+    // executeXstep error handling
+    // ========================================
+
+    public function testRunThrowsWhenXstepReturnsNoOutput(): void
+    {
+        $runner = $this->createFakeRunner();
+        // Only set result for run_a, not run_b
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('xstep returned no output for command: php test.php 2');
+
+        $runner->run();
+    }
+
+    // ========================================
+    // CLI argument validation tests (bin/xcompare)
+    // ========================================
+
+    public function testCliShowsHelpWithNoArgs(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare 2>&1', $output, $exitCode);
+
+        $firstLine = $output[0] ?? '';
+        $this->assertStringContainsString('Usage: xcompare', $firstLine);
+    }
+
+    public function testCliShowsHelpWithHelpFlag(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --help 2>&1', $output, $exitCode);
+
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--break=FILE:LINE', $joined);
+        $this->assertStringContainsString('--run-a=', $joined);
+        $this->assertStringContainsString('--run-b=', $joined);
+    }
+
+    public function testCliErrorWithoutBreak(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --run-a="php a.php" --run-b="php b.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--break=FILE:LINE is required', $joined);
+    }
+
+    public function testCliErrorWithoutRunA(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-b="php b.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run-a=', $joined);
+    }
+
+    public function testCliErrorWithoutRunB(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-a="php a.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run-b=', $joined);
+    }
+
+    // ========================================
+    // output() method test
+    // ========================================
+
+    public function testOutputProducesValidJson(): void
+    {
+        $runner = $this->createFakeRunner();
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => ['$x' => 'int: 1']]]],
+            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => ['$x' => 'int: 2']]]],
+        ]);
+
+        ob_start();
+        $runner->output();
+        $json = ob_get_clean();
+
+        $this->assertIsString($json);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('$schema', $decoded);
+        $this->assertArrayHasKey('diff', $decoded);
+    }
+}

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -353,16 +353,33 @@ class CompareRunnerTest extends TestCase
             ],
         ];
 
-        $location = $this->invokeMethod($runner, 'extractLocation', [$result]);
+        $fallback = ['file' => 'requested.php', 'line' => 10];
+        $location = $this->invokeMethod($runner, 'extractLocation', [$result, $fallback]);
         $this->assertSame(['file' => 'src/test.php', 'line' => 42], $location);
     }
 
-    public function testExtractLocationFromEmptyBreaks(): void
+    public function testExtractLocationFromEmptyBreaksReturnsRequested(): void
     {
         $runner = $this->createRunner();
 
-        $location = $this->invokeMethod($runner, 'extractLocation', [['breaks' => []]]);
-        $this->assertSame(['file' => '', 'line' => 0], $location);
+        $fallback = ['file' => 'requested.php', 'line' => 10];
+        $location = $this->invokeMethod($runner, 'extractLocation', [['breaks' => []], $fallback]);
+        $this->assertSame($fallback, $location);
+    }
+
+    public function testRunNoBreakFallsBackToRequestedLocation(): void
+    {
+        $runner = $this->createFakeRunner(['break' => 'src/app.php:42']);
+        $runner->setFakeResults([
+            'php test.php 1' => ['breaks' => []],
+            'php test.php 2' => ['breaks' => []],
+        ]);
+
+        $result = $runner->run();
+
+        $this->assertSame('no_break', $result['run_a']['status']);
+        $this->assertSame(['file' => 'src/app.php', 'line' => 42], $result['run_a']['location']);
+        $this->assertSame(['file' => 'src/app.php', 'line' => 42], $result['run_b']['location']);
     }
 
     public function testExtractStatusBreak(): void

--- a/tests/Unit/FakeCompareRunner.php
+++ b/tests/Unit/FakeCompareRunner.php
@@ -22,7 +22,7 @@ class FakeCompareRunner extends CompareRunner
     }
 
     /** @return array<string, mixed> */
-    protected function executeXstep(string $command): array
+    protected function executeXstep(string $command, string|null $cwd = null): array
     {
         if (! isset($this->fakeResults[$command])) {
             throw new RuntimeException("xstep returned no output for command: {$command}");

--- a/tests/Unit/FakeCompareRunner.php
+++ b/tests/Unit/FakeCompareRunner.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Unit;
+
+use Koriym\XdebugMcp\CompareRunner;
+use RuntimeException;
+
+/**
+ * Testable subclass that overrides executeXstep to avoid external process calls
+ */
+class FakeCompareRunner extends CompareRunner
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $fakeResults = [];
+
+    /** @param array<string, array<string, mixed>> $fakeResults Map of command => xstep result */
+    public function setFakeResults(array $fakeResults): void
+    {
+        $this->fakeResults = $fakeResults;
+    }
+
+    /** @return array<string, mixed> */
+    protected function executeXstep(string $command): array
+    {
+        if (! isset($this->fakeResults[$command])) {
+            throw new RuntimeException("xstep returned no output for command: {$command}");
+        }
+
+        return $this->fakeResults[$command];
+    }
+}


### PR DESCRIPTION
Add a new tool that compares variable states at the same breakpoint
across two different executions. This enables AI-driven analysis of
how different inputs affect program state at specific code locations.

Implementation:
- bin/xcompare: CLI entry point with --run-a/--run-b/--break options
- src/CompareRunner.php: Comparison logic with variable diff computation
- docs/schemas/xcompare.json: JSON schema for comparison output
- tests/Unit/CompareRunnerTest.php: 35 unit tests for diff logic
- .claude/skills/xcompare.md: Skill file for /xcompare slash command

Documentation:
- CLAUDE.md: Tool mapping table, available tools list, slash commands
- README.md: Tool table, CLI usage examples
- bin/README.md: Tool section with examples
- CHANGELOG.md: Release entry under [Unreleased]

https://claude.ai/code/session_012Wa1b8asqLqrr321ibpPKF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added xcompare CLI to run two executions at a breakpoint (two commands or vs. a git ref) and emit structured JSON comparisons with per-variable diffs and AI-oriented analysis hints.

* **Documentation**
  * Added usage examples, CLI behavior notes (labels, context, steps, include-vendor), demo commands, and a published JSON schema for output.

* **Tests**
  * Added unit, integration, and CLI tests covering diff logic, hint generation, run modes, git-ref worktree behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->