### PR TITLE
chore: prepare release notes and clean up stale 8.1 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **xstep JSON ergonomics** (#74):
+  - `--pretty` for indented JSON output
+  - `--max-value-bytes=N` to truncate long string values (UTF-8 safe via `mb_strcut`)
+  - `--max-depth=N` to cap nested array/object rendering
+  - `function` and `stack` context attached to each break
+  - Scalar before/after `diff` and shallow key diffs between consecutive snapshots
+  - `breakpoint.id` / `breakpoint.label` attached to each break
+  - `recording_type` field (`full` | `diff`) documented in `docs/schemas/xstep.json`
 - **xcompare**: Compare variable states at breakpoint across two different executions
   - Runs xstep twice with different commands/inputs
   - Computes diff: changed, unchanged, only_in_a, only_in_b
   - Provides analysis_hints for AI-readable summary
   - JSON schema: `docs/schemas/xcompare.json`
   - Use case: Debug edge cases by comparing normal vs problematic inputs
-  - **NEW**: `--compare-with=REF` mode to compare current code vs another git branch/commit
+  - `--compare-with=REF` mode to compare current code vs another git branch/commit
     - `xcompare --break=file.php:25 --run="php test.php" --compare-with=main`
     - Automatically creates temporary worktree, runs comparison, cleans up
-    - Perfect for "before vs after" debugging
+- **`composer demo`** (#76): runs every CLI tool documented in the README against
+  the bundled `demo/` scripts and reports PASS/FAIL. Smoke test for users and CI.
+- **`bin/xrepl` and `bin/xcompare` exposed via `composer global require`** (#76):
+  both shipped in `bin/` but were missing from `composer.json`'s `bin` array.
+
+### Changed
+- **BREAKING — Drop PHP 8.1 support** (#75): minimum PHP version is now `^8.2`.
+  - Upgrade to PHPUnit 11 (`^11.0`), migrate test attributes (`#[DataProvider]`
+    static providers, removed `expectDeprecation*`, `assertObjectHasAttribute`).
+  - Remove `composer audit ignore` entries no longer needed under 8.2+.
+  - CI matrix runs on PHP 8.2 / 8.3 / 8.4 / 8.5.
+
+### Fixed
+- **README CLI examples** (#76):
+  - Drop the broken `--exit-on-break` flag from `xstep` examples (the parser
+    silently dropped it; default JSON mode already exits after recording).
+  - Interactive REPL section now invokes `xrepl` (not `xstep`).
+  - `xcoverage --raw` is required for plain PHP scripts; the previous example
+    failed with "Class coverage cannot be found" because the default PHPUnit
+    mode interpreted the script path as a test class.
+  - Replace hard-coded `~/.composer/vendor/bin/check-env` path with
+    `composer global config bin-dir`-based lookup so it works under XDG.
+- Document `--pretty` / `--max-value-bytes` / `--max-depth` in README CLI Usage.
+- Stale `php8.1` references in `profiler/examples/basic-usage.md` and
+  `src/McpServer.php` example messages updated to `php8.2`.
 
 ## [0.8.0] - 2026-01-30
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ composer global require koriym/xdebug-mcp
 ### 2. Verify Xdebug
 
 ```bash
-~/.composer/vendor/bin/check-env
+"$(composer global config bin-dir --absolute --quiet)/check-env"
 ```
 
 ### 3. (Optional) Wire up an AI assistant
@@ -158,7 +158,10 @@ xtrace -- php script.php
 xprofile -- php api.php
 
 # Debug with conditional breakpoint
-xstep --break='script.php:42:$user==null' --exit-on-break -- php script.php
+xstep --break='script.php:42:$user==null' -- php script.php
+
+# Pretty-print JSON, truncate long values, limit nesting depth
+xstep --break='script.php:42' --pretty --max-value-bytes=200 --max-depth=3 -- php script.php
 
 # Code coverage
 xcoverage -- vendor/bin/phpunit
@@ -217,10 +220,10 @@ Find the path with `which xdebug-mcp`. Restart your client after editing the con
 
 ## Interactive REPL
 
-For hands-on debugging without AI, use the interactive debugger:
+For hands-on debugging without AI, use the interactive debugger (`xrepl`):
 
 ```bash
-xstep --break="script.php:42" -- php script.php
+xrepl --break="script.php:42" -- php script.php
 ```
 
 **Commands:**
@@ -241,7 +244,7 @@ xstep --break="script.php:42" -- php script.php
 All tools work with Docker, Podman, and Kubectl:
 
 ```bash
-xstep --break="/app/script.php:42" --exit-on-break -- \
+xstep --break="/app/script.php:42" -- \
   docker compose run --rm php php /app/script.php
 
 xtrace -- docker compose run --rm php php /app/script.php

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Run the demo examples to see each tool in action:
 # Profile performance bottlenecks
 ./bin/xprofile --json -- php demo/slow.php
 
-# Analyze code coverage
-./bin/xcoverage -- php demo/coverage.php
+# Analyze code coverage (raw mode for plain PHP scripts)
+./bin/xcoverage --raw -- php demo/coverage.php
 
 # Get stack trace at breakpoint
 ./bin/xback --break="demo/buggy.php:44" -- php demo/buggy.php

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "test-json": "Run comprehensive JSON test suite with all xdebug commands",
         "install-mcp": "Configure xdebug-mcp for Claude Code MCP integration",
         "install-desktop": "Configure xdebug-mcp for Claude Desktop integration",
-        "check-env": "Check Xdebug environment and configuration"
+        "check-env": "Check Xdebug environment and configuration",
+        "demo": "Run every CLI tool documented in README against the demo scripts"
     },
     "scripts": {
         "test": "phpunit",
@@ -66,6 +67,7 @@
             "phpstan"
         ],
         "test-json": "./bin/test-json",
+        "demo": "./demo/run-demo.sh",
         "install-mcp": "./bin/check-env --install-mcp",
         "install-desktop": "./bin/check-env --install-desktop",
         "check-env": "./bin/check-env",

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,12 @@
     "bin": [
         "bin/xdebug-mcp",
         "bin/xstep",
+        "bin/xrepl",
         "bin/xtrace",
         "bin/xprofile",
         "bin/xcoverage",
         "bin/xback",
+        "bin/xcompare",
         "bin/check-env",
         "bin/test-json"
     ],

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run every CLI command documented in README.md against the demo scripts
+# and report PASS/FAIL for each. Used both as a developer smoke test
+# (`composer demo`) and as a hands-on tour of every tool.
+
+set -u
+
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+LOG=$(mktemp -t xdebug-mcp-demo.XXXXXX)
+trap 'rm -f "$LOG"' EXIT
+
+run() {
+    local label="$1"
+    shift
+    printf '\n=== %s ===\n' "$label"
+    printf '  $ %s\n' "$*"
+    if "$@" >"$LOG" 2>&1; then
+        printf '  PASS\n'
+        PASS=$((PASS + 1))
+        return 0
+    fi
+    local code=$?
+    printf '  FAIL (exit %d)\n' "$code"
+    sed 's/^/    /' "$LOG" | tail -10
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$label")
+    return 1
+}
+
+run "xstep: breakpoint debugging" \
+    ./bin/xstep --break="demo/buggy.php:22" -- php demo/buggy.php
+
+run "xstep: conditional breakpoint" \
+    ./bin/xstep --break='demo/buggy.php:22:$a==10' -- php demo/buggy.php
+
+run "xstep: --pretty / --max-value-bytes / --max-depth" \
+    ./bin/xstep --break="demo/buggy.php:22" --pretty --max-value-bytes=200 --max-depth=3 -- php demo/buggy.php
+
+run "xtrace: execution flow" \
+    ./bin/xtrace --context="Demo run" -- php demo/buggy.php
+
+run "xprofile: performance profiling" \
+    ./bin/xprofile --json -- php demo/slow.php
+
+run "xcoverage: coverage analysis (raw mode)" \
+    ./bin/xcoverage --raw -- php demo/coverage.php
+
+run "xback: stack trace at breakpoint" \
+    ./bin/xback --break="demo/buggy.php:44" -- php demo/buggy.php
+
+run "xcompare: compare two runs" \
+    ./bin/xcompare --break="demo/buggy.php:22" \
+        --run-a="php demo/buggy.php" \
+        --run-b="php demo/buggy.php"
+
+printf '\n=========================\n'
+printf 'PASS: %d  FAIL: %d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    printf 'Failed:\n'
+    for name in "${FAIL_NAMES[@]}"; do
+        printf '  - %s\n' "$name"
+    done
+fi
+exit "$FAIL"

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -5,7 +5,10 @@
 
 set -u
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || {
+    printf 'Failed to change directory to repository root\n' >&2
+    exit 1
+}
 
 PASS=0
 FAIL=0
@@ -56,6 +59,9 @@ run "xcompare: compare two runs" \
     ./bin/xcompare --break="demo/buggy.php:22" \
         --run-a="php demo/buggy.php" \
         --run-b="php demo/buggy.php"
+
+run "xrepl: CLI availability (--help smoke check)" \
+    ./bin/xrepl --help
 
 printf '\n=========================\n'
 printf 'PASS: %d  FAIL: %d\n' "$PASS" "$FAIL"

--- a/profiler/examples/basic-usage.md
+++ b/profiler/examples/basic-usage.md
@@ -134,7 +134,7 @@ jobs:
       - name: Setup PHP with Xdebug
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: '8.2'
           extensions: xdebug
           
       - name: Run Performance Test
@@ -166,7 +166,7 @@ jobs:
 
 ```dockerfile
 # Dockerfile for analysis environment
-FROM php:8.1-cli
+FROM php:8.2-cli
 
 # Install Xdebug
 RUN pecl install xdebug && docker-php-ext-enable xdebug

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -645,9 +645,9 @@ final class McpServer
             throw new InvalidArgumentException('Script argument is required');
         }
 
-        // Check that script starts with PHP binary (handles php, php8.1, /usr/bin/php, C:\php\php.exe, etc.)
+        // Check that script starts with PHP binary (handles php, php8.2, /usr/bin/php, C:\php\php.exe, etc.)
         if (! preg_match('/^(\S*[\/\\\\])?php([0-9.]*)?(\.exe)?(\\s+|$)/i', $script)) {
-            throw new InvalidArgumentException('Script must start with PHP binary. Examples: "php script.php", "php8.1 script.php", "/usr/bin/php script.php", "C:\php\php.exe script.php". Received: "' . $script . '"');
+            throw new InvalidArgumentException('Script must start with PHP binary. Examples: "php script.php", "php8.2 script.php", "/usr/bin/php script.php", "C:\php\php.exe script.php". Received: "' . $script . '"');
         }
     }
 


### PR DESCRIPTION
## Summary

Prep work before cutting the next release. Stacks on top of #76 (the README + composer-demo PR); please merge #76 first or rebase this branch onto 1.x once #76 lands.

## Changes

- **CHANGELOG.md**: fill in the \`[Unreleased]\` section with everything that has accumulated since 0.8.0 — xstep JSON ergonomics (#74), the PHPUnit 11 / PHP 8.2 floor (#75, **BREAKING**), and the README/composer-demo cleanup (#76). The version header is intentionally left as \`[Unreleased]\` so the maintainer picks the version at \`gh release create\` time (likely 1.0.0 given the breaking change).
- **\`profiler/examples/basic-usage.md\`**: bump CI \`php-version: 8.1\` and \`FROM php:8.1-cli\` to 8.2 (project floor is now 8.2).
- **\`src/McpServer.php\`**: update the PHP-binary validation error message to use \`php8.2\` instead of \`php8.1\` in its example list.

## Out of scope (intentionally)

The **xback \`\$schema\` URL bug** (xback outputs a body shaped by xstep with \`xstep.json\` schema) is left for a follow-up. The fix is non-trivial because \`DebugServer::gracefulExit()\` calls \`exit()\` before \`bin/xback\`'s transformation logic can run, and \`bin/xback\`'s parser also expects a stack format that DebugServer no longer emits. Tracking separately so it doesn't block the release.

## Test plan

- [x] \`composer cs-fix\` clean
- [x] \`composer test\` (PHPUnit) — 260 tests pass
- [ ] Reviewer confirms CHANGELOG entries match their understanding of #74 / #75 / #76
- [ ] Maintainer picks version (\`0.9.0\` vs \`1.0.0\`) at release time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced demo command for smoke-testing all CLI tools.
  * Enhanced xstep with JSON formatting, value size, and depth controls.
  * Expanded xcompare with richer breakpoint state comparison and metadata.
  * Exposed xrepl and xcompare as Composer executables.

* **Breaking Changes**
  * Minimum PHP version requirement raised to 8.2.

* **Bug Fixes**
  * Fixed Composer bin-dir path detection.
  * Corrected documentation and examples throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->