### PR TITLE
fix: prevent xstep from emitting two JSON documents (#67)

### DIFF
--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -3026,10 +3026,12 @@ final class DebugServer
 
         // Output format based on jsonMode or jsonOutput option
         if ($this->jsonMode || ($this->options['jsonOutput'] ?? false)) {
-            // Mark step-recording output as done so the cleanup phase does not
-            // emit a second (empty) JSON document. See issue #67.
-            $this->stepRecordingOutputDone = true;
             echo json_encode($debugState, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n";
+
+            // Mark step-recording output as done only after JSON was successfully
+            // emitted so the cleanup phase can still fall back to its own output
+            // if encoding throws. See issue #67.
+            $this->stepRecordingOutputDone = true;
         } else {
             // Human-readable format
             $this->log("\n" . str_repeat('=', 60));

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -3026,6 +3026,9 @@ final class DebugServer
 
         // Output format based on jsonMode or jsonOutput option
         if ($this->jsonMode || ($this->options['jsonOutput'] ?? false)) {
+            // Mark step-recording output as done so the cleanup phase does not
+            // emit a second (empty) JSON document. See issue #67.
+            $this->stepRecordingOutputDone = true;
             echo json_encode($debugState, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n";
         } else {
             // Human-readable format

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -9,13 +9,19 @@ use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
+use function array_filter;
+use function array_values;
 use function basename;
 use function chdir;
 use function count;
 use function dirname;
+use function explode;
 use function file_exists;
 use function file_put_contents;
 use function getcwd;
+use function json_decode;
+use function ob_get_clean;
+use function ob_start;
 use function sys_get_temp_dir;
 use function tempnam;
 use function uniqid;
@@ -357,6 +363,49 @@ echo "Result: $result\n";
         $returnType = $method->getReturnType();
         $this->assertNotNull($returnType);
         $this->assertEquals('string', $returnType->getName());
+    }
+
+    /**
+     * Regression test for #67: xstep emits two JSON documents when --steps is omitted.
+     *
+     * When the multiple-breakpoint path (maxSteps unset) outputs its JSON, the
+     * subsequent cleanup phase must not emit a second, empty
+     * {"breaks":[]} JSON document.
+     */
+    public function testMultipleBreakResultsDoesNotDoubleEmitJson(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+
+        $reflection = new ReflectionClass($server);
+
+        $breaks = [
+            [
+                'step' => 1,
+                'location' => ['file' => basename($this->testScript), 'line' => 3],
+                'variables' => ['$x' => '10'],
+            ],
+        ];
+
+        $outputMultiple = $reflection->getMethod('outputMultipleBreakResults');
+        $outputStepRec = $reflection->getMethod('outputStepRecordingResults');
+
+        ob_start();
+        $outputMultiple->invoke($server, $breaks);
+        // Simulate the cleanup-phase call that previously double-emitted.
+        $outputStepRec->invoke($server);
+        $stdout = ob_get_clean();
+
+        $documents = array_values(array_filter(
+            explode("\n", $stdout),
+            static fn (string $line): bool => $line !== '',
+        ));
+
+        $this->assertCount(1, $documents, 'Expected exactly one JSON document on stdout');
+
+        $decoded = json_decode($documents[0], true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('https://koriym.github.io/xdebug-mcp/schemas/xstep.json', $decoded['$schema']);
+        $this->assertCount(1, $decoded['breaks']);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #67.

`xstep --break='FILE:LINE' -- php SCRIPT.php` (without `--steps`) was emitting **two** JSON documents to stdout, which breaks any caller that pipes output into `json_decode` / `json.loads`.

### Root cause

Two output sites in `src/DebugServer.php`:

1. `outputMultipleBreakResults` — emitted from `processMultipleBreakpoints` (the `--steps`-not-set branch).
2. `outputStepRecordingResults` — called unconditionally from the cleanup phase when `jsonMode` is on, even though step recording never ran. With empty `$this->breaks`, it emitted a second `{"breaks":[]}` document.

### Fix

Opted for the defensive guard (Option 2 in the issue). `outputStepRecordingResults` already has a `stepRecordingOutputDone` flag to prevent double-firing within its own path; we now also set it when `outputMultipleBreakResults` actually emits JSON. The cleanup-phase call then becomes a no-op.

This keeps existing default behaviour intact (no semantic change to what `--steps` omitted means) while closing the double-output symptom.

## Test plan

- [x] Added regression test `DebugServerTest::testMultipleBreakResultsDoesNotDoubleEmitJson` that:
  - invokes `outputMultipleBreakResults` with one break,
  - then calls `outputStepRecordingResults` (simulating the cleanup phase),
  - asserts exactly one JSON document is written to stdout and that `breaks` is preserved.
- [x] Confirmed the new test fails on `1.x` without the fix (actual size 2) and passes with it.
- [x] `vendor/bin/phpunit tests/Unit` — 178 tests, 343 assertions, 6 skipped, all green.
- [ ] Manual repro with real Xdebug — not runnable in this environment; reviewer-welcome to confirm with `./bin/xstep --break='demo/buggy.php:22' -- php demo/buggy.php 2>/dev/null | python3 -c 'import json,sys; json.loads(sys.stdin.read())'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where debug output in JSON mode could be emitted multiple times when processing multiple break results.

* **Tests**
  * Added regression test to ensure debug output remains correct in multiple break scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->