### PR TITLE
fix(xcompare): post-merge follow-ups from PR #62 review

### DIFF
--- a/bin/xcompare
+++ b/bin/xcompare
@@ -134,7 +134,8 @@ function showCompareHelp(): void
         }
 
         if (str_starts_with($arg, '--steps=')) {
-            $steps = (int) substr($arg, 8);
+            // xstep requires at least one recorded step; clamp to avoid xstep complaining about --steps=0.
+            $steps = max(1, (int) substr($arg, 8));
             continue;
         }
 

--- a/docs/schemas/xcompare.json
+++ b/docs/schemas/xcompare.json
@@ -5,6 +5,11 @@
   "description": "Comparison of variable states at the same breakpoint across two different executions. Shows what changed, what stayed the same, and what exists only in one run.",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI of this JSON Schema document"
+    },
     "breakpoint": {
       "type": "object",
       "description": "The breakpoint location being compared",

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp;
 
+use InvalidArgumentException;
 use RuntimeException;
 
 use function array_diff_key;
@@ -461,7 +462,7 @@ class CompareRunner
             return $result;
         }
 
-        return ['file' => $spec, 'line' => 0];
+        throw new InvalidArgumentException("Invalid breakpoint spec: '{$spec}' (expected FILE:LINE[:CONDITION])");
     }
 
     /**

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -185,9 +185,15 @@ class CompareRunner
     {
         $checkOutput = [];
         $checkExit = 0;
-        exec('git rev-parse --is-inside-work-tree 2>/dev/null', $checkOutput, $checkExit);
+        exec('git rev-parse --is-inside-work-tree 2>&1', $checkOutput, $checkExit);
         if ($checkExit !== 0 || trim(implode('', $checkOutput)) !== 'true') {
-            throw new RuntimeException('--compare-with requires the current directory to be inside a git repository');
+            $message = '--compare-with requires the current directory to be inside a git repository';
+            $detail = trim(implode("\n", $checkOutput));
+            if ($detail !== '' && $detail !== 'true' && $detail !== 'false') {
+                $message .= "\n" . $detail;
+            }
+
+            throw new RuntimeException($message);
         }
 
         $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid('', true);

--- a/tests/Integration/Cli/XcompareCliTest.php
+++ b/tests/Integration/Cli/XcompareCliTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Integration\Cli;
+
+use PHPUnit\Framework\TestCase;
+
+use function exec;
+use function implode;
+
+class XcompareCliTest extends TestCase
+{
+    public function testCliShowsHelpWithNoArgs(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare 2>&1', $output, $exitCode);
+
+        $firstLine = $output[0] ?? '';
+        $this->assertStringContainsString('Usage: xcompare', $firstLine);
+    }
+
+    public function testCliShowsHelpWithHelpFlag(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --help 2>&1', $output, $exitCode);
+
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--break=FILE:LINE', $joined);
+        $this->assertStringContainsString('--run-a=', $joined);
+        $this->assertStringContainsString('--run-b=', $joined);
+    }
+
+    public function testCliErrorWithoutBreak(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --run-a="php a.php" --run-b="php b.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--break=FILE:LINE is required', $joined);
+    }
+
+    public function testCliErrorWithoutRunA(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=test.php:10 --run-b="php b.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run-a=', $joined);
+    }
+
+    public function testCliErrorWithoutRunB(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=test.php:10 --run-a="php a.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run-b=', $joined);
+    }
+
+    public function testCliErrorMixingModes(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=test.php:10 --run-a="php a.php" --run="php x.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('Cannot mix', $joined);
+    }
+
+    public function testCliErrorCompareWithWithoutRun(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=test.php:10 --compare-with=main 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--run=', $joined);
+    }
+
+    public function testCliErrorRunWithoutCompareWith(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=test.php:10 --run="php a.php" 2>&1', $output, $exitCode);
+
+        $this->assertNotSame(0, $exitCode);
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--compare-with=', $joined);
+    }
+
+    public function testCliHelpShowsCompareWithMode(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --help 2>&1', $output, $exitCode);
+
+        $joined = implode("\n", $output);
+        $this->assertStringContainsString('--compare-with=', $joined);
+        $this->assertStringContainsString('--run=', $joined);
+        $this->assertStringContainsString('MODE 2:', $joined);
+    }
+}

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -11,8 +11,6 @@ use ReflectionClass;
 use RuntimeException;
 
 use function array_merge;
-use function exec;
-use function implode;
 use function json_decode;
 use function ob_get_clean;
 use function ob_start;
@@ -591,106 +589,6 @@ class CompareRunnerTest extends TestCase
         $this->expectExceptionMessage('xstep returned no output for command: php test.php 2');
 
         $runner->run();
-    }
-
-    public function testCliShowsHelpWithNoArgs(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare 2>&1', $output, $exitCode);
-
-        $firstLine = $output[0] ?? '';
-        $this->assertStringContainsString('Usage: xcompare', $firstLine);
-    }
-
-    public function testCliShowsHelpWithHelpFlag(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --help 2>&1', $output, $exitCode);
-
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--break=FILE:LINE', $joined);
-        $this->assertStringContainsString('--run-a=', $joined);
-        $this->assertStringContainsString('--run-b=', $joined);
-    }
-
-    public function testCliErrorWithoutBreak(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --run-a="php a.php" --run-b="php b.php" 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--break=FILE:LINE is required', $joined);
-    }
-
-    public function testCliErrorWithoutRunA(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-b="php b.php" 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--run-a=', $joined);
-    }
-
-    public function testCliErrorWithoutRunB(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-a="php a.php" 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--run-b=', $joined);
-    }
-
-    public function testCliErrorMixingModes(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run-a="php a.php" --run="php x.php" 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('Cannot mix', $joined);
-    }
-
-    public function testCliErrorCompareWithWithoutRun(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --compare-with=main 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--run=', $joined);
-    }
-
-    public function testCliErrorRunWithoutCompareWith(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --break=test.php:10 --run="php a.php" 2>&1', $output, $exitCode);
-
-        $this->assertNotSame(0, $exitCode);
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--compare-with=', $joined);
-    }
-
-    public function testCliHelpShowsCompareWithMode(): void
-    {
-        $output = [];
-        $exitCode = 0;
-        exec('php ' . __DIR__ . '/../../bin/xcompare --help 2>&1', $output, $exitCode);
-
-        $joined = implode("\n", $output);
-        $this->assertStringContainsString('--compare-with=', $joined);
-        $this->assertStringContainsString('--run=', $joined);
-        $this->assertStringContainsString('MODE 2:', $joined);
     }
 
     public function testOutputProducesValidJson(): void

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\Tests\Unit;
 
+use InvalidArgumentException;
 use Koriym\XdebugMcp\CompareRunner;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -266,8 +267,19 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createRunner();
 
-        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['noformat']);
-        $this->assertSame(['file' => 'noformat', 'line' => 0], $result);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid breakpoint spec: 'invalid-spec'");
+
+        $this->invokeMethod($runner, 'parseBreakSpec', ['invalid-spec']);
+    }
+
+    public function testParseBreakSpecWithWindowsPath(): void
+    {
+        $runner = $this->createRunner();
+
+        $result = $this->invokeMethod($runner, 'parseBreakSpec', ['C:\\foo.php:25']);
+        $this->assertSame('C:\\foo.php', $result['file']);
+        $this->assertSame(25, $result['line']);
     }
 
     public function testBuildXstepCommandDefaultsStepsToOne(): void


### PR DESCRIPTION
## Summary

Five small follow-up fixes surfaced by a post-merge review of PR #62 (xcompare). Each fix is its own commit so they can be reverted or cherry-picked individually.

- **`parseBreakSpec` rejects malformed input** — `--break=calc.php` (missing `:LINE`) used to silently parse to `line: 0` and flow into xstep. Now throws `InvalidArgumentException` with a helpful message. Adds a Windows-path test that pins the greedy-regex behavior.
- **`git rev-parse` surfaces stderr** — the `--compare-with` pre-check used `2>/dev/null`, hiding `safe.directory`, permission, and corrupted-repo errors behind a generic message. Captures git's output and appends it to the exception when present.
- **CLI exec tests moved to Integration suite** — `testCliShowsHelp*`, `testCliError*`, and `testCliHelpShowsCompareWithMode` shell out to `php bin/xcompare` and don't belong in `tests/Unit`. Moved verbatim to `tests/Integration/Cli/XcompareCliTest.php`; Unit suite is now hermetic.
- **JSON Schema declares top-level `$schema`** — every emitted document includes `\$schema`, but the schema didn't list it under `properties`. Now declared as a `string`/`uri`, optional (not in `required`).
- **`--steps` clamps to >= 1** — `--steps=0` or negative values used to be forwarded to xstep, which then errors out. CLI now clamps with `max(1, ...)`.

## Test plan

- [x] `composer cs` passes
- [x] `vendor/bin/phpstan analyse` passes
- [x] `vendor/bin/phpunit --no-coverage` — 254 tests, 581 assertions, 1 skipped (existing worktree integration skip), 0 failures
- [x] Each commit verified independently before the next

Refs: PR #62 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--steps` parameter now enforces a minimum value of 1; zero or negative values are rejected.
  * Improved error handling for invalid breakpoint specifications with clearer error messages.
  * Enhanced error reporting when git worktree detection fails.

* **Documentation**
  * Updated JSON Schema with `$schema` field documentation.

* **Tests**
  * Added comprehensive CLI integration tests validating help text, required options, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->