### PR TITLE
Clean up CLI help and vendor filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Core code lives in `src/` under the `Koriym\XdebugMcp` namespace; CLI entrypoints are in `bin/` (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`, `check-env`).
+- Tests are in `tests/` (`Unit/`, `Integration/`, `docker/`, `ai/`), with fixtures under `tests/fixtures` and fake data under `tests/fake`.
+- Documentation and assets reside in `docs/`; sample scenarios are under `demo/`; profiler helpers live in `profiler/`.
+- Quality configs: `phpcs.xml`, `phpstan.neon`, `psalm.xml`, `rector.php`, `phpunit.xml`.
+
+## Build, Test, and Development Commands
+- Install deps: `composer install`.
+- Fast test run: `composer test` (PHPUnit).
+- Full gate: `composer tests` (coding standard, static analysis, then PHPUnit).
+- Coverage: `composer coverage` (uses `bin/xcoverage` + PHPUnit, writes to `build/coverage`).
+- Static analysis: `composer sa` (PHPStan) and `composer psalm`.
+- Coding standard: `composer cs` / autofix with `composer cs-fix`.
+- Environment helpers: `composer check-env`, `composer install-mcp`, `composer install-desktop`.
+
+## Public Output Hygiene
+- Do not include local shell aliases, machine-specific PHP selector names, absolute private setup paths, or private environment setup details in public-facing docs, commits, PR bodies, issue comments, release notes, or examples.
+- When reporting validation publicly, translate local setup commands to portable project commands such as `composer test`, `composer demo`, `composer cs`, `composer validate --strict`, or `php -d memory_limit=512M ./vendor/bin/phpstan`.
+
+## Coding Style & Naming Conventions
+- Follow PSR-12 with Doctrine Coding Standard tweaks (`phpcs.xml`); 4-space indent, trailing commas where allowed, single quotes unless interpolation needed.
+- Namespace paths mirror `src/` layout; classes/interfaces use `PascalCase`, methods/properties `camelCase`; tests end with `*Test.php`.
+- Prefer typed properties/parameters/returns; keep public surface minimal and log through PSR-3.
+- Run `composer cs` and `composer sa` before pushing; commit fixes in separate change sets when practical.
+
+## Testing Guidelines
+- Framework: PHPUnit (`phpunit.xml`). Place new unit specs in `tests/Unit`, integration in `tests/Integration`; name files `{Subject}Test.php`.
+- Use data providers for matrix cases; prefer deterministic fixtures in `tests/fixtures`.
+- For coverage-sensitive work, run `composer coverage`; for end-to-end CLI checks, `composer test-json`.
+- Include failing test reproduction when fixing bugs; keep Docker-related scenarios under `tests/docker`.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short and prefixed by scope (e.g., `docs: ...`, `refactor: ...`, `fix: ...`); group unrelated changes into separate commits.
+- PRs should describe intent, approach, and risk; link issues when available and paste relevant CLI output (test/coverage snapshots, `check-env` for environment changes).
+- Add screenshots or logs when touching docs/UX or CLI output formatting; note any required Xdebug/runtime configuration adjustments.
+
+## Security & Configuration Notes
+- Xdebug must be installed but normally disabled; use `bin/check-env` to verify and to set up MCP/Claude integration (`.mcp.json` or `.claude/skills` symlink).
+- Avoid committing secrets in example configs; prefer environment variables and keep sample credentials in `demo/` only.

--- a/bin/README.md
+++ b/bin/README.md
@@ -10,7 +10,7 @@ Public debugging commands start with `x`. Helper scripts such as `check-env` and
 Interactive step debugging with conditional breakpoints and Forward Trace™ capabilities.
 ```bash
 # Interactive debugging session
-./xrepl --break='script.php:10' -- php script.php
+./xstep --break='script.php:10' -- php script.php
 
 # Conditional breakpoints (Forward Trace)
 ./xstep --break='User.php:42:$id==null' -- php script.php

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,6 +1,8 @@
 # Xdebug MCP Tools
 
-This directory contains executable tools for PHP debugging, profiling, and analysis using Xdebug and MCP (Model Context Protocol).
+This directory contains CLI tools for PHP debugging, profiling, and analysis using Xdebug and MCP (Model Context Protocol).
+
+Public debugging commands start with `x`. Helper scripts such as `check-env` and `test-json` are development or setup utilities, not debugging commands.
 
 ## Core Debugging Tools
 
@@ -8,23 +10,23 @@ This directory contains executable tools for PHP debugging, profiling, and analy
 Interactive step debugging with conditional breakpoints and Forward Trace™ capabilities.
 ```bash
 # Interactive debugging session
-./xstep script.php
+./xrepl --break='script.php:10' -- php script.php
 
 # Conditional breakpoints (Forward Trace)
-./xstep --break='User.php:42:$id==null' --exit-on-break -- php script.php
+./xstep --break='User.php:42:$id==null' -- php script.php
 
 # Step recording with JSON output
-./xstep --break='loop.php:15' --steps=100 --json -- php script.php
+./xstep --break='loop.php:15' --steps=100 -- php script.php
 
 # Multiple conditions (first match triggers)
-./xstep --break='Auth.php:20:empty($token),User.php:85:$id==0' --exit-on-break -- php app.php
+./xstep --break='Auth.php:20:empty($token),User.php:85:$id==0' -- php app.php
 ```
 
 ### `./xprofile`
 Performance profiling with microsecond precision and AI analysis integration.
 ```bash
 # Basic profiling
-./xprofile script.php
+./xprofile -- php script.php
 
 # With context for AI analysis
 ./xprofile --context="API endpoint performance" -- php api.php
@@ -37,7 +39,7 @@ Performance profiling with microsecond precision and AI analysis integration.
 Execution flow tracing with complete function call analysis.
 ```bash
 # Basic execution tracing
-./xtrace script.php
+./xtrace -- php script.php
 
 # With context documentation
 ./xtrace --context="Authentication flow analysis" -- php login.php
@@ -50,13 +52,13 @@ Execution flow tracing with complete function call analysis.
 Code coverage analysis with multiple output formats.
 ```bash
 # Basic coverage analysis
-./xcoverage tests/MyTest.php
+./xcoverage -- php ./vendor/bin/phpunit tests/MyTest.php
 
-# With context
-./xcoverage --context="Unit test coverage verification" -- php vendor/bin/phpunit tests/
+# Raw coverage for any PHP script
+./xcoverage --raw -- php app.php
 
-# Multiple formats: HTML, XML, JSON, text
-./xcoverage --format=html --format=json -- php tests/suite.php
+# Limit raw coverage to source paths
+./xcoverage --raw --source=src -- php app.php
 ```
 
 ### `./xcompare`
@@ -80,16 +82,6 @@ Compare variable states at the same breakpoint across two different executions.
 >
 > **Steps default:** `xcompare` defaults to `--steps=1` because the comparison only needs the variable snapshot at the breakpoint. Use `--steps=N` (e.g. `--steps=100`) to also capture how execution diverges after the break.
 
-### `./xdebug-phpunit`
-PHPUnit integration with Xdebug profiling and coverage.
-```bash
-# Run PHPUnit with Xdebug integration
-./xdebug-phpunit tests/UserTest.php
-
-# With context for analysis
-./xdebug-phpunit --context="User authentication tests" tests/AuthTest.php
-```
-
 ## MCP Protocol Tools
 
 ### `./xdebug-mcp`
@@ -105,7 +97,7 @@ MCP_DEBUG=1 ./xdebug-mcp
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | ./xdebug-mcp
 ```
 
-## Utility Tools
+## Utility Scripts
 
 ### `./check-env`
 Environment verification script - checks Xdebug installation and configuration.
@@ -115,17 +107,16 @@ Environment verification script - checks Xdebug installation and configuration.
 ```
 
 ### `./test-json`
-JSON validation and testing utility for MCP protocol compliance.
+Internal JSON regression script for development.
 ```bash
 ./test-json
-# Tests: JSON schema validation, MCP tool responses, output format compliance
 ```
 
 ### `./validate-profile-json`
 Profile data validation utility for ensuring schema compliance.
 ```bash
 ./validate-profile-json profile-data.json
-# Validates against: https://koriym.github.io/xdebug-mcp/schemas/xdebug-profile.json
+# Validates against: https://koriym.github.io/xdebug-mcp/schemas/xprofile.json
 ```
 
 ### `./autoload.php`
@@ -149,13 +140,12 @@ Legacy debugging server utility (development purposes).
 - `xcoverage` - Test coverage verification
 - `xcompare` - Compare variable states across two executions
 
-**Integration Tools:**
+**Integration Command:**
 - `xdebug-mcp` - AI assistant protocol handler
-- `xdebug-phpunit` - Test framework integration
 
-**Support Tools:**
+**Support Scripts:**
 - `check-env` - Environment validation
-- `test-json` - Protocol compliance testing
+- `test-json` - Internal JSON regression script
 - `validate-profile-json` - Schema validation
 
 ## Common Usage Patterns
@@ -163,7 +153,7 @@ Legacy debugging server utility (development purposes).
 ### Bug Investigation
 ```bash
 # Catch specific problem conditions
-./xstep --break='ErrorHandler.php:45:$error_code>400' --exit-on-break -- php api.php
+./xstep --break='ErrorHandler.php:45:$error_code>400' -- php api.php
 ```
 
 ### Performance Analysis
@@ -175,7 +165,7 @@ Legacy debugging server utility (development purposes).
 ### Test Coverage Verification
 ```bash
 # Analyze test effectiveness
-./xcoverage --context="AuthController test coverage" -- php vendor/bin/phpunit tests/AuthTest.php
+./xcoverage -- php ./vendor/bin/phpunit tests/AuthTest.php
 ```
 
 ### Complex Flow Understanding
@@ -193,4 +183,4 @@ Legacy debugging server utility (development purposes).
   --context='Email validation comparison'
 ```
 
-All tools support `--help` option for detailed usage information.
+Run `--help` on any `x*` command for detailed usage information.

--- a/bin/test-json
+++ b/bin/test-json
@@ -4,9 +4,9 @@
 declare(strict_types=1);
 
 /**
- * JSON Test Runner - Execute various xdebug commands and display results
+ * Internal JSON regression script.
  * 
- * This script runs a comprehensive suite of xdebug commands demonstrating:
+ * This script runs a small suite of x* CLI tools demonstrating:
  * - Forward trace debugging
  * - Performance profiling  
  * - Code coverage analysis
@@ -14,14 +14,14 @@ declare(strict_types=1);
  */
 
 $commands = [
-    'Forward Trace - Loop Counter' => './bin/xdebug-trace --json -- php tests/fake/loop-counter.php',
-    'Forward Trace - Array Manipulation' => './bin/xdebug-debug --context=ArrayManipulationTest --break=tests/fake/array-manipulation.php:8,tests/fake/array-manipulation.php:14,tests/fake/array-manipulation.php:18 --json --exit-on-break -- php tests/fake/array-manipulation.php',
-    'Forward Trace - Object State' => './bin/xdebug-debug --context=ObjectStateTest --break=tests/fake/object-state.php:12,tests/fake/object-state.php:19,tests/fake/object-state.php:23 --json --exit-on-break -- php tests/fake/object-state.php',
-    'Forward Trace - Conditional Logic' => './bin/xdebug-debug --context=ConditionalLogicTest --break=tests/fake/conditional-logic.php:8,tests/fake/conditional-logic.php:18,tests/fake/conditional-logic.php:21 --json --exit-on-break -- php tests/fake/conditional-logic.php',
-    'Profile - Loop Counter' => './bin/xdebug-profile --json -- php tests/fake/loop-counter.php',
-    'Profile - Array Manipulation' => './bin/xdebug-profile --json -- php tests/fake/array-manipulation.php',
-    'Coverage - Loop Counter' => './bin/xdebug-coverage -- php tests/fake/loop-counter.php',
-    'Coverage - Array Manipulation' => './bin/xdebug-coverage -- php tests/fake/array-manipulation.php',
+    'Trace - Loop Counter' => './bin/xtrace --json -- php tests/fake/loop-counter.php',
+    'Step - Array Manipulation' => './bin/xstep --context=ArrayManipulationTest --break=tests/fake/array-manipulation.php:10,tests/fake/array-manipulation.php:16,tests/fake/array-manipulation.php:25 -- php tests/fake/array-manipulation.php',
+    'Step - Object State' => './bin/xstep --context=ObjectStateTest --break=tests/fake/object-state.php:16,tests/fake/object-state.php:28,tests/fake/object-state.php:48 -- php tests/fake/object-state.php',
+    'Step - Conditional Logic' => './bin/xstep --context=ConditionalLogicTest --break=tests/fake/conditional-logic.php:11,tests/fake/conditional-logic.php:21,tests/fake/conditional-logic.php:35 -- php tests/fake/conditional-logic.php',
+    'Profile - Loop Counter' => './bin/xprofile --json -- php tests/fake/loop-counter.php',
+    'Profile - Array Manipulation' => './bin/xprofile --json -- php tests/fake/array-manipulation.php',
+    'Coverage - Loop Counter' => './bin/xcoverage --raw -- php tests/fake/loop-counter.php',
+    'Coverage - Array Manipulation' => './bin/xcoverage --raw -- php tests/fake/array-manipulation.php',
 ];
 
 $results = [];

--- a/bin/validate-profile-json
+++ b/bin/validate-profile-json
@@ -11,7 +11,7 @@ use JsonSchema\Constraints\Constraint;
 if (count($argv) < 2) {
     echo "Usage: validate-profile-json <profile-json-file>\n";
     echo "\n";
-    echo "Validates a profile JSON file against the xdebug-profile.json schema.\n";
+    echo "Validates a profile JSON file against the xprofile.json schema.\n";
     echo "\n";
     echo "Examples:\n";
     echo "  validate-profile-json profile-output.json\n";
@@ -21,7 +21,7 @@ if (count($argv) < 2) {
 }
 
 $jsonFile = $argv[1];
-$schemaPath = __DIR__ . '/../docs/schemas/xdebug-profile.json';
+$schemaPath = __DIR__ . '/../docs/schemas/xprofile.json';
 
 if (!file_exists($jsonFile)) {
     echo "❌ Error: JSON file not found: $jsonFile\n";
@@ -54,7 +54,7 @@ try {
     if ($validator->isValid()) {
         echo "✅ Profile JSON is valid and conforms to schema!\n";
         echo "📁 File: $jsonFile\n";
-        echo "📋 Schema: xdebug-profile.json\n";
+        echo "📋 Schema: xprofile.json\n";
         exit(0);
     } else {
         echo "❌ Profile JSON validation failed:\n\n";

--- a/bin/xcompare
+++ b/bin/xcompare
@@ -32,7 +32,7 @@ function showCompareHelp(): void
     echo "  --steps=N                Steps to record after breakpoint (default: 1)\n";
     echo "                           xcompare only reads the break-point snapshot; raise this\n";
     echo "                           when you want to inspect how execution diverges after the break.\n";
-    echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
+    echo "  --include-vendor=PATTERNS Include matching vendor packages in trace\n";
     echo "  --help, -h               Show this help\n";
     echo "\n";
     echo "EXAMPLES:\n";

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -4,6 +4,7 @@
 // Load autoloader
 require_once __DIR__ . '/autoload.php';
 use Koriym\XdebugMcp\XdebugFinder;
+use Koriym\XdebugMcp\Utilities\VendorFilter;
 
 // Xdebug's sentinel value for "exit" branch target in branch coverage data
 const XDEBUG_BRANCH_EXIT_SENTINEL = 2147483645;
@@ -15,8 +16,8 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "AI-Optimized PHP Code Coverage Collection Tool\n";
     echo "\n";
     echo "PURPOSE:\n";
-    echo "  Superior alternative to PHPUnit's HTML/XML coverage reports for AI analysis.\n";
-    echo "  Provides streamlined JSON coverage data that AI can immediately analyze\n";
+    echo "  Collect compact coverage data for CLI and AI-assisted analysis.\n";
+    echo "  Provides streamlined JSON coverage data that can be analyzed\n";
     echo "  without browser interaction or file navigation overhead.\n";
     echo "\n";
     echo "MODES:\n";
@@ -31,7 +32,7 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "OPTIONS:\n";
     echo "  --raw                     Use raw Xdebug coverage (ignores @codeCoverageIgnore)\n";
     echo "  --branch-coverage         Enable branch/path coverage (--raw mode only)\n";
-    echo "  --include-vendor=PATTERNS Include vendor packages (--raw mode only)\n";
+    echo "  --include-vendor=PATTERNS Include matching vendor packages (--raw mode only)\n";
     echo "  --source=PATH[,PATH...]   Restrict raw coverage to these source paths\n";
     echo "                              (--raw mode only; takes precedence over --include-vendor)\n";
     echo "  --cwd=PATH                Run from PATH (target project root)\n";
@@ -332,13 +333,15 @@ if (!$rawMode) {
 $args = normalizeRawArguments($args);
 $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
 $branchFlag = $branchCoverage ? 'true' : 'false';
-$includeVendorRequire = '';
 $sourceFilterEnabled = $sourceOption !== null && $sourceOption !== '';
-if ($includeVendor !== null && !$sourceFilterEnabled) {
-    $filterPath = __DIR__ . '/../prepend_filter.php';
-    $includeVendorRequire = 'require_once ' . var_export($filterPath, true) . ';';
-    putenv('COVERAGE_INCLUDE_VENDOR=' . $includeVendor);
+$vendorExcludePaths = [];
+if (! $sourceFilterEnabled) {
+    $vendorPath = getcwd() . '/vendor';
+    if (is_dir($vendorPath)) {
+        $vendorExcludePaths = VendorFilter::excludePaths($vendorPath, $includeVendor);
+    }
 }
+$vendorExcludePathsLiteral = var_export($vendorExcludePaths, true);
 
 if ($sourceFilterEnabled) {
     $resolvedSources = [];
@@ -364,22 +367,26 @@ if ($sourceFilterEnabled) {
 }
 
 file_put_contents($shutdownScript, '<?php
-' . $includeVendorRequire . '
 $tempDir = sys_get_temp_dir();
 $branchCoverage = ' . $branchFlag . ';
 $sourcePaths = ' . $sourceLiteral . ';
+$vendorExcludePaths = ' . $vendorExcludePathsLiteral . ';
 if (is_array($sourcePaths) && $sourcePaths !== []) {
     xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_INCLUDE, $sourcePaths);
     $coverageFlags = $branchCoverage
         ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
         : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
     xdebug_start_code_coverage($coverageFlags);
-} elseif ($branchCoverage) {
-    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, [getcwd() . "/vendor/", $tempDir]);
-    xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK);
 } else {
-    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, [getcwd() . "/vendor/", getcwd() . "/tests/", $tempDir]);
-    xdebug_start_code_coverage(XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+    $excludePaths = array_merge([$tempDir], $vendorExcludePaths);
+    if (! $branchCoverage) {
+        $excludePaths[] = getcwd() . "/tests/";
+    }
+    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
+    $coverageFlags = $branchCoverage
+        ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
+        : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+    xdebug_start_code_coverage($coverageFlags);
 }
 register_shutdown_function(function() use ($tempDir, $branchCoverage) {
     $coverage = xdebug_get_code_coverage();

--- a/bin/xprofile
+++ b/bin/xprofile
@@ -7,6 +7,7 @@ declare(strict_types=1);
 $projectRoot = require __DIR__ . '/autoload.php';
 
 use Koriym\XdebugMcp\XdebugRunner;
+use Koriym\XdebugMcp\Utilities\VendorFilter;
 
 function showHelp(string $scriptName): void
 {
@@ -15,8 +16,7 @@ function showHelp(string $scriptName): void
     echo "⚡ AI-Optimized PHP Performance Profiler with Docker Support\n";
     echo "\n";
     echo "PURPOSE:\n";
-    echo "  Scientific approach to PHP performance optimization. Identify actual bottlenecks\n";
-    echo "  with precision data rather than guesswork.\n";
+    echo "  Profile PHP execution and identify bottlenecks with runtime data.\n";
     echo "\n";
     echo "KEY BENEFITS:\n";
     echo "  ✅ Precision bottleneck identification: Know exactly which functions are slow\n";
@@ -28,7 +28,7 @@ function showHelp(string $scriptName): void
     echo "  --json                      AI-optimized JSON output\n";
     echo "  --claude                    Auto-analyze profile data with Claude AI\n";
     echo "  --context=TEXT             Add contextual description for AI analysis\n";
-    echo "  --include-vendor=PATTERNS  Include vendor packages in performance analysis\n";
+    echo "  --include-vendor=PATTERNS  Include matching vendor packages in analysis\n";
     echo "  --help, -h                 Show this help\n";
     echo "\n";
     echo "EXAMPLES:\n";
@@ -62,7 +62,7 @@ if (isset($argv[1]) && ($argv[1] === '--help' || $argv[1] === '-h')) {
 $separatorIndex = array_search('--', $argv);
 if ($separatorIndex === false) {
     fwrite(STDERR, "❌ Error: Missing '--' separator\n");
-    fwrite(STDERR, "Usage: xdebug-profile [options] -- command\n");
+    fwrite(STDERR, "Usage: {$argv[0]} [options] -- command\n");
     exit(1);
 }
 
@@ -119,7 +119,7 @@ try {
         exit(1);
     }
 
-    $result = generateEnhancedProfileData($profileFile, $jsonOutput, $context, $scriptOutput);
+    $result = generateEnhancedProfileData($profileFile, $jsonOutput, $context, $scriptOutput, $includeVendor);
 
     if ($jsonOutput) {
         // AI-optimized compact JSON output
@@ -148,7 +148,7 @@ try {
     exit(1);
 }
 
-function generateEnhancedProfileData(string $profileFile, bool $jsonOutput = false, ?string $context = null, ?string $scriptOutput = null): array
+function generateEnhancedProfileData(string $profileFile, bool $jsonOutput = false, ?string $context = null, ?string $scriptOutput = null, ?string $includeVendor = null): array
 {
     if (!file_exists($profileFile) || !is_readable($profileFile)) {
         throw new \RuntimeException("Profile file not found or not readable: $profileFile");
@@ -157,7 +157,7 @@ function generateEnhancedProfileData(string $profileFile, bool $jsonOutput = fal
     $fileSize = filesize($profileFile);
 
     // Comprehensive analysis
-    $stats = analyzeCachegrindFile($profileFile);
+    $stats = analyzeCachegrindFile($profileFile, $includeVendor);
 
     if ($jsonOutput) {
         $result = [
@@ -213,7 +213,7 @@ function generateEnhancedProfileData(string $profileFile, bool $jsonOutput = fal
     }
 }
 
-function analyzeCachegrindFile(string $profileFile): array
+function analyzeCachegrindFile(string $profileFile, ?string $includeVendor = null): array
 {
     $stats = [
         'total_lines' => 0,
@@ -258,13 +258,30 @@ function analyzeCachegrindFile(string $profileFile): array
     // Parse functions for classification and analysis
     $functionCosts = [];
     $currentFunction = null;
+    $currentFile = null;
+    $fileAliases = [];
     
     foreach ($lines as $line) {
         $line = trim($line);
         
+        if (preg_match('/^fl=\((\d+)\)\s+(.+)$/', $line, $matches)) {
+            $currentFile = $matches[2];
+            $fileAliases[$matches[1]] = $currentFile;
+            continue;
+        }
+
+        if (preg_match('/^fl=\((\d+)\)$/', $line, $matches)) {
+            $currentFile = $fileAliases[$matches[1]] ?? null;
+            continue;
+        }
+
         // Function definitions
         if (strpos($line, 'fn=') === 0) {
             $currentFunction = substr($line, 3);
+            if (! shouldIncludeProfileFile($currentFile, $includeVendor)) {
+                $currentFunction = null;
+                continue;
+            }
             
             // Skip empty function references (just numbers like "(19)")
             if (preg_match('/^\(\d+\)$/', $currentFunction)) {
@@ -389,6 +406,31 @@ function analyzeCachegrindFile(string $profileFile): array
     // Estimate call depth (simplified)
 
     return $stats;
+}
+
+function shouldIncludeProfileFile(?string $file, ?string $includeVendor): bool
+{
+    if ($file === null || $file === '' || $file === 'php:internal') {
+        return true;
+    }
+
+    $normalised = str_replace('\\', '/', $file);
+    $vendorPos = strpos($normalised, '/vendor/');
+    if ($vendorPos === false) {
+        return true;
+    }
+
+    if ($includeVendor === null || trim($includeVendor) === '') {
+        return false;
+    }
+
+    $relative = substr($normalised, $vendorPos + strlen('/vendor/'));
+    $segments = explode('/', $relative);
+    if (count($segments) < 2) {
+        return VendorFilter::matchesPackage('*/*', $includeVendor);
+    }
+
+    return VendorFilter::matchesPackage($segments[0] . '/' . $segments[1], $includeVendor);
 }
 
 function displayHumanReadableProfile(array $result): void

--- a/bin/xstep
+++ b/bin/xstep
@@ -31,7 +31,7 @@ function showHelp(string $commandName = 'xstep'): void
         echo "\n";
         echo "CORE OPTIONS:\n";
         echo "  --break=SPEC            Set breakpoints (file.php:line or file.php:line:condition)\n";
-        echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
+        echo "  --include-vendor=PATTERNS Include matching vendor packages in trace\n";
         echo "  --help, -h              Show this help\n";
     } else {
         echo "Usage: xstep [options] [--] command\n";
@@ -40,8 +40,8 @@ function showHelp(string $commandName = 'xstep'): void
         echo "🔍 AI-Optimized PHP Step Debugger\n";
         echo "\n";
         echo "PURPOSE:\n";
-        echo "  Revolutionary approach to PHP debugging - no var_dump(), no print_r(), no code modification.\n";
-        echo "  Provides runtime execution analysis through breakpoints and variable inspection.\n";
+        echo "  Debug PHP without var_dump(), print_r(), or source edits.\n";
+        echo "  Captures runtime state through breakpoints and variable inspection.\n";
         echo "\n";
         echo "COMMANDS:\n";
         echo "  xstep    JSON output mode (AI-optimized, default)\n";
@@ -63,7 +63,7 @@ function showHelp(string $commandName = 'xstep'): void
         echo "  --pretty                Pretty-print JSON output with 2-space indentation\n";
         echo "  --max-value-bytes=N     Truncate long string values to N bytes in JSON output\n";
         echo "  --max-depth=N           Truncate nested array/object rendering after N levels\n";
-        echo "  --include-vendor=PATTERNS Include vendor packages in trace\n";
+        echo "  --include-vendor=PATTERNS Include matching vendor packages in trace\n";
         echo "  --help, -h              Show this help\n";
     }
     echo "\n";
@@ -113,12 +113,11 @@ function showHelp(string $commandName = 'xstep'): void
         echo "  xrepl: Interactive REPL with step control (s, o, c, p, bt, q commands)\n";
         echo "  Benefits: AI can analyze exact variable values at breakpoints without guesswork\n";
         echo "\n";
-        echo "📋 JSON SCHEMA RESOURCES (Essential for AI):\n";
+        echo "📋 JSON SCHEMA RESOURCES:\n";
         echo "  Schema Definition: https://koriym.github.io/xdebug-mcp/schemas/xstep.json\n";
         echo "  Xdebug Trace Docs: https://xdebug.org/docs/trace\n";
         echo "  Debug Guidelines: https://koriym.github.io/xdebug-mcp/debug_guideline_for_ai.md\n";
         echo "  Forward Trace™ Guide: Complete methodology for AI-powered PHP debugging\n";
-        echo "  Schema Note: Combines 'crime scene photo' (breakpoints) + 'surveillance footage' (traces)\n";
         echo "\n";
         echo "AI WORKFLOW INTEGRATION:\n";
         echo "  1. Set contextual breakpoints based on error analysis\n";
@@ -129,10 +128,6 @@ function showHelp(string $commandName = 'xstep'): void
         echo "\n";
         echo "RECOMMENDED AI PROMPT:\n";
         echo "  'Run xstep --help first, then help me debug this PHP issue using breakpoints'\n";
-        echo "\n";
-        echo "VS. TRADITIONAL DEBUGGING:\n";
-        echo "  ❌ Traditional: Add var_dump(), run, analyze, remove debug code\n";
-        echo "  ✅ This tool: Set breakpoints, analyze runtime data, done\n";
         echo "\n";
     }
     exit(0);
@@ -273,6 +268,7 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
     $pretty = false;
     $maxValueBytes = null;
     $maxDepth = null;
+    $includeVendor = null;
 
     for ($i = 1; $i < count($argv); $i++) {
         $arg = $argv[$i];
@@ -356,7 +352,7 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
         }
 
         if ($parseOptions && str_starts_with($arg, '--include-vendor=')) {
-            // This flag is passed directly to prepend_filter.php via auto_prepend_file
+            $includeVendor = substr($arg, 17);
             continue;
         }
 
@@ -455,10 +451,11 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
             'pretty' => $pretty,
             'maxValueBytes' => $maxValueBytes,
             'maxDepth' => $maxDepth,
+            'includeVendor' => $includeVendor,
         ], $jsonOutput);
     } else {
         // For legacy format, only pass command if it's not just the target script
-        $options = ['breakpointFile' => $breakpointFile, 'traceOnly' => $traceOnly, 'jsonOutput' => $jsonOutput, 'context' => $context, 'maxSteps' => $maxSteps, 'watches' => $watches, 'pretty' => $pretty, 'maxValueBytes' => $maxValueBytes, 'maxDepth' => $maxDepth];
+        $options = ['breakpointFile' => $breakpointFile, 'traceOnly' => $traceOnly, 'jsonOutput' => $jsonOutput, 'context' => $context, 'maxSteps' => $maxSteps, 'watches' => $watches, 'pretty' => $pretty, 'maxValueBytes' => $maxValueBytes, 'maxDepth' => $maxDepth, 'includeVendor' => $includeVendor];
         if (count($command) > 1 || ($command[0] !== $targetScript)) {
             $options['command'] = $command;
         }

--- a/bin/xtrace
+++ b/bin/xtrace
@@ -16,8 +16,7 @@ function showHelp(string $scriptName): void {
     echo "📊 AI-Optimized PHP Execution Flow Tracer with Docker Support\n";
     echo "\n";
     echo "PURPOSE:\n";
-    echo "  The ultimate alternative to static code analysis - understand what your PHP code\n";
-    echo "  ACTUALLY does at runtime. Captures complete execution flow, function calls,\n";
+    echo "  Understand what your PHP code does at runtime. Captures execution flow, function calls,\n";
     echo "  parameters, and timing data for AI analysis without any code modification.\n";
     echo "\n";
     echo "KEY BENEFITS FOR AI ANALYSIS:\n";
@@ -32,7 +31,7 @@ function showHelp(string $scriptName): void {
     echo "  --json                      Output structured JSON for AI consumption\n";
     echo "  --claude                    Auto-analyze trace data with Claude AI\n";
     echo "  --context=TEXT             Add contextual description for AI analysis\n";
-    echo "  --include-vendor=PATTERNS  Include vendor packages in trace analysis\n";
+    echo "  --include-vendor=PATTERNS  Include matching vendor packages in local traces\n";
     echo "  --help, -h                 Show this comprehensive help\n";
     echo "\n";
     echo "EXAMPLES:\n";
@@ -49,7 +48,7 @@ function showHelp(string $scriptName): void {
     echo "  # PHPUnit test analysis\n";
     echo "  $scriptName --context=\"Test analysis\" -- php vendor/bin/phpunit tests/UserTest.php\n";
     echo "\n";
-    echo "  # With vendor filtering\n";
+    echo "  # Include selected vendor packages in local traces\n";
     echo "  $scriptName --include-vendor=\"bear/*\" --context=\"BEAR DI\" -- php app.php\n";
     echo "\n";
     echo "OUTPUT FORMATS:\n";
@@ -69,7 +68,7 @@ if (isset($argv[1]) && ($argv[1] === '--help' || $argv[1] === '-h')) {
 $separatorIndex = array_search('--', $argv);
 if ($separatorIndex === false) {
     fwrite(STDERR, "❌ Error: Missing '--' separator\n");
-    fwrite(STDERR, "Usage: xdebug-trace [options] -- command\n");
+    fwrite(STDERR, "Usage: {$argv[0]} [options] -- command\n");
     exit(1);
 }
 

--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,11 @@
         "bin/xcoverage",
         "bin/xback",
         "bin/xcompare",
-        "bin/check-env",
-        "bin/test-json"
+        "bin/check-env"
     ],
 
     "scripts-descriptions": {
-        "test-json": "Run comprehensive JSON test suite with all xdebug commands",
+        "test-json": "Run the internal JSON regression script",
         "install-mcp": "Configure xdebug-mcp for Claude Code MCP integration",
         "install-desktop": "Configure xdebug-mcp for Claude Desktop integration",
         "check-env": "Check Xdebug environment and configuration",

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -349,16 +349,16 @@ rm reset-test.php
 
 1. **Run diagnostics**:
    ```bash
-./bin/check-env > diagnostics.txt
-php -v >> diagnostics.txt
-php -m | grep xdebug >> diagnostics.txt
+   ./bin/check-env > diagnostics.txt
+   php -v >> diagnostics.txt
+   php -m | grep xdebug >> diagnostics.txt
    ```
 
 2. **Create minimal reproduction**:
    ```bash
-echo '<?php echo "Test\n";' > minimal-test.php
-./bin/xtrace --json --context="Minimal test" -- php minimal-test.php
-```
+   echo '<?php echo "Test\n";' > minimal-test.php
+   ./bin/xtrace --json --context="Minimal test" -- php minimal-test.php
+   ```
 
 3. **Include system information**:
    - Operating system and version

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -16,7 +16,7 @@ Run these commands first to identify the problem:
 
 ```bash
 ./bin/check-env          # Check Xdebug installation
-composer test-json       # Test MCP functionality
+composer test-json       # Run internal JSON regression script
 MCP_DEBUG=1 php bin/xdebug-mcp  # Enable debug logging
 ```
 
@@ -120,7 +120,7 @@ head -n 50 src/User.php | tail -n 10  # Check around line 42
 **Check Command Format**:
 ```bash
 # ✅ Correct format
-./bin/xstep --break="loop.php:15" --steps=100 --json -- php script.php
+./bin/xstep --break="loop.php:15" --steps=100 -- php script.php
 
 # ❌ Wrong format
 ./bin/xstep --break="loop.php:15" --steps 100  # Missing equals sign
@@ -129,7 +129,7 @@ head -n 50 src/User.php | tail -n 10  # Check around line 42
 **Verify Output**:
 ```bash
 # Check if JSON contains "breaks" array with step data
-./bin/xstep --break="test.php:1" --steps=5 --json -- php -r "echo 'test';" | jq '.breaks'
+./bin/xstep --break="tests/fixtures/simple.php:1" --steps=5 -- php tests/fixtures/simple.php | jq '.breaks'
 ```
 
 ### 3. Context Memory Problems
@@ -202,7 +202,7 @@ MCP_DEBUG=1 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | php bin/xdeb
 **Optimizations**:
 ```bash
 # Use specific conditions to limit scope
-./bin/xstep --break='file.php:42:$specific_condition' --exit-on-break
+./bin/xstep --break='file.php:42:$specific_condition' -- php script.php
 
 # Limit step recording
 ./bin/xstep --break='file.php:42' --steps=50  # Instead of 1000+
@@ -221,8 +221,8 @@ rm /tmp/trace.*.xt /tmp/cachegrind.out.*
 ./bin/xprofile --json -- php script.php | jq '.'
 # parse error: Invalid numeric literal at line 1, column 8
 
-# ✅ Now: Clean JSON output (script stdout/stderr automatically suppressed)
-./bin/xprofile --json -- php script.php | jq '.["🎯 bottleneck_functions"]'
+# ✅ Now: Clean JSON output with captured script output under the "output" key
+./bin/xprofile --json -- php script.php | jq '.bottlenecks'
 ```
 
 **Format Solutions**:
@@ -231,13 +231,13 @@ rm /tmp/trace.*.xt /tmp/cachegrind.out.*
 ./bin/xprofile --json -- php script.php
 
 # Pipe to jq for filtering
-./bin/xprofile --json -- php script.php | jq '.["⏱️ execution_time_ms"]'
+./bin/xprofile --json -- php script.php | jq '.time_ms'
 
 # Verify schema compliance
 ./bin/validate-profile-json profile-output.json
 
 # Check output structure
-./bin/xstep --json --break="test.php:1" --steps=1 -- php -r "echo 'test';" | jq '.'
+./bin/xstep --break="tests/fixtures/simple.php:1" --steps=1 -- php tests/fixtures/simple.php | jq '.'
 ```
 
 ### 3. File Path Issues
@@ -247,7 +247,7 @@ rm /tmp/trace.*.xt /tmp/cachegrind.out.*
 **Path Solutions**:
 ```bash
 # Use absolute paths
-./bin/xdebug-trace -- php /full/path/to/script.php
+./bin/xtrace -- php /full/path/to/script.php
 
 # Check working directory
 pwd
@@ -262,7 +262,7 @@ chmod 755 $(dirname script.php)
 
 ### 1. PHPUnit Integration Problems
 
-**Issue**: `./bin/xdebug-phpunit` not working with tests
+**Issue**: PHPUnit coverage or profiling commands do not work with tests
 
 **Solutions**:
 ```bash
@@ -273,7 +273,7 @@ vendor/bin/phpunit --version
 vendor/bin/phpunit tests/Unit/
 
 # Check Xdebug + PHPUnit integration
-./bin/xdebug-phpunit --context="Test integration" tests/Unit/McpServerTest.php
+./bin/xcoverage -- php ./vendor/bin/phpunit tests/Unit/McpServerTest.php
 ```
 
 ### 2. Fake Test Environment
@@ -309,7 +309,7 @@ composer test-json
 
 # 4. Test basic functionality
 echo '<?php echo "Reset test\n";' > reset-test.php
-./bin/xdebug-trace --context="Reset verification" -- php reset-test.php
+./bin/xtrace --context="Reset verification" -- php reset-test.php
 rm reset-test.php
 ```
 
@@ -349,16 +349,16 @@ rm reset-test.php
 
 1. **Run diagnostics**:
    ```bash
-   ./bin/check-env > diagnostics.txt
-   php -v >> diagnostics.txt
-   php -m | grep xdebug >> diagnostics.txt
+./bin/check-env > diagnostics.txt
+php -v >> diagnostics.txt
+php -m | grep xdebug >> diagnostics.txt
    ```
 
 2. **Create minimal reproduction**:
    ```bash
-   echo '<?php echo "Test\n";' > minimal-test.php
-   ./bin/xdebug-trace --json --context="Minimal test" -- php minimal-test.php
-   ```
+echo '<?php echo "Test\n";' > minimal-test.php
+./bin/xtrace --json --context="Minimal test" -- php minimal-test.php
+```
 
 3. **Include system information**:
    - Operating system and version

--- a/prepend_filter.php
+++ b/prepend_filter.php
@@ -17,16 +17,24 @@ if (!extension_loaded('xdebug')) {
 }
 
 require_once __DIR__ . '/src/Utilities/PathNormalizer.php';
+require_once __DIR__ . '/src/Utilities/VendorFilter.php';
 
 use Koriym\XdebugMcp\Utilities\PathNormalizer;
+use Koriym\XdebugMcp\Utilities\VendorFilter;
 
 $normalisePath = static function (string $path): string {
     return PathNormalizer::normalise($path);
 };
 
-// Parse CLI arguments for vendor filtering options
+// Parse CLI/env arguments for vendor filtering options.
 $options = getopt('', ['include-vendor::']); // :: = optional value
-$includeVendor = $options['include-vendor'] ?? null;
+$includeVendor = getenv('XDEBUG_MCP_INCLUDE_VENDOR');
+if ($includeVendor === false) {
+    $includeVendor = getenv('COVERAGE_INCLUDE_VENDOR');
+}
+if ($includeVendor === false) {
+    $includeVendor = $options['include-vendor'] ?? null;
+}
 
 // Find vendor directory
 $vendorPath = null;
@@ -39,30 +47,11 @@ foreach ([__DIR__ . '/../../../vendor', __DIR__ . '/vendor'] as $path) {
 
 // Apply vendor filtering if vendor exists
 if ($vendorPath) {
-    $excludePaths = [$vendorPath];  // Default: exclude entire vendor
-
-    if ($includeVendor) {
-        // Pattern-based selective filtering
-        $patterns = array_map('trim', explode(',', $includeVendor));
-        $excludePaths = [$vendorPath . '/autoload.php', $vendorPath . '/composer'];
-
-        foreach (glob($vendorPath . '/*/*', GLOB_ONLYDIR) as $packageDir) {
-            $packageName = substr($packageDir, strlen($vendorPath) + 1);
-            $matches = false;
-            foreach ($patterns as $pattern) {
-                if (fnmatch($pattern, $packageName)) {
-                    $matches = true;
-                    break;
-                }
-            }
-            if (!$matches) {
-                $excludePaths[] = $normalisePath($packageDir);
-            }
-        }
+    $excludePaths = VendorFilter::excludePaths($vendorPath, $includeVendor);
+    if ($excludePaths !== []) {
+        xdebug_set_filter(XDEBUG_FILTER_TRACING, XDEBUG_PATH_EXCLUDE, $excludePaths);
+        xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
     }
-
-    xdebug_set_filter(XDEBUG_FILTER_TRACING, XDEBUG_PATH_EXCLUDE, $excludePaths);
-    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
 }
 
 xdebug_start_trace();

--- a/prepend_filter.php
+++ b/prepend_filter.php
@@ -33,7 +33,8 @@ if ($includeVendor === false) {
     $includeVendor = getenv('COVERAGE_INCLUDE_VENDOR');
 }
 if ($includeVendor === false) {
-    $includeVendor = $options['include-vendor'] ?? null;
+    $cliIncludeVendor = is_array($options) ? ($options['include-vendor'] ?? null) : null;
+    $includeVendor = is_string($cliIncludeVendor) ? $cliIncludeVendor : null;
 }
 
 // Find vendor directory

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -167,7 +167,7 @@ final class DebugServer
     /** @var array{id: string, label: string, file: string, line: int, condition?: string}|null */
     private array|null $activeBreakpoint = null;
 
-    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null, phpBinary?: string} $options */
+    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null, phpBinary?: string, includeVendor?: string|null} $options */
     public function __construct(
         private readonly string $targetScript,
         private readonly int $debugPort,
@@ -360,9 +360,12 @@ final class DebugServer
                     $phpBinary = ($this->options['phpBinary'] ?? '') !== ''
                         ? (string) $this->options['phpBinary']
                         : 'php';
+                    $includeVendorEnv = ($this->options['includeVendor'] ?? null) !== null
+                        ? 'XDEBUG_MCP_INCLUDE_VENDOR=' . escapeshellarg((string) $this->options['includeVendor']) . ' '
+                        : '';
 
                     $cmd = sprintf(
-                        'XDEBUG_SESSION=xdebug-mcp %s %s'
+                        'XDEBUG_SESSION=xdebug-mcp %s%s %s'
                         . '-dxdebug.mode=debug,trace '
                         . '-dxdebug.start_with_request=yes '
                         . '-dxdebug.client_host=127.0.0.1 '
@@ -379,6 +382,7 @@ final class DebugServer
                         . '-derror_log=/tmp/php.log '
                         . '-dauto_prepend_file=%s '
                         . '%s',
+                        $includeVendorEnv,
                         escapeshellarg($phpBinary),
                         $xdebugPart,
                         $this->debugPort,
@@ -403,9 +407,12 @@ final class DebugServer
                 $phpBinary = ($this->options['phpBinary'] ?? '') !== ''
                     ? (string) $this->options['phpBinary']
                     : 'php';
+                $includeVendorEnv = ($this->options['includeVendor'] ?? null) !== null
+                    ? 'XDEBUG_MCP_INCLUDE_VENDOR=' . escapeshellarg((string) $this->options['includeVendor']) . ' '
+                    : '';
 
                 $cmd = sprintf(
-                    'XDEBUG_SESSION=xdebug-mcp %s %s'
+                    'XDEBUG_SESSION=xdebug-mcp %s%s %s'
                     . '-dxdebug.mode=debug,trace '
                     . '-dxdebug.start_with_request=yes '
                     . '-dxdebug.client_host=127.0.0.1 '
@@ -418,6 +425,7 @@ final class DebugServer
                     . '-dxdebug.connect_timeout_ms=5000 '
                     . '-dauto_prepend_file=%s '
                     . '%s',
+                    $includeVendorEnv,
                     escapeshellarg($phpBinary),
                     $xdebugPart,
                     $this->debugPort,

--- a/src/Utilities/VendorFilter.php
+++ b/src/Utilities/VendorFilter.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Utilities;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function explode;
+use function fnmatch;
+use function glob;
+use function in_array;
+use function is_array;
+use function is_dir;
+use function rtrim;
+use function str_replace;
+use function strlen;
+use function substr;
+use function trim;
+
+use const DIRECTORY_SEPARATOR;
+use const GLOB_ONLYDIR;
+
+final class VendorFilter
+{
+    /** @return list<string> */
+    public static function excludePaths(string $vendorPath, string|null $includeVendor): array
+    {
+        $vendorPath = self::normaliseDir($vendorPath);
+        if ($vendorPath === '' || ! is_dir($vendorPath)) {
+            return [];
+        }
+
+        $patterns = self::patterns($includeVendor);
+        if ($patterns === []) {
+            return [$vendorPath];
+        }
+
+        if (self::matchesAllVendor($patterns)) {
+            return [];
+        }
+
+        $excludePaths = [
+            $vendorPath . 'autoload.php',
+            $vendorPath . 'composer' . DIRECTORY_SEPARATOR,
+        ];
+
+        $packageDirs = glob($vendorPath . '*' . DIRECTORY_SEPARATOR . '*', GLOB_ONLYDIR);
+        if ($packageDirs === false) {
+            return $excludePaths;
+        }
+
+        foreach ($packageDirs as $packageDir) {
+            $packageName = str_replace(DIRECTORY_SEPARATOR, '/', substr($packageDir, strlen($vendorPath)));
+            if (self::matchesPackage($packageName, $patterns)) {
+                continue;
+            }
+
+            $excludePaths[] = self::normaliseDir($packageDir);
+        }
+
+        return $excludePaths;
+    }
+
+    /** @param list<string>|string|null $patterns */
+    public static function matchesPackage(string $packageName, array|string|null $patterns): bool
+    {
+        $patterns = is_array($patterns) ? $patterns : self::patterns($patterns);
+        if ($patterns === []) {
+            return false;
+        }
+
+        if (self::matchesAllVendor($patterns)) {
+            return true;
+        }
+
+        foreach ($patterns as $pattern) {
+            if (fnmatch($pattern, $packageName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return list<string> */
+    private static function patterns(string|null $includeVendor): array
+    {
+        if ($includeVendor === null || trim($includeVendor) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(trim(...), explode(',', $includeVendor)),
+            static fn (string $pattern): bool => $pattern !== '',
+        ));
+    }
+
+    /** @param list<string> $patterns */
+    private static function matchesAllVendor(array $patterns): bool
+    {
+        return in_array('*/*', $patterns, true) || in_array('*', $patterns, true);
+    }
+
+    private static function normaliseDir(string $path): string
+    {
+        $normalised = PathNormalizer::normalise(rtrim($path, '/\\'));
+
+        return $normalised === '' ? '' : $normalised . DIRECTORY_SEPARATOR;
+    }
+}

--- a/src/XdebugRunner.php
+++ b/src/XdebugRunner.php
@@ -22,6 +22,7 @@ use function glob;
 use function implode;
 use function passthru;
 use function preg_match;
+use function sprintf;
 use function trim;
 use function usort;
 
@@ -290,9 +291,12 @@ class XdebugRunner
             $phpBinary = array_shift($workingParts);
         }
 
-        $xdebugArgs = $this->generateXdebugArguments();
+        $xdebugArgs = $this->generateXdebugArguments(true);
+        $envPrefix = $this->includeVendor !== null
+            ? sprintf('XDEBUG_MCP_INCLUDE_VENDOR=%s ', escapeshellarg($this->includeVendor))
+            : '';
 
-        return escapeshellarg($phpBinary) . ' ' . implode(' ', $xdebugArgs) . ' ' . implode(' ', array_map(escapeshellarg(...), $workingParts));
+        return $envPrefix . escapeshellarg($phpBinary) . ' ' . implode(' ', $xdebugArgs) . ' ' . implode(' ', array_map(escapeshellarg(...), $workingParts));
     }
 
     /**
@@ -310,7 +314,9 @@ class XdebugRunner
             );
         }
 
-        $xdebugArgs = $this->generateXdebugArguments();
+        // Do not inject the local auto_prepend_file into containers. The host
+        // path is not guaranteed to exist inside the container.
+        $xdebugArgs = $this->generateXdebugArguments(false);
 
         // Insert Xdebug arguments right after 'php' command
         foreach (array_reverse($xdebugArgs) as $arg) {
@@ -333,7 +339,7 @@ class XdebugRunner
     }
 
     /** @return string[] */
-    private function generateXdebugArguments(): array
+    private function generateXdebugArguments(bool $enableLocalVendorFilter): array
     {
         // Add zend_extension flag if Xdebug is not already loaded
         $xdebugFlag = XdebugFinder::getXdebugFlag();
@@ -354,7 +360,7 @@ class XdebugRunner
         if ($this->mode === 'trace') {
             $args[] = '-dxdebug.trace_format=1';
 
-            if ($this->includeVendor !== null) {
+            if ($enableLocalVendorFilter) {
                 $prependFile = __DIR__ . '/prepend_filter.php';
                 if (file_exists($prependFile)) {
                     $args[] = '-dauto_prepend_file=' . $prependFile;

--- a/src/prepend_filter.php
+++ b/src/prepend_filter.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/Utilities/PathNormalizer.php';
+require_once __DIR__ . '/Utilities/VendorFilter.php';
+
+use Koriym\XdebugMcp\Utilities\VendorFilter;
+
 // Automatically exclude vendor directory from all Xdebug tracing
 // This file is prepended to PHP execution via -dauto_prepend_file
 // to ensure vendor code is filtered out from the very beginning,
@@ -19,7 +24,11 @@ if (extension_loaded('xdebug')) {
     }
 
     if (function_exists('xdebug_set_filter')) {
-        xdebug_set_filter(XDEBUG_FILTER_TRACING, XDEBUG_PATH_EXCLUDE, [$vendorPath]);
-        xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, [$vendorPath]);
+        $includeVendor = getenv('XDEBUG_MCP_INCLUDE_VENDOR');
+        $excludePaths = VendorFilter::excludePaths($vendorPath, $includeVendor === false ? null : $includeVendor);
+        if ($excludePaths !== []) {
+            xdebug_set_filter(XDEBUG_FILTER_TRACING, XDEBUG_PATH_EXCLUDE, $excludePaths);
+            xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
+        }
     }
 }

--- a/tests/Unit/VendorFilterTest.php
+++ b/tests/Unit/VendorFilterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Tests\Unit;
+
+use Koriym\XdebugMcp\Utilities\VendorFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+#[CoversClass(VendorFilter::class)]
+final class VendorFilterTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/xdebug_mcp_vendor_' . uniqid();
+        mkdir($this->root . '/vendor/bear/resource', 0777, true);
+        mkdir($this->root . '/vendor/ray/di', 0777, true);
+        mkdir($this->root . '/vendor/composer', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        rmdir($this->root . '/vendor/composer');
+        rmdir($this->root . '/vendor/ray/di');
+        rmdir($this->root . '/vendor/ray');
+        rmdir($this->root . '/vendor/bear/resource');
+        rmdir($this->root . '/vendor/bear');
+        rmdir($this->root . '/vendor');
+        rmdir($this->root);
+    }
+
+    #[Test]
+    public function excludesWholeVendorDirectoryByDefault(): void
+    {
+        $excludePaths = VendorFilter::excludePaths($this->root . '/vendor', null);
+
+        $this->assertSame([$this->root . '/vendor/'], $excludePaths);
+    }
+
+    #[Test]
+    public function includesOnlyMatchingVendorPackages(): void
+    {
+        $excludePaths = VendorFilter::excludePaths($this->root . '/vendor', 'bear/*');
+
+        $this->assertContains($this->root . '/vendor/ray/di/', $excludePaths);
+        $this->assertNotContains($this->root . '/vendor/bear/resource/', $excludePaths);
+    }
+
+    #[Test]
+    public function starPatternIncludesEveryVendorPackage(): void
+    {
+        $excludePaths = VendorFilter::excludePaths($this->root . '/vendor', '*/*');
+
+        $this->assertSame([], $excludePaths);
+    }
+}

--- a/tests/Unit/XdebugRunnerTest.php
+++ b/tests/Unit/XdebugRunnerTest.php
@@ -469,7 +469,9 @@ final class XdebugRunnerTest extends TestCase
         $command = $runner->buildCommand();
 
         $this->assertStringContainsString('-dxdebug.mode=trace', $command);
-        // prepend_filter.php is loaded when includeVendor is set
+        $this->assertStringContainsString('XDEBUG_MCP_INCLUDE_VENDOR=', $command);
+        // prepend_filter.php is loaded for local traces so vendor filtering can
+        // exclude all vendor code by default or include selected packages.
         if (! file_exists(__DIR__ . '/../../src/prepend_filter.php')) {
             return;
         }
@@ -487,7 +489,8 @@ final class XdebugRunnerTest extends TestCase
         $command = $runner->buildCommand();
 
         $this->assertStringContainsString('-dxdebug.mode=trace', $command);
-        $this->assertStringNotContainsString('-dauto_prepend_file=', $command);
+        $this->assertStringContainsString('-dauto_prepend_file=', $command);
+        $this->assertStringNotContainsString('XDEBUG_MCP_INCLUDE_VENDOR=', $command);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- keep public debugging commands aligned to the `x*` command set and stop publishing `test-json` as a Composer bin command
- update internal `test-json`, troubleshooting docs, and bin docs to use current command names and supported options
- add shared vendor filtering so `--include-vendor` behavior matches the CLI help for trace, step, profile analysis, and raw coverage
- add AGENTS guidance to keep local setup details out of public-facing text

## Validation
- `composer test-json`
- `composer demo`
- `composer cs`
- `php -d memory_limit=512M ./vendor/bin/phpstan`
- `composer validate --strict`
- `composer test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vendor-package filtering (include-vendor) added across trace, step, profile, and coverage tools for more focused debugging and profiling.

* **Documentation**
  * Updated CLI help, examples, troubleshooting, and READMEs to reflect new options and invocation patterns.

* **Tests**
  * New unit tests cover vendor-filter behavior; CLI test expectations updated.

* **Chores**
  * Composer CLI entrypoints adjusted to align with updated tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/koriym/xdebug-mcp/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->