### PR TITLE
fix: address CodeRabbit review findings on PR #60

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ composer tests                   # cs + sa + phpunit (CI-equivalent)
 ./bin/xprofile  --json                     -- php script.php
 ./bin/xcoverage                            -- vendor/bin/phpunit
 ./bin/xback     --break="app.php:50"       -- php app.php
-./bin/xrepl     --break="script.php:42"    -- php script.php   # interactive mode of xstep
+./bin/xrepl     --break="script.php:42"    -- php script.php   # convenience wrapper (not an MCP tool)
 ```
 
 Demo targets live in `demo/` (`buggy.php`, `slow.php`, `coverage.php`).

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ composer global require koriym/xdebug-mcp
 
 #### Codex (Recommended: Local Skill)
 
-If you prefer a local skill or slash-command workflow, install the bundled skill from `skills/xdebug/SKILL.md`. For example on macOS/Linux:
+If you prefer a local skill or slash-command workflow, install the bundled skill from `skills/xdebug/SKILL.md`. For example on macOS/Linux (after `composer global require`):
 
 ```bash
 mkdir -p ~/.codex/skills
-ln -s "$(pwd)/skills/xdebug" ~/.codex/skills/xdebug
+ln -s ~/.composer/vendor/koriym/xdebug-mcp/skills/xdebug ~/.codex/skills/xdebug
 ```
+
+If you cloned the repository instead, link from your checkout (e.g. `ln -s "$(pwd)/skills/xdebug" ~/.codex/skills/xdebug`).
 
 Restart Codex after adding the skill.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ composer require koriym/xdebug-mcp
 echo "@vendor/koriym/xdebug-mcp/docs/debug_guideline_for_ai.md" >> CLAUDE.md
 
 # Codex: install the bundled local skill
+# (run from the consumer project root that contains vendor/)
 # mkdir -p ~/.codex/skills
 # ln -s "$(pwd)/vendor/koriym/xdebug-mcp/skills/xdebug" ~/.codex/skills/xdebug
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -61,12 +61,15 @@ composer global require koriym/xdebug-mcp
 
 ### Codex Local Skill (Recommended)
 
-Install the bundled skill from `skills/xdebug/SKILL.md`. Example for macOS/Linux:
+Install the bundled skill from `skills/xdebug/SKILL.md`. Example for macOS/Linux
+(using a Composer global install):
 
 ```bash
 mkdir -p ~/.codex/skills
-ln -s "$(pwd)/skills/xdebug" ~/.codex/skills/xdebug
+ln -s ~/.composer/vendor/koriym/xdebug-mcp/skills/xdebug ~/.codex/skills/xdebug
 ```
+
+If you cloned the repository instead, substitute the path to your checkout.
 
 Restart Codex after adding the skill.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,12 +45,15 @@ composer global require koriym/xdebug-mcp
 
 ### Codex Local Skill (Recommended)
 
-Install the bundled skill from `skills/xdebug/SKILL.md`. Example for macOS/Linux:
+Install the bundled skill from `skills/xdebug/SKILL.md`. Example for macOS/Linux
+(using a Composer global install):
 
 ```bash
 mkdir -p ~/.codex/skills
-ln -s "$(pwd)/skills/xdebug" ~/.codex/skills/xdebug
+ln -s ~/.composer/vendor/koriym/xdebug-mcp/skills/xdebug ~/.codex/skills/xdebug
 ```
+
+If you cloned the repository instead, substitute the path to your checkout.
 
 Restart Codex after adding the skill.
 

--- a/src/CLIParamsNormalizer.php
+++ b/src/CLIParamsNormalizer.php
@@ -8,6 +8,7 @@ use JsonException;
 use Koriym\XdebugMcp\DTO\CliParams;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 
+use function array_is_list;
 use function array_slice;
 use function count;
 use function ctype_digit;
@@ -242,7 +243,7 @@ class CLIParamsNormalizer
             );
         }
 
-        if (! is_array($decoded)) {
+        if (! is_array($decoded) || ! array_is_list($decoded)) {
             throw new InvalidArgumentException(
                 "不正：--{$key}:json の値は配列である必要があります。",
             );

--- a/src/ClaudeTraceAnalyzer.php
+++ b/src/ClaudeTraceAnalyzer.php
@@ -12,7 +12,6 @@ use function escapeshellarg;
 use function explode;
 use function file;
 use function implode;
-use function in_array;
 use function ini_get;
 use function is_file;
 use function is_readable;
@@ -71,7 +70,7 @@ final class ClaudeTraceAnalyzer
 
         $logger('📊 Claude Analysis Result:');
         foreach (explode("\n", trim($output)) as $line) {
-            if (in_array(trim($line), ['', '0'], true)) {
+            if (trim($line) === '') {
                 continue;
             }
 
@@ -113,7 +112,7 @@ final class ClaudeTraceAnalyzer
             $prompt .= "Stopped at line {$breakpointLine} in {$targetScript}\n\n";
         }
 
-        if ($userArgs !== '' && $userArgs !== '0') {
+        if ($userArgs !== '') {
             $prompt .= "## Specific Analysis Request\n";
             $prompt .= $userArgs . "\n\n";
         }

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -82,6 +82,7 @@ use function strlen;
 use function strtolower;
 use function strtoupper;
 use function substr;
+use function time;
 use function trim;
 use function usort;
 
@@ -126,6 +127,7 @@ final class DebugServer
     private bool $shouldExit = false;
     private readonly DebugResultFormatter $resultFormatter;
     private readonly ClaudeTraceAnalyzer $claudeTraceAnalyzer;
+    private readonly int $sessionStartTime;
 
     /** @var list<array{step: int, location: array{file: string, line: int}, variables: array<string, string>, recording_type: string}> */
     private array $breaks = [];
@@ -149,6 +151,8 @@ final class DebugServer
         $this->isDockerCommand = ContainerHelper::isContainerCommand($command);
         $this->resultFormatter = new DebugResultFormatter();
         $this->claudeTraceAnalyzer = new ClaudeTraceAnalyzer();
+        // Capture session start so trace lookups can filter out stale files from prior runs.
+        $this->sessionStartTime = time();
 
         // Check for existing sessions (warning only)
         $this->checkExistingSessions();
@@ -2271,8 +2275,14 @@ final class DebugServer
 
         $this->stepRecordingOutputDone = true;
 
-        $patterns = ['/tmp/trace*.xt', '/var/tmp/trace*.xt', '/tmp/trace*.xt.gz', '/var/tmp/trace*.xt.gz'];
-        $allTraceFiles = $this->findTraceFiles($patterns);
+        $scriptName = basename($this->targetScript, '.php');
+        $patterns = [
+            '/tmp/trace-*-' . $scriptName . '.xt',
+            '/tmp/trace-*-' . $scriptName . '.xt.gz',
+            '/var/tmp/trace-*-' . $scriptName . '.xt',
+            '/var/tmp/trace-*-' . $scriptName . '.xt.gz',
+        ];
+        $allTraceFiles = $this->filterTraceFilesToSession($this->findTraceFiles($patterns));
 
         $payload = $this->resultFormatter->buildBreakpointPayload(
             $this->breaks,
@@ -2589,6 +2599,31 @@ final class DebugServer
         }
 
         return $allTraceFiles;
+    }
+
+    /**
+     * Keep only trace files written during the current debug session.
+     *
+     * Trace files are generated into a shared directory (e.g. /tmp), so a naive
+     * "latest match" lookup could pick up another concurrent session's trace.
+     *
+     * @param list<string> $traceFiles
+     *
+     * @return list<string>
+     */
+    private function filterTraceFilesToSession(array $traceFiles): array
+    {
+        $filtered = [];
+        foreach ($traceFiles as $file) {
+            $mtime = @filemtime($file);
+            if ($mtime === false || $mtime < $this->sessionStartTime) {
+                continue;
+            }
+
+            $filtered[] = $file;
+        }
+
+        return $filtered;
     }
 
     /**

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -6,12 +6,14 @@ namespace Koriym\XdebugMcp;
 
 use JsonException;
 use Koriym\XdebugMcp\DTO\GenericResult;
+use Koriym\XdebugMcp\DTO\JsonRpcError;
 use Koriym\XdebugMcp\DTO\JsonRpcResponse;
 use Koriym\XdebugMcp\DTO\McpTool;
 use Koriym\XdebugMcp\DTO\ToolsListResult;
 use Koriym\XdebugMcp\Exceptions\FileNotFoundException;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use Koriym\XdebugMcp\Exceptions\InvalidToolException;
+use RuntimeException;
 use Throwable;
 
 use function array_filter;
@@ -624,7 +626,12 @@ final class McpServer
             throw new InvalidToolException("Unknown tool: $toolName");
         }
 
-        return $this->extractResultText($this->invokeToolHandler($definition, null, $arguments));
+        $response = $this->invokeToolHandler($definition, null, $arguments);
+        if ($response->error instanceof JsonRpcError) {
+            throw new RuntimeException($response->error->message, $response->error->code);
+        }
+
+        return $this->extractResultText($response);
     }
 
     private function buildInstructions(): string

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -354,18 +354,12 @@ class McpServerTest extends TestCase
 
     public function testExecuteToolCall(): void
     {
-        // Test executeToolCall method directly - it should handle exceptions and return formatted result
-        // The method catches exceptions and handles them, so let's test it returns proper error content
-        try {
-            $result = $this->invokePrivateMethod($this->server, 'executeToolCall', ['xtrace', ['script' => '']]);
-            // executeToolCall should return a string result, not throw exception
-            $this->assertIsString($result);
-            $this->assertStringContainsString('No result', $result); // Default fallback when execution fails
-        } catch (Throwable $e) {
-            // If an exception is thrown, it should be InvalidArgumentException
-            $this->assertInstanceOf(InvalidArgumentException::class, $e);
-            $this->assertStringContainsString('Script argument is required', $e->getMessage());
-        }
+        // executeToolCall must propagate tool handler errors so handleToolCall
+        // reports a real JSON-RPC failure instead of silently returning a
+        // success-shaped "No result" payload.
+        $this->expectException(Throwable::class);
+        $this->expectExceptionMessage('Script argument is required');
+        $this->invokePrivateMethod($this->server, 'executeToolCall', ['xtrace', ['script' => '']]);
     }
 
     public function testHandleToolCallError(): void


### PR DESCRIPTION
Addresses the 7 actionable CodeRabbit findings (plus one outside-diff) on #60.

## Summary

- **ClaudeTraceAnalyzer**: stop dropping output lines and `$userArgs` equal to `"0"`; drop the now-unused `in_array` import.
- **McpServer::executeToolCall**: propagate handler error responses as `RuntimeException` so `tools/call` reports real failures instead of silently returning "No result".
- **DebugServer::outputStepRecordingResults**: scope the trace-file lookup to the current session by narrowing glob patterns to the target script and filtering out files written before the session started.
- **CLIParamsNormalizer::convertJson**: reject JSON objects so the declared `list<string>` return contract is honored.
- **CLAUDE.md**: label `xrepl` as a convenience wrapper (not an MCP tool) to keep the canonical 5-tool surface coherent.
- **README.md / docs/README.md / docs/llms.txt / docs/llms-full.txt**: fix the Codex local-skill symlink example so it works with `composer global require`, with a note for cloned-repo users.
- **tests/Unit/McpServerTest.php**: update `testExecuteToolCall` to assert the new error-propagation contract.

## Validation

- `composer sa` — OK (no errors)
- `composer tests` — 221 tests, 489 assertions, 7 skipped

## Base branch

Targeted at `codex/refactor-mcp-tooling-and-codex-docs` so the fixes stack onto PR #60.

https://claude.ai/code/session_013js5cnfv541MBYjhCUCzor