### PR TITLE
Fix xcoverage / xback ergonomics for external projects (#79)

### DIFF
--- a/bin/xback
+++ b/bin/xback
@@ -19,6 +19,8 @@ function showHelp(): void
     echo "  --break=SPEC      Breakpoint (file.php:line)\n";
     echo "  --depth=N         Maximum stack depth to return (default: 10)\n";
     echo "  --context=TEXT    Context description for AI analysis\n";
+    echo "  --cwd=PATH        Run from PATH (target project root)\n";
+    echo "  --php=PATH        Use this PHP binary instead of the default 'php'\n";
     echo "  --help, -h        Show this help\n";
     echo "\n";
     echo "OUTPUT: Structured JSON (schema: xback.json)\n";
@@ -112,6 +114,8 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
     $breakpointStr = null;
     $depth = 10;
     $context = '';
+    $cwdOption = null;
+    $phpOverride = null;
     $command = [];
     $parseOptions = true;
 
@@ -140,6 +144,16 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
             continue;
         }
 
+        if ($parseOptions && str_starts_with($arg, '--cwd=')) {
+            $cwdOption = substr($arg, 6);
+            continue;
+        }
+
+        if ($parseOptions && str_starts_with($arg, '--php=')) {
+            $phpOverride = substr($arg, 6);
+            continue;
+        }
+
         if ($parseOptions && ($arg === '--help' || $arg === '-h')) {
             showHelp();
         }
@@ -153,8 +167,36 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
         showHelp();
     }
 
+    // Resolve --php against original cwd before chdir.
+    if ($phpOverride !== null && $phpOverride !== '') {
+        $resolved = realpath($phpOverride);
+        if ($resolved === false || !is_executable($resolved)) {
+            fwrite(STDERR, "Error: --php=$phpOverride not found or not executable\n");
+            exit(1);
+        }
+        $phpOverride = $resolved;
+    }
+
+    if ($cwdOption !== null && $cwdOption !== '') {
+        if (!is_dir($cwdOption) || !chdir($cwdOption)) {
+            fwrite(STDERR, "Error: --cwd=$cwdOption is not a directory or chdir failed\n");
+            exit(1);
+        }
+    }
+
     // Detect Docker/Podman/Kubectl commands
     $isDockerCommand = \Koriym\XdebugMcp\ContainerHelper::isContainerCommand($command);
+
+    // Apply --php override to local commands whose first token is a PHP binary.
+    if (
+        !$isDockerCommand
+        && $phpOverride !== null
+        && $phpOverride !== ''
+        && !empty($command)
+        && \Koriym\XdebugMcp\XdebugRunner::isPhpBinary($command[0])
+    ) {
+        $command[0] = $phpOverride;
+    }
 
     // Parse breakpoint now that we know if it's a Docker command
     if ($breakpointStr !== null) {

--- a/bin/xback
+++ b/bin/xback
@@ -187,16 +187,17 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
     // Detect Docker/Podman/Kubectl commands
     $isDockerCommand = \Koriym\XdebugMcp\ContainerHelper::isContainerCommand($command);
 
-    // Apply --php override to local commands whose first token is a PHP binary.
-    if (
+    // Decide whether the --php override should apply to the local command.
+    // Keep $command[0] as the literal 'php' so DebugServer's strict-equality
+    // check still selects the local-PHP execution branch; the actual override
+    // path is plumbed through DebugServer's `phpBinary` option below.
+    $applyPhpOverride = (
         !$isDockerCommand
         && $phpOverride !== null
         && $phpOverride !== ''
         && !empty($command)
         && \Koriym\XdebugMcp\XdebugRunner::isPhpBinary($command[0])
-    ) {
-        $command[0] = $phpOverride;
-    }
+    );
 
     // Parse breakpoint now that we know if it's a Docker command
     if ($breakpointStr !== null) {
@@ -247,6 +248,10 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
         'context' => $context,
         'maxSteps' => 1,
     ];
+
+    if ($applyPhpOverride) {
+        $options['phpBinary'] = $phpOverride;
+    }
 
     // Capture DebugServer output
     ob_start();

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -32,7 +32,16 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "  --raw                     Use raw Xdebug coverage (ignores @codeCoverageIgnore)\n";
     echo "  --branch-coverage         Enable branch/path coverage (--raw mode only)\n";
     echo "  --include-vendor=PATTERNS Include vendor packages (--raw mode only)\n";
+    echo "  --source=PATH[,PATH...]   Restrict raw coverage to these source paths\n";
+    echo "                              (--raw mode only; takes precedence over --include-vendor)\n";
+    echo "  --cwd=PATH                Run from PATH (target project root)\n";
+    echo "  --php=PATH                Use this PHP binary instead of " . PHP_BINARY . "\n";
     echo "  --help, -h                Show this help\n";
+    echo "\n";
+    echo "NOTES:\n";
+    echo "  --raw mode does not honor non-executable line metadata, so closing braces and\n";
+    echo "  declarations may appear as uncovered. Use the default PHPUnit mode for parity\n";
+    echo "  with php-code-coverage / Codecov.\n";
     echo "\n";
     echo "COMMON USAGE PATTERNS:\n";
     echo "  # Default: PHPUnit mode with @codeCoverageIgnore support\n";
@@ -55,11 +64,35 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
 
 // Parse options
 $optind = 0;
-$options = getopt('', ['include-vendor::', 'branch-coverage', 'raw'], $optind);
+$options = getopt('', ['include-vendor::', 'branch-coverage', 'raw', 'cwd:', 'php:', 'source:'], $optind);
 
 $includeVendor = $options['include-vendor'] ?? null;
 $branchCoverage = isset($options['branch-coverage']);
 $rawMode = isset($options['raw']);
+$cwdOption = $options['cwd'] ?? null;
+$phpOverride = $options['php'] ?? null;
+$sourceOption = $options['source'] ?? null;
+
+// Resolve --php against the original cwd before chdir.
+if ($phpOverride !== null && $phpOverride !== '') {
+    $resolved = realpath($phpOverride);
+    if ($resolved === false || !is_executable($resolved)) {
+        fwrite(STDERR, "Error: --php=$phpOverride not found or not executable\n");
+        exit(1);
+    }
+    $phpOverride = $resolved;
+}
+
+if ($cwdOption !== null && $cwdOption !== '') {
+    if (!is_dir($cwdOption) || !chdir($cwdOption)) {
+        fwrite(STDERR, "Error: --cwd=$cwdOption is not a directory or chdir failed\n");
+        exit(1);
+    }
+}
+
+if ($sourceOption !== null && $sourceOption !== '' && $includeVendor !== null) {
+    fwrite(STDERR, "Note: --source overrides --include-vendor (only one path filter is active at a time).\n");
+}
 
 // Get remaining arguments
 $args = $optind !== null ? array_slice($argv, $optind) : [];
@@ -149,7 +182,7 @@ if (!$rawMode) {
 
     // Get Xdebug flag for explicit loading
     $xdebugFlag = XdebugFinder::getXdebugFlag();
-    $phpPath = PHP_BINARY;
+    $phpPath = $phpOverride ?? PHP_BINARY;
 
     // Build PHPUnit command with coverage-clover (stable XML format)
     $phpunitArgs = array_merge(
@@ -300,17 +333,48 @@ $args = normalizeRawArguments($args);
 $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
 $branchFlag = $branchCoverage ? 'true' : 'false';
 $includeVendorRequire = '';
-if ($includeVendor !== null) {
+$sourceFilterEnabled = $sourceOption !== null && $sourceOption !== '';
+if ($includeVendor !== null && !$sourceFilterEnabled) {
     $filterPath = __DIR__ . '/../prepend_filter.php';
     $includeVendorRequire = 'require_once ' . var_export($filterPath, true) . ';';
     putenv('COVERAGE_INCLUDE_VENDOR=' . $includeVendor);
+}
+
+if ($sourceFilterEnabled) {
+    $resolvedSources = [];
+    foreach (explode(',', $sourceOption) as $candidate) {
+        $candidate = trim($candidate);
+        if ($candidate === '') {
+            continue;
+        }
+        $real = realpath($candidate);
+        if ($real === false) {
+            fwrite(STDERR, "Error: --source path not found: $candidate\n");
+            exit(1);
+        }
+        $resolvedSources[] = $real;
+    }
+    if ($resolvedSources === []) {
+        fwrite(STDERR, "Error: --source produced no valid paths\n");
+        exit(1);
+    }
+    $sourceLiteral = var_export($resolvedSources, true);
+} else {
+    $sourceLiteral = 'null';
 }
 
 file_put_contents($shutdownScript, '<?php
 ' . $includeVendorRequire . '
 $tempDir = sys_get_temp_dir();
 $branchCoverage = ' . $branchFlag . ';
-if ($branchCoverage) {
+$sourcePaths = ' . $sourceLiteral . ';
+if (is_array($sourcePaths) && $sourcePaths !== []) {
+    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_INCLUDE, $sourcePaths);
+    $coverageFlags = $branchCoverage
+        ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
+        : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+    xdebug_start_code_coverage($coverageFlags);
+} elseif ($branchCoverage) {
     xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, [getcwd() . "/vendor/", $tempDir]);
     xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK);
 } else {
@@ -425,7 +489,7 @@ register_shutdown_function(function() use ($tempDir, $branchCoverage) {
 });
 ');
 
-$phpPath = PHP_BINARY;
+$phpPath = $phpOverride ?? PHP_BINARY;
 $xdebugFlag = XdebugFinder::getXdebugFlag();
 $escapedPrependFile = escapeshellarg($shutdownScript);
 

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -166,7 +166,7 @@ final class DebugServer
     /** @var array{id: string, label: string, file: string, line: int, condition?: string}|null */
     private array|null $activeBreakpoint = null;
 
-    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null} $options */
+    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null, phpBinary?: string} $options */
     public function __construct(
         private readonly string $targetScript,
         private readonly int $debugPort,

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -354,8 +354,14 @@ final class DebugServer
                     $xdebugFlag = XdebugFinder::getXdebugFlag();
                     $xdebugPart = $xdebugFlag !== '' ? $xdebugFlag . ' ' : '';
 
+                    // Allow callers (e.g. xback --php=...) to override the spawned
+                    // PHP binary while keeping $command[0] as the literal 'php'.
+                    $phpBinary = ($this->options['phpBinary'] ?? '') !== ''
+                        ? (string) $this->options['phpBinary']
+                        : 'php';
+
                     $cmd = sprintf(
-                        'XDEBUG_SESSION=xdebug-mcp php %s'
+                        'XDEBUG_SESSION=xdebug-mcp %s %s'
                         . '-dxdebug.mode=debug,trace '
                         . '-dxdebug.start_with_request=yes '
                         . '-dxdebug.client_host=127.0.0.1 '
@@ -372,6 +378,7 @@ final class DebugServer
                         . '-derror_log=/tmp/php.log '
                         . '-dauto_prepend_file=%s '
                         . '%s',
+                        escapeshellarg($phpBinary),
                         $xdebugPart,
                         $this->debugPort,
                         escapeshellarg($prependFilter),
@@ -391,8 +398,13 @@ final class DebugServer
                 $xdebugFlag = XdebugFinder::getXdebugFlag();
                 $xdebugPart = $xdebugFlag !== '' ? $xdebugFlag . ' ' : '';
 
+                // Honor an optional PHP-binary override.
+                $phpBinary = ($this->options['phpBinary'] ?? '') !== ''
+                    ? (string) $this->options['phpBinary']
+                    : 'php';
+
                 $cmd = sprintf(
-                    'XDEBUG_SESSION=xdebug-mcp php %s'
+                    'XDEBUG_SESSION=xdebug-mcp %s %s'
                     . '-dxdebug.mode=debug,trace '
                     . '-dxdebug.start_with_request=yes '
                     . '-dxdebug.client_host=127.0.0.1 '
@@ -405,6 +417,7 @@ final class DebugServer
                     . '-dxdebug.connect_timeout_ms=5000 '
                     . '-dauto_prepend_file=%s '
                     . '%s',
+                    escapeshellarg($phpBinary),
                     $xdebugPart,
                     $this->debugPort,
                     escapeshellarg($prependFilter),

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -2306,6 +2306,18 @@ final class DebugServer
     }
 
     /**
+     * Strip XML 1.0 illegal control characters from a DBGp byte stream.
+     *
+     * Xdebug emits raw bytes (e.g., NUL inside anonymous-class names from PHP 8.3+)
+     * that libxml's strict parser rejects. We delete every byte that is illegal in
+     * XML 1.0 while preserving tab/LF/CR and any high-bit bytes (UTF-8 sequences).
+     */
+    private static function sanitizeDbgpXml(string $xml): string
+    {
+        return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $xml) ?? $xml;
+    }
+
+    /**
      * Parse XML response safely without error suppression
      */
     private function parseXmlResponse(string $xmlString): SimpleXMLElement|null
@@ -2318,7 +2330,7 @@ final class DebugServer
         $useErrors = libxml_use_internal_errors(true);
         libxml_clear_errors();
 
-        $xml = simplexml_load_string($xmlString);
+        $xml = simplexml_load_string(self::sanitizeDbgpXml($xmlString));
 
         // Get any errors that occurred
         $errors = libxml_get_errors();
@@ -2805,7 +2817,11 @@ final class DebugServer
             }
 
             $variables = [];
-            $xml = simplexml_load_string($response);
+            $useErrors = libxml_use_internal_errors(true);
+            libxml_clear_errors();
+            $xml = simplexml_load_string(self::sanitizeDbgpXml($response));
+            libxml_clear_errors();
+            libxml_use_internal_errors($useErrors);
             if ($xml && (property_exists($xml, 'property') && $xml->property !== null)) {
                 foreach ($xml->property as $prop) {
                     $name = (string) $prop['name'];
@@ -2944,7 +2960,11 @@ final class DebugServer
                 return null;
             }
 
-            $xml = simplexml_load_string($response);
+            $useErrors = libxml_use_internal_errors(true);
+            libxml_clear_errors();
+            $xml = simplexml_load_string(self::sanitizeDbgpXml($response));
+            libxml_clear_errors();
+            libxml_use_internal_errors($useErrors);
             if (! $xml || (! property_exists($xml, 'property') || $xml->property === null)) {
                 return null;
             }
@@ -3448,7 +3468,11 @@ final class DebugServer
     private function parseStackFrames(string $stackXml): array
     {
         try {
-            $xml = simplexml_load_string($stackXml);
+            $useErrors = libxml_use_internal_errors(true);
+            libxml_clear_errors();
+            $xml = simplexml_load_string(self::sanitizeDbgpXml($stackXml));
+            libxml_clear_errors();
+            libxml_use_internal_errors($useErrors);
             if (! $xml || (! property_exists($xml, 'stack') || $xml->stack === null)) {
                 return [];
             }
@@ -3547,7 +3571,11 @@ final class DebugServer
     private function extractLocationDataFromBreakResponse(string $response): array|null
     {
         try {
-            $xml = simplexml_load_string($response);
+            $useErrors = libxml_use_internal_errors(true);
+            libxml_clear_errors();
+            $xml = simplexml_load_string(self::sanitizeDbgpXml($response));
+            libxml_clear_errors();
+            libxml_use_internal_errors($useErrors);
             if ($xml) {
                 // Register xdebug namespace
                 $xml->registerXPathNamespace('xdebug', 'https://xdebug.org/dbgp/xdebug');

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -193,6 +193,21 @@ final class McpServer
                             'description' => 'Include vendor packages in coverage (e.g., "bear/*,ray/di" or "*/*" for all)',
                             'default' => '',
                         ],
+                        'cwd' => [
+                            'type' => 'string',
+                            'description' => 'Run from this directory (target project root)',
+                            'default' => '',
+                        ],
+                        'php' => [
+                            'type' => 'string',
+                            'description' => 'Path to the PHP binary to use instead of the default',
+                            'default' => '',
+                        ],
+                        'source' => [
+                            'type' => 'string',
+                            'description' => 'Restrict raw-mode coverage to these source paths (comma-separated). Mutually exclusive with include_vendor.',
+                            'default' => '',
+                        ],
                     ],
                     'required' => ['script'],
                 ],
@@ -220,6 +235,16 @@ final class McpServer
                         'context' => [
                             'type' => 'string',
                             'description' => 'Context description for backtrace analysis',
+                            'default' => '',
+                        ],
+                        'cwd' => [
+                            'type' => 'string',
+                            'description' => 'Run from this directory (target project root)',
+                            'default' => '',
+                        ],
+                        'php' => [
+                            'type' => 'string',
+                            'description' => 'Path to the PHP binary to use instead of the default',
                             'default' => '',
                         ],
                     ],
@@ -584,8 +609,8 @@ final class McpServer
         $mapping = match ($promptName) {
             'xtrace', 'xprofile' => ['script', 'context', 'include_vendor'],
             'xstep' => ['script', 'breakpoints', 'steps', 'context', 'include_vendor'],
-            'xcoverage' => ['script', 'context', 'include_vendor'],
-            'xback' => ['script', 'breakpoint', 'depth', 'context'],
+            'xcoverage' => ['script', 'context', 'include_vendor', 'cwd', 'php', 'source'],
+            'xback' => ['script', 'breakpoint', 'depth', 'context', 'cwd', 'php'],
             default => [],
         };
 
@@ -1067,6 +1092,9 @@ final class McpServer
             $this->validatePhpBinaryScript($script);
             $context = $args['context'] ?? '';
             $includeVendor = $args['include_vendor'] ?? '';
+            $cwd = $args['cwd'] ?? '';
+            $phpBinary = $args['php'] ?? '';
+            $source = $args['source'] ?? '';
 
             // Build command - user must specify PHP binary explicitly
             $cmd = $this->binDir . '/xcoverage';
@@ -1074,6 +1102,18 @@ final class McpServer
             // Add include_vendor option if specified
             if ($includeVendor !== '') {
                 $cmd .= ' --include-vendor=' . escapeshellarg($includeVendor);
+            }
+
+            if ($cwd !== '') {
+                $cmd .= ' --cwd=' . escapeshellarg($cwd);
+            }
+
+            if ($phpBinary !== '') {
+                $cmd .= ' --php=' . escapeshellarg($phpBinary);
+            }
+
+            if ($source !== '') {
+                $cmd .= ' --source=' . escapeshellarg($source);
             }
 
             $cmd .= ' -- ' . $script;
@@ -1129,6 +1169,8 @@ final class McpServer
             $context = $args['context'] ?? '';
             $breakpoint = $args['breakpoint'] ?? '';
             $depth = $args['depth'] ?? '10';
+            $cwd = $args['cwd'] ?? '';
+            $phpBinary = $args['php'] ?? '';
 
             // Build command
             $cmd = $this->binDir . '/xback';
@@ -1144,6 +1186,14 @@ final class McpServer
 
             if ($depth !== '' && (int) $depth > 0 && (int) $depth <= 1000) {
                 $cmd .= ' --depth=' . escapeshellarg((string) (int) $depth);
+            }
+
+            if ($cwd !== '') {
+                $cmd .= ' --cwd=' . escapeshellarg($cwd);
+            }
+
+            if ($phpBinary !== '') {
+                $cmd .= ' --php=' . escapeshellarg($phpBinary);
             }
 
             // Build command - user must specify PHP binary explicitly

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -34,6 +34,7 @@ use function unlink;
 use function var_export;
 
 use const JSON_THROW_ON_ERROR;
+use const PHP_BINARY;
 
 class XdebugCommandsTest extends TestCase
 {
@@ -404,6 +405,48 @@ PHP);
         $this->assertNotNull($output);
 
         // xback emits a single JSON document; --cwd should not break execution
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $payload = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('$schema', $payload);
+    }
+
+    public function testXbackPhpOption(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        // Resolve the current PHP binary as the override target. Using PHP_BINARY
+        // guarantees the path exists and is executable on the running system.
+        $phpBinary = realpath(PHP_BINARY);
+        if ($phpBinary === false || ! is_executable($phpBinary)) {
+            $this->markTestSkipped('Cannot resolve PHP_BINARY for --php override test');
+        }
+
+        $fixture = dirname(__DIR__) . '/fixtures/print_cwd.php';
+
+        // Run with --php pointing at an absolute PHP binary path. Without the
+        // fix this fails with "Custom command must start with 'php' or be a
+        // Docker/Podman/Kubectl command" because $command[0] becomes the
+        // absolute path and DebugServer's strict-equality check rejects it.
+        $command = sprintf(
+            'cd %s && ./bin/xback --php=%s -- php %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($phpBinary),
+            escapeshellarg($fixture),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringNotContainsString(
+            "must start with 'php'",
+            $output,
+            '--php override should not fall through to the DebugServer error path',
+        );
+
         $jsonStart = strrpos($output, '{"$schema"');
         $this->assertNotFalse($jsonStart, $output);
 

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -7,6 +7,7 @@ namespace Koriym\XdebugMcp\Tests\Integration;
 use Koriym\XdebugMcp\XdebugFinder;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
 use function bin2hex;
 use function dirname;
 use function escapeshellarg;
@@ -19,6 +20,7 @@ use function json_decode;
 use function json_encode;
 use function mkdir;
 use function random_bytes;
+use function realpath;
 use function rmdir;
 use function shell_exec;
 use function sprintf;
@@ -29,6 +31,7 @@ use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
 use function unlink;
+use function var_export;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -221,6 +224,100 @@ PHP);
         }
     }
 
+    public function testXcoverageRawSourceFilterExcludesSiblingFiles(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $root = dirname(__DIR__, 2);
+        $buildDir = $root . '/build';
+        if (! is_dir($buildDir)) {
+            mkdir($buildDir);
+        }
+
+        $fixtureDir = $buildDir . '/xcoverage_source_' . bin2hex(random_bytes(6));
+        $sourceDir = $fixtureDir . '/src';
+        $extraDir = $fixtureDir . '/extra';
+        mkdir($sourceDir, 0777, true);
+        mkdir($extraDir, 0777, true);
+
+        $sourceFile = $sourceDir . '/InSrc.php';
+        $extraFile = $extraDir . '/Sibling.php';
+        $entryFile = $fixtureDir . '/entry.php';
+
+        file_put_contents($sourceFile, <<<'PHP'
+<?php
+function in_src_call(): string
+{
+    $touched = 'covered';
+    $alsoTouched = 'still covered';
+    if ($touched === 'never') {
+        return 'unreachable';
+    }
+
+    return $touched . $alsoTouched;
+}
+PHP);
+
+        file_put_contents($extraFile, <<<'PHP'
+<?php
+function sibling_uncalled(): string
+{
+    $never = 'reached';
+    $also = 'never';
+    return $never . $also;
+}
+PHP);
+
+        file_put_contents($entryFile, sprintf(
+            "<?php\nrequire %s;\nrequire %s;\nin_src_call();\n",
+            var_export($sourceFile, true),
+            var_export($extraFile, true),
+        ));
+
+        try {
+            $command = sprintf(
+                'cd %s && ./bin/xcoverage --raw --source=%s -- php %s 2>&1',
+                escapeshellarg($root),
+                escapeshellarg($sourceDir),
+                escapeshellarg($entryFile),
+            );
+
+            $output = shell_exec($command);
+            $this->assertNotNull($output);
+
+            $jsonStart = strrpos($output, '{"$schema"');
+            $this->assertNotFalse($jsonStart, $output);
+
+            $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+
+            $resolvedExtra = realpath($extraDir);
+            $this->assertNotFalse($resolvedExtra);
+
+            // The sibling file should NOT appear in uncovered when --source is used
+            foreach (array_keys($coverage['uncovered'] ?? []) as $file) {
+                $this->assertStringNotContainsString($resolvedExtra, $file, 'Sibling file leaked into filtered raw coverage');
+            }
+        } finally {
+            foreach ([$entryFile, $extraFile, $sourceFile] as $f) {
+                if (! file_exists($f)) {
+                    continue;
+                }
+
+                unlink($f);
+            }
+
+            foreach ([$extraDir, $sourceDir, $fixtureDir] as $d) {
+                if (! is_dir($d)) {
+                    continue;
+                }
+
+                rmdir($d);
+            }
+        }
+    }
+
     public function testXstepCommandExists(): void
     {
         $this->assertTrue(file_exists(__DIR__ . '/../../bin/xstep'));
@@ -250,6 +347,69 @@ PHP);
         $this->assertNotNull($output);
         $this->assertStringContainsString('Usage:', $output);
         $this->assertStringContainsString('xback', $output);
+        $this->assertStringContainsString('--cwd=', $output);
+        $this->assertStringContainsString('--php=', $output);
+    }
+
+    public function testXcoverageHelp(): void
+    {
+        $output = shell_exec('cd ' . dirname(__DIR__, 2) . ' && ./bin/xcoverage --help 2>&1');
+        $this->assertNotNull($output);
+        $this->assertStringContainsString('Usage:', $output);
+        $this->assertStringContainsString('xcoverage', $output);
+        $this->assertStringContainsString('--cwd=', $output);
+        $this->assertStringContainsString('--php=', $output);
+        $this->assertStringContainsString('--source=', $output);
+    }
+
+    public function testXcoverageCwdOption(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $fixture = dirname(__DIR__) . '/fixtures/print_cwd.php';
+        $tmpDir = sys_get_temp_dir();
+
+        $command = sprintf(
+            'cd %s && ./bin/xcoverage --raw --cwd=%s -- php %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($tmpDir),
+            escapeshellarg($fixture),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        // print_cwd.php prints the cwd; --cwd should have made it the temp dir
+        $this->assertStringContainsString($tmpDir, $output);
+    }
+
+    public function testXbackCwdOption(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $fixture = dirname(__DIR__) . '/fixtures/print_cwd.php';
+        $tmpDir = sys_get_temp_dir();
+
+        $command = sprintf(
+            'cd %s && ./bin/xback --cwd=%s -- php %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($tmpDir),
+            escapeshellarg($fixture),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+
+        // xback emits a single JSON document; --cwd should not break execution
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $payload = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+        $this->assertArrayHasKey('$schema', $payload);
     }
 
     public function testAllCommandsAreExecutable(): void

--- a/tests/Unit/DebugServerXmlSanitizerTest.php
+++ b/tests/Unit/DebugServerXmlSanitizerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Unit;
+
+use Koriym\XdebugMcp\DebugServer;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+use function libxml_clear_errors;
+use function libxml_use_internal_errors;
+use function simplexml_load_string;
+use function strpos;
+
+class DebugServerXmlSanitizerTest extends TestCase
+{
+    private ReflectionMethod $sanitize;
+
+    protected function setUp(): void
+    {
+        $this->sanitize = new ReflectionMethod(DebugServer::class, 'sanitizeDbgpXml');
+        $this->sanitize->setAccessible(true);
+    }
+
+    public function testStripsNullByteFromAnonymousClassname(): void
+    {
+        $payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            . '<response classname="Ray\\MediaQuery\\PagesInterface@anonymous'
+            . "\x00"
+            . '/path/to/file.php:42"/>';
+
+        $clean = $this->sanitize->invoke(null, $payload);
+
+        $this->assertFalse(strpos($clean, "\x00"));
+
+        $useErrors = libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($clean);
+        libxml_clear_errors();
+        libxml_use_internal_errors($useErrors);
+
+        $this->assertNotFalse($xml);
+        $this->assertStringContainsString('@anonymous', (string) $xml['classname']);
+    }
+
+    public function testPreservesTabNewlineAndCarriageReturn(): void
+    {
+        $input = "a\tb\nc\rd";
+        $this->assertSame($input, $this->sanitize->invoke(null, $input));
+    }
+
+    public function testPreservesUtf8MultibyteSequences(): void
+    {
+        $input = 'こんにちは';
+        $this->assertSame($input, $this->sanitize->invoke(null, $input));
+    }
+
+    public function testStripsAdditionalC0Controls(): void
+    {
+        $input = "begin\x01\x05\x0B\x0C\x0E\x1F\x7Fend";
+        $this->assertSame('beginend', $this->sanitize->invoke(null, $input));
+    }
+}

--- a/tests/fixtures/print_cwd.php
+++ b/tests/fixtures/print_cwd.php
@@ -1,0 +1,3 @@
+<?php
+
+echo getcwd();


### PR DESCRIPTION
## Summary

Fixes [#79](https://github.com/koriym/xdebug-mcp/issues/79). When running `xcoverage` and `xback` against an external project (Ray.MediaQuery in the report), four real issues showed up:

1. **No way to set the working directory.** `xcoverage -- cd /path && phpunit ...` parses `cd` as the script (`Could not open input file: cd`).
2. **No way to override the PHP binary.** `xcoverage` ran the target with PHP 8.4 even though the project uses PHP 8.5.
3. **Vendor / `@swoole` stub paths leak into raw-mode JSON** despite PHPUnit's `--coverage-filter src` flag (Xdebug's `XDEBUG_PATH_EXCLUDE` doesn't match `--coverage-filter`).
4. **`xback` crashes parsing DBGp XML** when an anonymous class name contains a NUL byte (`PagesInterface@anonymous\0/path/file.php:42`, the format PHP 8.3+ emits): `simplexml_load_string(): xmlParseCharRef: invalid xmlChar value 0`.

This PR addresses 1–4. A fifth report (raw mode marking closing braces as uncovered) is documented as a `--raw` limitation in the help text and deferred — the default PHPUnit mode already gives php-code-coverage parity.

## Changes

### CLI

- `bin/xcoverage`: new `--cwd=PATH`, `--php=PATH`, `--source=PATH[,PATH…]`. `--source` uses Xdebug's `XDEBUG_PATH_INCLUDE` and takes precedence over `--include-vendor` (with a STDERR notice when both are set). `--php` is resolved against the original cwd before `chdir`. `--raw`-mode caveats noted in `--help`.
- `bin/xback`: new `--cwd=PATH`, `--php=PATH`. `--php` is resolved before `chdir`; the override is only applied when the first token of the command is a PHP binary (per `XdebugRunner::isPhpBinary()`), so `docker`/`composer`/etc. are left alone.

### MCP

- `src/McpServer.php`: `cwd`, `php`, `source` on the `xcoverage` tool; `cwd`, `php` on the `xback` tool. Positional-arg allowlists updated and the new flags plumbed through `executeXCoverage()` / `executeXBacktrace()` with `escapeshellarg()`.

### XML sanitizer (#5)

- `src/DebugServer.php`: new `sanitizeDbgpXml()` strips XML 1.0 illegal C0 control bytes (`\x00-\x08`, `\x0B`, `\x0C`, `\x0E-\x1F`, `\x7F`) while preserving `\x09`, `\x0A`, `\x0D`, and all UTF-8 multibyte sequences (`\x80-\xFF` left intact; intentionally no `/u` flag — DBGp is a byte stream). Applied at all five `simplexml_load_string()` call sites, which now also share `libxml_use_internal_errors` / `libxml_clear_errors` parity.

### Tests

- `tests/Unit/DebugServerXmlSanitizerTest.php` — sanitizer unit tests via `ReflectionMethod`: NUL byte stripped, tab/LF/CR preserved, UTF-8 preserved, additional C0 controls stripped.
- `tests/Integration/XdebugCommandsTest.php` — `testXcoverageHelp`, `testXcoverageCwdOption`, `testXcoverageRawSourceFilterExcludesSiblingFiles`, `testXbackCwdOption`; existing `testXbackHelp` extended.
- `tests/fixtures/print_cwd.php` — minimal cwd-printing fixture for the integration tests.

## Out of scope (mentioned for context)

- **Closing-brace uncovered lines in raw mode (#79 item 4):** raw mode uses `xdebug_get_code_coverage()` directly and doesn't compute non-executable line metadata. The default PHPUnit mode goes through `php-code-coverage` and already filters them. Documented in `--help`; a future change could add token/AST-level executable-line detection.
- **Diff coverage:** would slot in well as a follow-up `--diff[=REF]` option now that `--source` plumbing exists.
- `xtrace`/`xprofile`/`xstep`/`xcompare` could grow the same `--cwd`/`--php` options, but they go through `XdebugRunner` and need a deeper refactor — left for follow-up.

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/DebugServerXmlSanitizerTest.php` (4 tests)
- [x] `vendor/bin/phpunit tests/Integration/XdebugCommandsTest.php` (new + existing tests)
- [x] `vendor/bin/phpunit --no-coverage` full suite (268 tests, 1 skipped)
- [x] `composer cs-fix` clean
- [x] Manual: `./bin/xcoverage --cwd=/tmp --raw -- php tests/fixtures/print_cwd.php` — runs from `/tmp`, returns coverage JSON
- [x] Manual: `./bin/xback --cwd=/tmp -- php tests/fixtures/print_cwd.php` — runs from `/tmp`, returns valid JSON stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `xback` and `xcoverage` CLI tools now support `--cwd` to run from a target project root and `--php` to use an alternate PHP binary.
  * `xcoverage` adds `--source` option to filter coverage results to specific source paths.

* **Bug Fixes**
  * Improved XML parsing robustness to handle control characters in Xdebug responses.

* **Tests**
  * Added integration tests for new CLI options.
  * Added unit tests for XML sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->