### PR TITLE
build: upgrade to PHPUnit 11 and drop PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
         stability: [prefer-stable]
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ The server exposes multiple tools via MCP across main categories:
 - Environment variables: MCP_DEBUG for debug logging
 
 ## PHP Requirements
-- PHP >= 8.0
+- PHP >= 8.2
 - ext-sockets extension for Xdebug communication
 - ext-xml extension for parsing Xdebug responses
 - Xdebug extension (with debug, profile, and coverage modes enabled)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The AI automatically selects the appropriate tool, executes it, and analyzes the
 
 ## Requirements
 
-- PHP 8.1+
+- PHP 8.2+
 - [Xdebug 3.x](https://xdebug.org/docs/install) extension (installed, but **not** enabled by default)
 - Optional: an AI assistant (Claude Code plugin, or any MCP-capable client)
 
@@ -253,7 +253,7 @@ See [tests/docker/README.md](tests/docker/README.md) for details.
 
 ## Debugging Legacy PHP (7.x / 5.x)
 
-While xdebug-mcp itself requires PHP 8.1+, it can debug older PHP versions as long as a compatible Xdebug 3.x release is installed on the target PHP. Simply specify the target PHP binary after `--`:
+While xdebug-mcp itself requires PHP 8.2+, it can debug older PHP versions as long as a compatible Xdebug 3.x release is installed on the target PHP. Simply specify the target PHP binary after `--`:
 
 ```bash
 # Debug PHP 7.2 code

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://koriym.github.io/xdebug-mcp/",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-sockets": "*",
         "ext-xml": "*",
         "symfony/polyfill-php83": "^1.33",
@@ -15,7 +15,7 @@
         "amphp/http-server": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^11.0",
         "doctrine/coding-standard": "^13.0",
         "justinrainbow/json-schema": "^6.4",
         "phpstan/phpstan": "^2.1",
@@ -82,12 +82,6 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        },
-        "audit": {
-            "ignore": {
-                "PKSA-5jz8-6tcw-pbk4": "phpunit is require-dev only; advisory blocks 10.x install on CI",
-                "PKSA-z3gr-8qht-p93v": "phpunit is require-dev only; advisory blocks 10.x install on CI"
-            }
         }
     }
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -58,7 +58,7 @@ php -dzend_extension=xdebug -r "echo 'Xdebug version: ' . phpversion('xdebug');"
 
 **Check PHP Version**:
 ```bash
-php -v  # Must be PHP 8.0+
+php -v  # Must be PHP 8.2+
 which php
 ```
 
@@ -68,7 +68,7 @@ which php
 export PATH="/usr/local/bin:$PATH"
 
 # Ubuntu: Install PHP 8.x
-sudo apt-get install php8.1-cli php8.1-xdebug
+sudo apt-get install php8.2-cli php8.2-xdebug
 ```
 
 ### 3. Port Conflicts

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -77,7 +77,7 @@ Find the correct path: `which xdebug-mcp`
 
 ## Requirements
 
-- PHP 8.1+ with ext-sockets, ext-xml
+- PHP 8.2+ with ext-sockets, ext-xml
 - Xdebug 3.x extension (installed but not enabled by default)
 - AI assistant: Claude Code (plugin), Cursor/Windsurf (MCP), or CLI
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -60,7 +60,7 @@ Create `.mcp.json` in your project root:
 
 ## Requirements
 
-- PHP 8.1+ with ext-sockets, ext-xml
+- PHP 8.2+ with ext-sockets, ext-xml
 - Xdebug 3.x extension (installed but not enabled by default)
 - AI assistant: Claude Code (plugin), Cursor/Windsurf (MCP), or CLI
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory=".phpunit.cache"

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -21,7 +21,6 @@ class CompareRunnerTest extends TestCase
     {
         $ref = new ReflectionClass($runner);
         $m = $ref->getMethod($method);
-        $m->setAccessible(true);
 
         return $m->invokeArgs($runner, $args);
     }


### PR DESCRIPTION
## Summary

Upgrade the test toolchain to PHPUnit 11 and bump the PHP floor to 8.2 so we can drop the `audit.ignore` workaround for PHPUnit 10.x advisories.

- `composer.json`: `php` `^8.2`, `phpunit/phpunit` `^11.0`, removed `config.audit.ignore`
- `.github/workflows/ci.yml`: drop PHP 8.1 from the matrix (8.2 / 8.3 / 8.4 / 8.5 remain)
- `phpunit.xml`: schema reference moved to PHPUnit 11
- Tests: removed PHP 8.5-deprecated `ReflectionMethod::setAccessible()` call; existing data providers were already static `#[DataProvider]`
- Docs: `PHP ^8.1` → `^8.2` references updated

Closes #61

## Test plan

- [x] `composer cs-fix`
- [x] `composer sa` (PHPStan)
- [x] `vendor/bin/phpunit --no-coverage` — 255 tests, 586 assertions, 1 skipped (PHPUnit 11.5.55)
- [ ] CI matrix passes on PHP 8.2 / 8.3 / 8.4 / 8.5