### PR TITLE
ci: ignore phpunit advisories that block composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,12 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": {
+                "PKSA-5jz8-6tcw-pbk4": "phpunit is require-dev only; advisory blocks 10.x install on CI",
+                "PKSA-z3gr-8qht-p93v": "phpunit is require-dev only; advisory blocks 10.x install on CI"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Packagist flagged PKSA-5jz8-6tcw-pbk4 and PKSA-z3gr-8qht-p93v against phpunit/phpunit 10.x
- composer's default block-insecure policy refuses to resolve our require-dev constraint
- phpunit is never shipped at runtime, so ignore both advisories until phpunit 11 migration

Cherry-picked from #60 (38ba1d5) since #60 itself will be closed as part of the MCP layer removal plan (Taycan Turbo direction).

This fix is also a prerequisite for #62 (xcompare) CI recovery.

## Test plan

- [x] \`composer install\` succeeds locally
- [ ] CI passes on all PHP versions