### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-30
+
 ### Added
 - **xstep JSON ergonomics** (#74):
   - `--pretty` for indented JSON output


### PR DESCRIPTION
## Summary

Cut release v0.9.0. Promotes the `[Unreleased]` section to `[0.9.0] - 2026-04-30`.

## Highlights

- **BREAKING**: drop PHP 8.1 support (#75) — minimum is now `^8.2`, PHPUnit 11
- New: `xcompare` breakpoint comparison tool, `xstep` JSON ergonomics (`--pretty`, `--max-value-bytes`, `--max-depth`), `composer demo`, `bin/xrepl` and `bin/xcompare` exposed via composer (#74, #76)
- README CLI examples corrected (#76)

See `CHANGELOG.md` for the full list.

## Test plan

- [x] `composer validate`
- [ ] After merge: tag `v0.9.0` and `gh release create`