### PR TITLE
fix: format PHPUnit coverage in xcoverage

### DIFF
--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -10,7 +10,7 @@ const XDEBUG_BRANCH_EXIT_SENTINEL = 2147483645;
 
 // Show help if requested
 if (in_array('--help', $argv) || in_array('-h', $argv)) {
-    echo "Usage: " . $argv[0] . " [OPTIONS] [--] [php script.php [args...]]\n";
+    echo "Usage: " . $argv[0] . " [OPTIONS] [--] [phpunit args | php vendor/bin/phpunit [args...]]\n";
     echo "\n";
     echo "AI-Optimized PHP Code Coverage Collection Tool\n";
     echo "\n";
@@ -37,6 +37,7 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "COMMON USAGE PATTERNS:\n";
     echo "  # Default: PHPUnit mode with @codeCoverageIgnore support\n";
     echo "  " . $argv[0] . "\n";
+    echo "  " . $argv[0] . " -- php ./vendor/bin/phpunit --filter MyTest\n";
     echo "\n";
     echo "  # Raw mode: Xdebug direct coverage (any PHP script)\n";
     echo "  " . $argv[0] . " --raw -- php app.php\n";
@@ -63,8 +64,8 @@ $rawMode = isset($options['raw']);
 // Get remaining arguments
 $args = $optind !== null ? array_slice($argv, $optind) : [];
 
-// If first argument is 'php', remove it
-if (!empty($args) && $args[0] === 'php') {
+// Remove the option delimiter if present
+if (!empty($args) && $args[0] === '--') {
     $args = array_slice($args, 1);
 }
 
@@ -73,6 +74,65 @@ $debug = getenv('COVERAGE_DEBUG');
 if ($debug) {
     fwrite(STDERR, "[COVERAGE_DEBUG] Raw mode: " . ($rawMode ? 'true' : 'false') . "\n");
     fwrite(STDERR, "[COVERAGE_DEBUG] Args: " . json_encode($args) . "\n");
+}
+
+/**
+ * Normalize a user-provided PHPUnit command into arguments for the local PHPUnit binary.
+ *
+ * xcoverage asks PHPUnit for Clover output, so flags that disable coverage are removed.
+ *
+ * @param list<string> $args
+ *
+ * @return list<string>
+ */
+function normalizePhpUnitArguments(array $args): array
+{
+    if (! empty($args) && isPhpBinary($args[0])) {
+        $args = array_slice($args, 1);
+    }
+
+    if (! empty($args) && isPhpUnitCommand($args[0])) {
+        $args = array_slice($args, 1);
+    }
+
+    $normalized = [];
+    foreach ($args as $arg) {
+        if ($arg === '--no-coverage') {
+            continue;
+        }
+
+        $normalized[] = $arg;
+    }
+
+    return $normalized;
+}
+
+/**
+ * @param list<string> $args
+ *
+ * @return list<string>
+ */
+function normalizeRawArguments(array $args): array
+{
+    if (! empty($args) && isPhpBinary($args[0])) {
+        return array_slice($args, 1);
+    }
+
+    return $args;
+}
+
+function isPhpBinary(string $arg): bool
+{
+    $binary = basename(str_replace('\\', '/', $arg));
+
+    return preg_match('/^php(?:[0-9.]+)?(?:\.exe)?$/i', $binary) === 1;
+}
+
+function isPhpUnitCommand(string $arg): bool
+{
+    $binary = basename(str_replace('\\', '/', $arg));
+
+    return $binary === 'phpunit' || $binary === 'phpunit.phar';
 }
 
 // PHPUnit mode (default) - uses PHPUnit's coverage with @codeCoverageIgnore support
@@ -92,18 +152,16 @@ if (!$rawMode) {
     $phpPath = PHP_BINARY;
 
     // Build PHPUnit command with coverage-clover (stable XML format)
-    $phpunitArgs = ['--coverage-clover=' . $coverageFile, '--testdox', '--no-progress', '--colors=never'];
-
-    // Add any additional args
-    if (!empty($args)) {
-        $phpunitArgs = array_merge($phpunitArgs, $args);
-    }
+    $phpunitArgs = array_merge(
+        ['--coverage-clover=' . $coverageFile, '--testdox', '--no-progress', '--colors=never'],
+        normalizePhpUnitArguments($args),
+    );
 
     echo "# Running PHPUnit with coverage (respects @codeCoverageIgnore)\n";
 
     $escapedArgs = array_map('escapeshellarg', $phpunitArgs);
     // Run PHPUnit via PHP with Xdebug enabled
-    $cmd = escapeshellarg($phpPath) . $xdebugFlag . ' -dxdebug.mode=coverage ' . escapeshellarg('./vendor/bin/phpunit') . ' ' . implode(' ', $escapedArgs);
+    $cmd = escapeshellarg($phpPath) . $xdebugFlag . ' -dxdebug.mode=coverage -dpcov.enabled=0 ' . escapeshellarg('./vendor/bin/phpunit') . ' ' . implode(' ', $escapedArgs);
 
     if ($debug) {
         fwrite(STDERR, "[COVERAGE_DEBUG] PHPUnit command: $cmd\n");
@@ -238,6 +296,7 @@ if (!$rawMode) {
 }
 
 // Raw mode - uses Xdebug directly (original behavior)
+$args = normalizeRawArguments($args);
 $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
 $branchFlag = $branchCoverage ? 'true' : 'false';
 $includeVendorRequire = '';

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -7,6 +7,7 @@ namespace Koriym\XdebugMcp\Tests\Integration;
 use Koriym\XdebugMcp\XdebugFinder;
 use PHPUnit\Framework\TestCase;
 
+use function bin2hex;
 use function dirname;
 use function escapeshellarg;
 use function explode;
@@ -17,6 +18,7 @@ use function is_executable;
 use function json_decode;
 use function json_encode;
 use function mkdir;
+use function random_bytes;
 use function rmdir;
 use function shell_exec;
 use function sprintf;
@@ -136,10 +138,7 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
             mkdir($buildDir);
         }
 
-        $fixtureDir = tempnam($buildDir, 'xcoverage_phpunit_');
-        $this->assertIsString($fixtureDir);
-        unlink($fixtureDir);
-
+        $fixtureDir = $buildDir . '/xcoverage_phpunit_' . bin2hex(random_bytes(6));
         $sourceDir = $fixtureDir . '/src';
         $testDir = $fixtureDir . '/tests';
         mkdir($sourceDir, 0777, true);
@@ -189,7 +188,9 @@ PHP);
             $output = shell_exec($command);
 
             $this->assertNotNull($output);
-            $jsonStart = strrpos($output, "{\n    \"\$schema\"");
+            $schemaPos = strrpos($output, '"$schema"');
+            $this->assertNotFalse($schemaPos, $output);
+            $jsonStart = strrpos(substr($output, 0, $schemaPos), '{');
             $this->assertNotFalse($jsonStart, $output);
 
             $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\Tests\Integration;
 
+use Koriym\XdebugMcp\XdebugFinder;
 use PHPUnit\Framework\TestCase;
 
 use function dirname;
@@ -11,16 +12,23 @@ use function escapeshellarg;
 use function explode;
 use function file_exists;
 use function file_put_contents;
+use function is_dir;
 use function is_executable;
 use function json_decode;
 use function json_encode;
+use function mkdir;
+use function rmdir;
 use function shell_exec;
 use function sprintf;
 use function str_starts_with;
+use function strrpos;
+use function substr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
 use function unlink;
+
+use const JSON_THROW_ON_ERROR;
 
 class XdebugCommandsTest extends TestCase
 {
@@ -114,6 +122,102 @@ echo "Memory usage: " . memory_get_usage() . " bytes\n";
     {
         $this->assertTrue(file_exists(__DIR__ . '/../../bin/xcoverage'));
         $this->assertTrue(is_executable(__DIR__ . '/../../bin/xcoverage'));
+    }
+
+    public function testXcoverageFormatsPhpUnitCoverageAndIgnoresNoCoverageFlag(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $root = dirname(__DIR__, 2);
+        $buildDir = $root . '/build';
+        if (! is_dir($buildDir)) {
+            mkdir($buildDir);
+        }
+
+        $fixtureDir = tempnam($buildDir, 'xcoverage_phpunit_');
+        $this->assertIsString($fixtureDir);
+        unlink($fixtureDir);
+
+        $sourceDir = $fixtureDir . '/src';
+        $testDir = $fixtureDir . '/tests';
+        mkdir($sourceDir, 0777, true);
+        mkdir($testDir, 0777, true);
+
+        $sourceFile = $sourceDir . '/IgnoredSubject.php';
+        $testFile = $testDir . '/IgnoredSubjectTest.php';
+
+        file_put_contents($sourceFile, <<<'PHP'
+<?php
+final class IgnoredSubject
+{
+    public function value(bool $flag): string
+    {
+        if ($flag) {
+            return 'covered';
+        }
+
+        return 'ignored'; // @codeCoverageIgnore
+    }
+}
+PHP);
+
+        file_put_contents($testFile, <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../src/IgnoredSubject.php';
+
+final class IgnoredSubjectTest extends TestCase
+{
+    public function testCoveredBranch(): void
+    {
+        self::assertSame('covered', (new IgnoredSubject())->value(true));
+    }
+}
+PHP);
+
+        try {
+            $command = sprintf(
+                'cd %s && ./bin/xcoverage -- php ./vendor/bin/phpunit --no-coverage --no-configuration --coverage-filter %s %s 2>&1',
+                escapeshellarg($root),
+                escapeshellarg($sourceDir),
+                escapeshellarg($testFile),
+            );
+            $output = shell_exec($command);
+
+            $this->assertNotNull($output);
+            $jsonStart = strrpos($output, "{\n    \"\$schema\"");
+            $this->assertNotFalse($jsonStart, $output);
+
+            $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame('phpunit', $coverage['mode']);
+            $this->assertSame(100.0, (float) $coverage['summary']['coverage_percent']);
+            $this->assertSame([], $coverage['uncovered']);
+        } finally {
+            if (file_exists($testFile)) {
+                unlink($testFile);
+            }
+
+            if (file_exists($sourceFile)) {
+                unlink($sourceFile);
+            }
+
+            if (is_dir($testDir)) {
+                rmdir($testDir);
+            }
+
+            if (is_dir($sourceDir)) {
+                rmdir($sourceDir);
+            }
+
+            if (is_dir($fixtureDir)) {
+                rmdir($fixtureDir);
+            }
+        }
     }
 
     public function testXstepCommandExists(): void


### PR DESCRIPTION
## Summary

- Normalize xcoverage PHPUnit-mode arguments so -- php ./vendor/bin/phpunit ... is treated as PHPUnit arguments.
- Remove --no-coverage when xcoverage owns Clover generation.
- Force PHPUnit away from PCOV with -dpcov.enabled=0 so Xdebug coverage is used consistently.
- Add an integration test proving @codeCoverageIgnore is honored through PHPUnit Clover formatting.

Fixes #70.

## Validation

- composer cs
- composer sa
- composer test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PHPUnit argument parsing to handle `--` delimiter and normalize command-line inputs.
  * Ensures coverage output is always generated by filtering conflicting flags.

* **Tests**
  * Added integration test validating JSON output format and coverage behavior for PHPUnit runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->