### PR TITLE
docs(xstep): document recording_type field (closes #59)

### DIFF
--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -40,7 +40,12 @@
         },
         "variables": {
           "type": "object",
-          "description": "Variable values at breakpoint"
+          "description": "Variable values at breakpoint. In step-recording mode (--break combined with --steps) the contents depend on recording_type: a 'full' frame carries every variable, while a 'diff' frame carries only variables that were added, changed, or removed since the previous step (deleted variables appear with the value '[DELETED]')."
+        },
+        "recording_type": {
+          "type": "string",
+          "enum": ["full", "diff"],
+          "description": "Present only in step-recording mode (--break + --steps). 'full' marks the first recorded step and contains the complete variable snapshot; 'diff' marks subsequent steps and contains only the changes from the previous step (added, modified, or deleted entries — deletions are encoded as '[DELETED]')."
         },
         "watches": {
           "type": "array",

--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -40,7 +40,7 @@
         },
         "variables": {
           "type": "object",
-          "description": "Variable values at breakpoint. In step-recording mode (--break combined with --steps) the contents depend on recording_type: a 'full' frame carries every variable, while a 'diff' frame carries only variables that were added, changed, or removed since the previous step (deleted variables appear with the value '[DELETED]')."
+          "description": "Variable values at breakpoint. In step-recording mode (--break + --steps) the contents depend on recording_type: a 'full' frame carries every variable, while a 'diff' frame carries only variables that were added, changed, or removed since the previous step (deleted variables appear with the value '[DELETED]')."
         },
         "recording_type": {
           "type": "string",

--- a/tests/Unit/XstepSchemaTest.php
+++ b/tests/Unit/XstepSchemaTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+final class XstepSchemaTest extends TestCase
+{
+    #[Test]
+    public function documentsStepRecordingType(): void
+    {
+        $schemaJson = file_get_contents(dirname(__DIR__, 2) . '/docs/schemas/xstep.json');
+        $this->assertIsString($schemaJson);
+
+        /** @var array{
+         *     definitions: array{
+         *         breakpoint: array{
+         *             properties: array<string, array<string, mixed>>,
+         *             required: list<string>
+         *         }
+         *     }
+         * } $schema
+         */
+        $schema = json_decode($schemaJson, true, 512, JSON_THROW_ON_ERROR);
+        $breakpoint = $schema['definitions']['breakpoint'];
+        $properties = $breakpoint['properties'];
+
+        $this->assertArrayHasKey('recording_type', $properties);
+        $this->assertSame('string', $properties['recording_type']['type']);
+        $this->assertSame(['full', 'diff'], $properties['recording_type']['enum']);
+        $this->assertNotContains('recording_type', $breakpoint['required']);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `recording_type` (enum: `full`, `diff`) to `docs/schemas/xstep.json` so the field xstep emits in step-recording mode (`--break` combined with `--steps`) is documented.
- Expand the `variables` description to explain that a `full` frame carries every variable while a `diff` frame carries only added / changed / removed entries (with `[DELETED]` as the deletion marker).
- Add a regression test that locks the schema definition for `recording_type` and keeps it optional outside step-recording mode.

Closes #59.

The other half of #59 (duplicate JSON document in pure breakpoint mode) is no longer reproducible on `1.x` — verified by running the issue reproduction command, which now emits a single JSON object.

## Test plan

- [x] `php -r 'json_decode(file_get_contents("docs/schemas/xstep.json"), true, 512, JSON_THROW_ON_ERROR); echo "schema ok\n";'`
- [x] `./vendor/bin/phpunit tests/Unit/XstepSchemaTest.php --colors=never`
- [x] `composer cs`
- [x] `composer sa`
- [x] `composer test` (255 tests, 586 assertions, 1 skipped)
- [x] Re-ran both repro commands from #59; the duplicate JSON output is no longer present, and the schema mismatch is covered by this PR.