### PR TITLE
Handle invalid XML character references

### DIFF
--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -60,6 +60,7 @@ use function getenv;
 use function glob;
 use function implode;
 use function in_array;
+use function intval;
 use function is_array;
 use function is_bool;
 use function is_float;
@@ -2322,12 +2323,41 @@ final class DebugServer
      * Strip XML 1.0 illegal control characters from a DBGp byte stream.
      *
      * Xdebug emits raw bytes (e.g., NUL inside anonymous-class names from PHP 8.3+)
-     * that libxml's strict parser rejects. We delete every byte that is illegal in
-     * XML 1.0 while preserving tab/LF/CR and any high-bit bytes (UTF-8 sequences).
+     * and can also surface invalid numeric character references such as &#0;.
+     * Both forms make libxml's strict parser reject the response.
      */
     private static function sanitizeDbgpXml(string $xml): string
     {
+        $xml = preg_replace_callback(
+            '/&#(x[0-9A-Fa-f]+|\d+);/',
+            static function (array $matches): string {
+                $value = $matches[1];
+                $isHex = $value[0] === 'x';
+                $digits = $isHex ? ltrim(substr($value, 1), '0') : ltrim($value, '0');
+                $digits = $digits === '' ? '0' : $digits;
+
+                if (strlen($digits) > ($isHex ? 6 : 7)) {
+                    return '';
+                }
+
+                $codepoint = $isHex ? intval($digits, 16) : (int) $digits;
+
+                return self::isXmlCharacter($codepoint) ? $matches[0] : '';
+            },
+            $xml,
+        ) ?? $xml;
+
         return preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $xml) ?? $xml;
+    }
+
+    private static function isXmlCharacter(int $codepoint): bool
+    {
+        return $codepoint === 0x09
+            || $codepoint === 0x0A
+            || $codepoint === 0x0D
+            || ($codepoint >= 0x20 && $codepoint <= 0xD7FF)
+            || ($codepoint >= 0xE000 && $codepoint <= 0xFFFD)
+            || ($codepoint >= 0x10000 && $codepoint <= 0x10FFFF);
     }
 
     /**

--- a/tests/Unit/DebugServerXmlSanitizerTest.php
+++ b/tests/Unit/DebugServerXmlSanitizerTest.php
@@ -20,7 +20,6 @@ class DebugServerXmlSanitizerTest extends TestCase
     protected function setUp(): void
     {
         $this->sanitize = new ReflectionMethod(DebugServer::class, 'sanitizeDbgpXml');
-        $this->sanitize->setAccessible(true);
     }
 
     public function testStripsNullByteFromAnonymousClassname(): void
@@ -58,6 +57,58 @@ class DebugServerXmlSanitizerTest extends TestCase
     public function testStripsAdditionalC0Controls(): void
     {
         $input = "begin\x01\x05\x0B\x0C\x0E\x1F\x7Fend";
+        $this->assertSame('beginend', $this->sanitize->invoke(null, $input));
+    }
+
+    public function testStripsInvalidNumericCharacterReferences(): void
+    {
+        $payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            . '<response classname="Ray\\MediaQuery\\PagesInterface@anonymous'
+            . '&#0;&#x0;&#x0B;'
+            . '/path/to/file.php:42" valid="&#9;&#10;&#13;&#x20;"/>';
+
+        $clean = $this->sanitize->invoke(null, $payload);
+
+        $this->assertStringNotContainsString('&#0;', $clean);
+        $this->assertStringNotContainsString('&#x0;', $clean);
+        $this->assertStringNotContainsString('&#x0B;', $clean);
+        $this->assertStringContainsString('&#9;&#10;&#13;&#x20;', $clean);
+
+        $useErrors = libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($clean);
+        libxml_clear_errors();
+        libxml_use_internal_errors($useErrors);
+
+        $this->assertNotFalse($xml);
+        $this->assertStringContainsString('@anonymous', (string) $xml['classname']);
+    }
+
+    public function testStripsInvalidXmlCodepointReferences(): void
+    {
+        $payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            . '<response invalid="&#11;&#xD800;&#xDFFF;&#xFFFE;&#xFFFF;&#x110000;" valid="&#x10000;"/>';
+
+        $clean = $this->sanitize->invoke(null, $payload);
+
+        $this->assertStringNotContainsString('&#11;', $clean);
+        $this->assertStringNotContainsString('&#xD800;', $clean);
+        $this->assertStringNotContainsString('&#xDFFF;', $clean);
+        $this->assertStringNotContainsString('&#xFFFE;', $clean);
+        $this->assertStringNotContainsString('&#xFFFF;', $clean);
+        $this->assertStringNotContainsString('&#x110000;', $clean);
+        $this->assertStringContainsString('&#x10000;', $clean);
+
+        $useErrors = libxml_use_internal_errors(true);
+        $xml = simplexml_load_string($clean);
+        libxml_clear_errors();
+        libxml_use_internal_errors($useErrors);
+
+        $this->assertNotFalse($xml);
+    }
+
+    public function testStripsOverlongNumericCharacterReferences(): void
+    {
+        $input = 'begin&#xFFFFFFFFFFFF;&#99999999;end';
         $this->assertSame('beginend', $this->sanitize->invoke(null, $input));
     }
 }


### PR DESCRIPTION
## Summary

- extend DBGp XML sanitization to remove invalid numeric character references such as `&#0;`, `&#x0;`, and other XML 1.0-invalid code points
- preserve valid XML character references like tab, newline, carriage return, space, and supplementary-plane code points
- remove the now-unnecessary `ReflectionMethod::setAccessible()` call from the sanitizer test on PHP 8.1+

## Why

PR #80 handles raw illegal control bytes from Xdebug responses. Issue #79 also showed the `xmlParseCharRef: invalid xmlChar value 0` form, where the invalid NUL arrives as a numeric XML character reference. libxml rejects that before parsing, so the sanitizer needs to cover both representations.

## Test plan

- `zsh -ic 'sphp85; vendor/bin/phpunit tests/Unit/DebugServerXmlSanitizerTest.php'`
- `zsh -ic 'sphp85; composer cs'`
- `zsh -ic 'sphp85; php -d memory_limit=512M ./vendor/bin/phpstan'`
- `zsh -ic 'sphp85; composer test'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened XML data sanitization to properly decode and validate numeric character references, removing those that don't conform to XML standards.

* **Tests**
  * Added comprehensive test coverage for XML sanitization validation, including invalid character references and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->