### PR TITLE
Add php -r support for coverage and profile

### DIFF
--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -198,14 +198,10 @@ function buildRawCoverageBootstrap(
     string $branchFlag,
     string $sourceLiteral,
     string $vendorExcludePathsLiteral,
-    int $commandLineCodeOffset = 0,
-    bool $filterCommandLineBootstrap = false,
 ): string
 {
     return '$tempDir = sys_get_temp_dir();
 $branchCoverage = ' . $branchFlag . ';
-$commandLineCodeOffset = ' . $commandLineCodeOffset . ';
-$filterCommandLineBootstrap = ' . ($filterCommandLineBootstrap ? 'true' : 'false') . ';
 $sourcePaths = ' . $sourceLiteral . ';
 $vendorExcludePaths = ' . $vendorExcludePathsLiteral . ';
 if (is_array($sourcePaths) && $sourcePaths !== []) {
@@ -220,39 +216,11 @@ if (is_array($sourcePaths) && $sourcePaths !== []) {
 $coverageFlags = $branchCoverage
     ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
     : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
-register_shutdown_function(function() use ($tempDir, $branchCoverage, $commandLineCodeOffset, $filterCommandLineBootstrap) {
+register_shutdown_function(function() use ($tempDir, $branchCoverage) {
     $coverage = xdebug_get_code_coverage();
     $filtered = array_filter($coverage, function($path) use ($tempDir) {
         return strpos($path, $tempDir) === false;
     }, ARRAY_FILTER_USE_KEY);
-
-    if (! $branchCoverage && $commandLineCodeOffset > 0 && isset($filtered["Command line code"]) && is_array($filtered["Command line code"])) {
-        $adjusted = [];
-        foreach ($filtered["Command line code"] as $line => $hitCount) {
-            if (! is_int($line) && ! ctype_digit((string) $line)) {
-                continue;
-            }
-
-            $adjustedLine = (int) $line - $commandLineCodeOffset;
-            if ($adjustedLine >= 1) {
-                $adjusted[$adjustedLine] = $hitCount;
-            }
-        }
-
-        if ($adjusted === []) {
-            unset($filtered["Command line code"]);
-        } else {
-            $filtered["Command line code"] = $adjusted;
-        }
-    }
-
-    if ($branchCoverage && $filterCommandLineBootstrap && isset($filtered["Command line code"]["functions"]) && is_array($filtered["Command line code"]["functions"])) {
-        foreach (array_keys($filtered["Command line code"]["functions"]) as $function) {
-            if (str_starts_with((string) $function, "{closure:Command line code:")) {
-                unset($filtered["Command line code"]["functions"][$function]);
-            }
-        }
-    }
 
     if ($branchCoverage) {
         $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_branch_coverage_") . ".dot";
@@ -612,12 +580,7 @@ if ($runCodeArgument !== null) {
     }
 
     $inlineBootstrap = compactPhpSnippet(
-        buildRawCoverageBootstrap(
-            $branchFlag,
-            $sourceLiteral,
-            $vendorExcludePathsLiteral,
-            filterCommandLineBootstrap: true,
-        ),
+        buildRawCoverageBootstrap($branchFlag, $sourceLiteral, $vendorExcludePathsLiteral),
     );
     $args[$codeIndex] = $codePrefix . prefixPhpRunCode($inlineCode, $inlineBootstrap);
 } else {

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -606,6 +606,11 @@ if ($runCodeArgument !== null) {
         exit(1);
     }
 
+    if ($branchCoverage) {
+        fwrite(STDERR, "Error: --branch-coverage is not supported with PHP inline code ({$runCodeArgument['option']}). Use a script file for branch coverage.\n");
+        exit(1);
+    }
+
     $inlineBootstrap = compactPhpSnippet(
         buildRawCoverageBootstrap(
             $branchFlag,

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -177,7 +177,20 @@ function isPhpUnitCommand(string $arg): bool
  */
 function findPhpRunCodeArgument(array $args): array|null
 {
-    foreach ($args as $index => $arg) {
+    // Only PHP interpreter options that appear before the script file may
+    // introduce inline code. Stop scanning once the script path (first
+    // non-option) or the "--" end-of-options marker is reached so the script's
+    // own arguments are not mistaken for inline code (e.g. `php app.php -r foo`).
+    // $args has already had the leading php binary stripped by normalizeRawArguments().
+    $optionsWithValue = [
+        '-d', '-c', '-z', '-B', '-R', '-F', '-E',
+        '--define', '--php-ini', '--zend-extension',
+        '--process-begin', '--process-code', '--process-file', '--process-end',
+    ];
+
+    for ($index = 0; isset($args[$index]); $index++) {
+        $arg = $args[$index];
+
         if ($arg === '-r' || $arg === '--run') {
             return ['code_index' => $index + 1, 'code_prefix' => '', 'option' => $arg];
         }
@@ -188,6 +201,14 @@ function findPhpRunCodeArgument(array $args): array|null
 
         if (str_starts_with($arg, '--run=')) {
             return ['code_index' => $index, 'code_prefix' => '--run=', 'option' => '--run'];
+        }
+
+        if ($arg === '--' || ! str_starts_with($arg, '-')) {
+            return null;
+        }
+
+        if (in_array($arg, $optionsWithValue, true) && isset($args[$index + 1])) {
+            $index++;
         }
     }
 
@@ -585,10 +606,19 @@ if ($runCodeArgument !== null) {
     $args[$codeIndex] = $codePrefix . prefixPhpRunCode($inlineCode, $inlineBootstrap);
 } else {
     $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
-    file_put_contents(
+    if ($shutdownScript === false) {
+        fwrite(STDERR, "Error: failed to create temporary bootstrap file\n");
+        exit(1);
+    }
+
+    if (file_put_contents(
         $shutdownScript,
         "<?php\n" . buildRawCoverageBootstrap($branchFlag, $sourceLiteral, $vendorExcludePathsLiteral),
-    );
+    ) === false) {
+        @unlink($shutdownScript);
+        fwrite(STDERR, "Error: failed to write temporary bootstrap file\n");
+        exit(1);
+    }
 }
 
 $escapedArgs = array_map('escapeshellarg', $args);

--- a/bin/xcoverage
+++ b/bin/xcoverage
@@ -51,6 +51,7 @@ if (in_array('--help', $argv) || in_array('-h', $argv)) {
     echo "\n";
     echo "  # Raw mode: Xdebug direct coverage (any PHP script)\n";
     echo "  " . $argv[0] . " --raw -- php app.php\n";
+    echo "  " . $argv[0] . " --raw -- php -r 'echo strlen(\"abc\"), PHP_EOL;'\n";
     echo "\n";
     echo "  # Include specific vendor packages (raw mode)\n";
     echo "  " . $argv[0] . " --raw --include-vendor=bear/resource,ray/di -- php script.php\n";
@@ -167,6 +168,215 @@ function isPhpUnitCommand(string $arg): bool
     $binary = basename(str_replace('\\', '/', $arg));
 
     return $binary === 'phpunit' || $binary === 'phpunit.phar';
+}
+
+/**
+ * @param list<string> $args
+ *
+ * @return array{code_index: int, code_prefix: string, option: string}|null
+ */
+function findPhpRunCodeArgument(array $args): array|null
+{
+    foreach ($args as $index => $arg) {
+        if ($arg === '-r' || $arg === '--run') {
+            return ['code_index' => $index + 1, 'code_prefix' => '', 'option' => $arg];
+        }
+
+        if (str_starts_with($arg, '-r') && $arg !== '-r') {
+            return ['code_index' => $index, 'code_prefix' => '-r', 'option' => '-r'];
+        }
+
+        if (str_starts_with($arg, '--run=')) {
+            return ['code_index' => $index, 'code_prefix' => '--run=', 'option' => '--run'];
+        }
+    }
+
+    return null;
+}
+
+function buildRawCoverageBootstrap(
+    string $branchFlag,
+    string $sourceLiteral,
+    string $vendorExcludePathsLiteral,
+    int $commandLineCodeOffset = 0,
+    bool $filterCommandLineBootstrap = false,
+): string
+{
+    return '$tempDir = sys_get_temp_dir();
+$branchCoverage = ' . $branchFlag . ';
+$commandLineCodeOffset = ' . $commandLineCodeOffset . ';
+$filterCommandLineBootstrap = ' . ($filterCommandLineBootstrap ? 'true' : 'false') . ';
+$sourcePaths = ' . $sourceLiteral . ';
+$vendorExcludePaths = ' . $vendorExcludePathsLiteral . ';
+if (is_array($sourcePaths) && $sourcePaths !== []) {
+    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_INCLUDE, $sourcePaths);
+} else {
+    $excludePaths = array_merge([$tempDir], $vendorExcludePaths);
+    if (! $branchCoverage) {
+        $excludePaths[] = getcwd() . "/tests/";
+    }
+    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
+}
+$coverageFlags = $branchCoverage
+    ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
+    : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
+register_shutdown_function(function() use ($tempDir, $branchCoverage, $commandLineCodeOffset, $filterCommandLineBootstrap) {
+    $coverage = xdebug_get_code_coverage();
+    $filtered = array_filter($coverage, function($path) use ($tempDir) {
+        return strpos($path, $tempDir) === false;
+    }, ARRAY_FILTER_USE_KEY);
+
+    if (! $branchCoverage && $commandLineCodeOffset > 0 && isset($filtered["Command line code"]) && is_array($filtered["Command line code"])) {
+        $adjusted = [];
+        foreach ($filtered["Command line code"] as $line => $hitCount) {
+            if (! is_int($line) && ! ctype_digit((string) $line)) {
+                continue;
+            }
+
+            $adjustedLine = (int) $line - $commandLineCodeOffset;
+            if ($adjustedLine >= 1) {
+                $adjusted[$adjustedLine] = $hitCount;
+            }
+        }
+
+        if ($adjusted === []) {
+            unset($filtered["Command line code"]);
+        } else {
+            $filtered["Command line code"] = $adjusted;
+        }
+    }
+
+    if ($branchCoverage && $filterCommandLineBootstrap && isset($filtered["Command line code"]["functions"]) && is_array($filtered["Command line code"]["functions"])) {
+        foreach (array_keys($filtered["Command line code"]["functions"]) as $function) {
+            if (str_starts_with((string) $function, "{closure:Command line code:")) {
+                unset($filtered["Command line code"]["functions"][$function]);
+            }
+        }
+    }
+
+    if ($branchCoverage) {
+        $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_branch_coverage_") . ".dot";
+        $dotContent = "digraph coverage {\n  rankdir=TB;\n  node [shape=box];\n\n";
+
+        foreach ($filtered as $file => $data) {
+            if (isset($data["functions"])) {
+                foreach ($data["functions"] as $function => $funcData) {
+                    if (isset($funcData["branches"])) {
+                        $dotContent .= "  // Function: $function\n";
+                        foreach ($funcData["branches"] as $branchId => $branch) {
+                            $label = "Branch $branchId\\nLines {$branch["line_start"]}-{$branch["line_end"]}";
+                            $style = $branch["hit"] > 0 ? "filled,solid" : "filled,dashed";
+                            $color = $branch["hit"] > 0 ? "lightgreen" : "lightcoral";
+                            $dotContent .= "  \"$function-$branchId\" [label=\"$label\", style=\"$style\", fillcolor=\"$color\"];\n";
+
+                            foreach ($branch["out"] as $i => $targetBranch) {
+                                if ($targetBranch !== ' . XDEBUG_BRANCH_EXIT_SENTINEL . ') {
+                                    $edgeStyle = ($branch["out_hit"][$i] ?? 0) > 0 ? "solid" : "dashed";
+                                    $dotContent .= "  \"$function-$branchId\" -> \"$function-$targetBranch\" [style=\"$edgeStyle\"];\n";
+                                }
+                            }
+                        }
+                        $dotContent .= "\n";
+                    }
+                }
+            }
+        }
+
+        $dotContent .= "}\n";
+        file_put_contents($dotFilePath, $dotContent);
+        $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
+
+        $result = [
+            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json",
+            "coverage_type" => "branch",
+            "mode" => "raw",
+            "coverage" => $filtered,
+            "graphviz_dot_file" => $dotFilePath,
+            "visualization_command" => "dot -Tpng " . escapeshellarg($dotFilePath) . " -o " . escapeshellarg($outputPath)
+        ];
+    } else {
+        $uncoveredOnly = [];
+        $totalFiles = 0;
+        $totalLines = 0;
+        $coveredLines = 0;
+        $uncoveredLines = 0;
+
+        foreach ($filtered as $file => $lines) {
+            if (is_array($lines)) {
+                $totalFiles++;
+                $uncoveredLineNums = [];
+                foreach ($lines as $lineNum => $hitCount) {
+                    if (is_numeric($lineNum)) {
+                        $totalLines++;
+                        if ($hitCount > 0) {
+                            $coveredLines++;
+                        } else {
+                            $uncoveredLines++;
+                            $uncoveredLineNums[] = (int)$lineNum;
+                        }
+                    }
+                }
+                if (!empty($uncoveredLineNums)) {
+                    sort($uncoveredLineNums);
+                    $ranges = [];
+                    $start = $uncoveredLineNums[0];
+                    $end = $start;
+                    for ($i = 1; $i < count($uncoveredLineNums); $i++) {
+                        if ($uncoveredLineNums[$i] === $end + 1) {
+                            $end = $uncoveredLineNums[$i];
+                        } else {
+                            $ranges[] = ($start === $end) ? $start : "$start-$end";
+                            $start = $uncoveredLineNums[$i];
+                            $end = $start;
+                        }
+                    }
+                    $ranges[] = ($start === $end) ? $start : "$start-$end";
+                    $uncoveredOnly[$file] = $ranges;
+                }
+            }
+        }
+
+        $coveragePercent = $totalLines > 0 ? round(($coveredLines / $totalLines) * 100, 1) : 0;
+
+        $result = [
+            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
+            "coverage_type" => "line",
+            "mode" => "raw",
+            "summary" => [
+                "files" => $totalFiles,
+                "total_lines" => $totalLines,
+                "covered_lines" => $coveredLines,
+                "uncovered_lines" => $uncoveredLines,
+                "coverage_percent" => $coveragePercent
+            ],
+            "uncovered" => $uncoveredOnly
+        ];
+    }
+    echo(json_encode($result, JSON_UNESCAPED_SLASHES));
+});
+xdebug_start_code_coverage($coverageFlags);
+';
+}
+
+function compactPhpSnippet(string $php): string
+{
+    $compact = preg_replace('/\s*\R\s*/', ' ', trim($php));
+    if ($compact === null) {
+        throw new RuntimeException('Failed to compact PHP bootstrap');
+    }
+
+    return $compact . ' ';
+}
+
+function prefixPhpRunCode(string $inlineCode, string $inlineBootstrap): string
+{
+    if (preg_match('/^\s*declare\s*\(\s*strict_types\s*=\s*[01]\s*\)\s*;/', $inlineCode, $matches) !== 1) {
+        return $inlineBootstrap . $inlineCode;
+    }
+
+    $declare = $matches[0];
+
+    return $declare . $inlineBootstrap . substr($inlineCode, strlen($declare));
 }
 
 // PHPUnit mode (default) - uses PHPUnit's coverage with @codeCoverageIgnore support
@@ -331,7 +541,6 @@ if (!$rawMode) {
 
 // Raw mode - uses Xdebug directly (original behavior)
 $args = normalizeRawArguments($args);
-$shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
 $branchFlag = $branchCoverage ? 'true' : 'false';
 $sourceFilterEnabled = $sourceOption !== null && $sourceOption !== '';
 $vendorExcludePaths = [];
@@ -366,139 +575,8 @@ if ($sourceFilterEnabled) {
     $sourceLiteral = 'null';
 }
 
-file_put_contents($shutdownScript, '<?php
-$tempDir = sys_get_temp_dir();
-$branchCoverage = ' . $branchFlag . ';
-$sourcePaths = ' . $sourceLiteral . ';
-$vendorExcludePaths = ' . $vendorExcludePathsLiteral . ';
-if (is_array($sourcePaths) && $sourcePaths !== []) {
-    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_INCLUDE, $sourcePaths);
-    $coverageFlags = $branchCoverage
-        ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
-        : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
-    xdebug_start_code_coverage($coverageFlags);
-} else {
-    $excludePaths = array_merge([$tempDir], $vendorExcludePaths);
-    if (! $branchCoverage) {
-        $excludePaths[] = getcwd() . "/tests/";
-    }
-    xdebug_set_filter(XDEBUG_FILTER_CODE_COVERAGE, XDEBUG_PATH_EXCLUDE, $excludePaths);
-    $coverageFlags = $branchCoverage
-        ? (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE | XDEBUG_CC_BRANCH_CHECK)
-        : (XDEBUG_CC_UNUSED | XDEBUG_CC_DEAD_CODE);
-    xdebug_start_code_coverage($coverageFlags);
-}
-register_shutdown_function(function() use ($tempDir, $branchCoverage) {
-    $coverage = xdebug_get_code_coverage();
-    $filtered = array_filter($coverage, function($path) use ($tempDir) {
-        return strpos($path, $tempDir) === false;
-    }, ARRAY_FILTER_USE_KEY);
-
-    if ($branchCoverage) {
-        $dotFilePath = tempnam(sys_get_temp_dir(), "xdebug_branch_coverage_") . ".dot";
-        $dotContent = "digraph coverage {\n  rankdir=TB;\n  node [shape=box];\n\n";
-
-        foreach ($filtered as $file => $data) {
-            if (isset($data["functions"])) {
-                foreach ($data["functions"] as $function => $funcData) {
-                    if (isset($funcData["branches"])) {
-                        $dotContent .= "  // Function: $function\n";
-                        foreach ($funcData["branches"] as $branchId => $branch) {
-                            $label = "Branch $branchId\\nLines {$branch["line_start"]}-{$branch["line_end"]}";
-                            $style = $branch["hit"] > 0 ? "filled,solid" : "filled,dashed";
-                            $color = $branch["hit"] > 0 ? "lightgreen" : "lightcoral";
-                            $dotContent .= "  \"$function-$branchId\" [label=\"$label\", style=\"$style\", fillcolor=\"$color\"];\n";
-
-                            foreach ($branch["out"] as $i => $targetBranch) {
-                                if ($targetBranch !== ' . XDEBUG_BRANCH_EXIT_SENTINEL . ') {
-                                    $edgeStyle = ($branch["out_hit"][$i] ?? 0) > 0 ? "solid" : "dashed";
-                                    $dotContent .= "  \"$function-$branchId\" -> \"$function-$targetBranch\" [style=\"$edgeStyle\"];\n";
-                                }
-                            }
-                        }
-                        $dotContent .= "\n";
-                    }
-                }
-            }
-        }
-
-        $dotContent .= "}\n";
-        file_put_contents($dotFilePath, $dotContent);
-        $outputPath = pathinfo($dotFilePath, PATHINFO_DIRNAME) . "/" . pathinfo($dotFilePath, PATHINFO_FILENAME) . ".png";
-
-        $result = [
-            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage-branch.json",
-            "coverage_type" => "branch",
-            "mode" => "raw",
-            "coverage" => $filtered,
-            "graphviz_dot_file" => $dotFilePath,
-            "visualization_command" => "dot -Tpng " . escapeshellarg($dotFilePath) . " -o " . escapeshellarg($outputPath)
-        ];
-    } else {
-        $uncoveredOnly = [];
-        $totalFiles = 0;
-        $totalLines = 0;
-        $coveredLines = 0;
-        $uncoveredLines = 0;
-
-        foreach ($filtered as $file => $lines) {
-            if (is_array($lines)) {
-                $totalFiles++;
-                $uncoveredLineNums = [];
-                foreach ($lines as $lineNum => $hitCount) {
-                    if (is_numeric($lineNum)) {
-                        $totalLines++;
-                        if ($hitCount > 0) {
-                            $coveredLines++;
-                        } else {
-                            $uncoveredLines++;
-                            $uncoveredLineNums[] = (int)$lineNum;
-                        }
-                    }
-                }
-                if (!empty($uncoveredLineNums)) {
-                    sort($uncoveredLineNums);
-                    $ranges = [];
-                    $start = $uncoveredLineNums[0];
-                    $end = $start;
-                    for ($i = 1; $i < count($uncoveredLineNums); $i++) {
-                        if ($uncoveredLineNums[$i] === $end + 1) {
-                            $end = $uncoveredLineNums[$i];
-                        } else {
-                            $ranges[] = ($start === $end) ? $start : "$start-$end";
-                            $start = $uncoveredLineNums[$i];
-                            $end = $start;
-                        }
-                    }
-                    $ranges[] = ($start === $end) ? $start : "$start-$end";
-                    $uncoveredOnly[$file] = $ranges;
-                }
-            }
-        }
-
-        $coveragePercent = $totalLines > 0 ? round(($coveredLines / $totalLines) * 100, 1) : 0;
-
-        $result = [
-            "\$schema" => "https://koriym.github.io/xdebug-mcp/schemas/xcoverage.json",
-            "coverage_type" => "line",
-            "mode" => "raw",
-            "summary" => [
-                "files" => $totalFiles,
-                "total_lines" => $totalLines,
-                "covered_lines" => $coveredLines,
-                "uncovered_lines" => $uncoveredLines,
-                "coverage_percent" => $coveragePercent
-            ],
-            "uncovered" => $uncoveredOnly
-        ];
-    }
-    echo(json_encode($result, JSON_UNESCAPED_SLASHES));
-});
-');
-
 $phpPath = $phpOverride ?? PHP_BINARY;
 $xdebugFlag = XdebugFinder::getXdebugFlag();
-$escapedPrependFile = escapeshellarg($shutdownScript);
 
 // Default to PHPUnit for raw mode if no args
 if (empty($args)) {
@@ -512,13 +590,49 @@ if (empty($args)) {
     }
 }
 
+$shutdownScript = null;
+$runCodeArgument = findPhpRunCodeArgument($args);
+if ($runCodeArgument !== null) {
+    $codeIndex = $runCodeArgument['code_index'];
+    $codePrefix = $runCodeArgument['code_prefix'];
+    if (! isset($args[$codeIndex])) {
+        fwrite(STDERR, "Error: PHP inline code argument is required after {$runCodeArgument['option']}\n");
+        exit(1);
+    }
+
+    $inlineCode = $codePrefix === '' ? $args[$codeIndex] : substr($args[$codeIndex], strlen($codePrefix));
+    if ($inlineCode === '') {
+        fwrite(STDERR, "Error: PHP inline code argument is required after {$runCodeArgument['option']}\n");
+        exit(1);
+    }
+
+    $inlineBootstrap = compactPhpSnippet(
+        buildRawCoverageBootstrap(
+            $branchFlag,
+            $sourceLiteral,
+            $vendorExcludePathsLiteral,
+            filterCommandLineBootstrap: true,
+        ),
+    );
+    $args[$codeIndex] = $codePrefix . prefixPhpRunCode($inlineCode, $inlineBootstrap);
+} else {
+    $shutdownScript = tempnam(sys_get_temp_dir(), 'coverage_end_');
+    file_put_contents(
+        $shutdownScript,
+        "<?php\n" . buildRawCoverageBootstrap($branchFlag, $sourceLiteral, $vendorExcludePathsLiteral),
+    );
+}
+
 $escapedArgs = array_map('escapeshellarg', $args);
 $cmd = escapeshellarg($phpPath)
      . $xdebugFlag
-     . ' -dxdebug.mode=coverage -dauto_prepend_file='
-     . $escapedPrependFile
-     . ' '
-     . implode(' ', $escapedArgs);
+     . ' -dxdebug.mode=coverage ';
+
+if ($shutdownScript !== null) {
+    $cmd .= '-dauto_prepend_file=' . escapeshellarg($shutdownScript) . ' ';
+}
+
+$cmd .= implode(' ', $escapedArgs);
 
 if ($debug) {
     fwrite(STDERR, "[COVERAGE_DEBUG] Command: $cmd\n");
@@ -530,5 +644,7 @@ exec($cmd . ' 2>&1', $lines, $exitCode);
 $output = implode("\n", $lines);
 
 echo $output;
-unlink($shutdownScript);
+if ($shutdownScript !== null && file_exists($shutdownScript)) {
+    unlink($shutdownScript);
+}
 exit($exitCode);

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -676,6 +676,11 @@ final class McpServer
         }
     }
 
+    private function isPhpInlineCodeScript(string $script): bool
+    {
+        return preg_match('/^(\S*[\/\\\\])?php([0-9.]*)?(\.exe)?(?:\s+|$)(?:.*\s)?(?:-r\S*|--run(?:=\S*)?)(?:\s|$)/i', $script) === 1;
+    }
+
     /**
      * Validate breakpoint specifications
      * Format: "file.php:line" or "file.php:line:condition"
@@ -1102,6 +1107,10 @@ final class McpServer
 
             // Build command - user must specify PHP binary explicitly
             $cmd = $this->binDir . '/xcoverage';
+
+            if ($this->isPhpInlineCodeScript($script)) {
+                $cmd .= ' --raw';
+            }
 
             // Add include_vendor option if specified
             if ($includeVendor !== '') {

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -40,6 +40,7 @@ use function is_string;
 use function json_decode;
 use function json_encode;
 use function preg_match;
+use function preg_split;
 use function str_contains;
 use function str_ends_with;
 use function str_starts_with;
@@ -678,7 +679,54 @@ final class McpServer
 
     private function isPhpInlineCodeScript(string $script): bool
     {
-        return preg_match('/^(\S*[\/\\\\])?php([0-9.]*)?(\.exe)?(?:\s+|$)(?:.*\s)?(?:-r\S*|--run(?:=\S*)?)(?:\s|$)/i', $script) === 1;
+        $parts = preg_split('/\s+/', trim($script)) ?: [];
+        if ($parts === [] || preg_match('/^(\S*[\/\\\\])?php([0-9.]*)?(\.exe)?$/i', $parts[0]) !== 1) {
+            return false;
+        }
+
+        // Only inspect PHP interpreter options before the script file. Stop at the
+        // first non-option token (the script) or "--" so that a script's own
+        // arguments (e.g. `php app.php -r foo`) are not mistaken for inline code.
+        $optionsWithValue = [
+            '-d',
+            '-c',
+            '-z',
+            '-B',
+            '-R',
+            '-F',
+            '-E',
+            '--define',
+            '--php-ini',
+            '--zend-extension',
+            '--process-begin',
+            '--process-code',
+            '--process-file',
+            '--process-end',
+        ];
+
+        for ($i = 1; isset($parts[$i]); $i++) {
+            $arg = $parts[$i];
+
+            if (
+                $arg === '-r' || $arg === '--run'
+                || str_starts_with($arg, '--run=')
+                || (str_starts_with($arg, '-r') && $arg !== '-r')
+            ) {
+                return true;
+            }
+
+            if ($arg === '--' || ! str_starts_with($arg, '-')) {
+                return false;
+            }
+
+            if (! in_array($arg, $optionsWithValue, true) || ! isset($parts[$i + 1])) {
+                continue;
+            }
+
+            $i++;
+        }
+
+        return false;
     }
 
     /**

--- a/src/XdebugRunner.php
+++ b/src/XdebugRunner.php
@@ -59,6 +59,22 @@ class XdebugRunner
     /** PHP CLI options that consume the following argument as their value. */
     private const PHP_OPTIONS_WITH_VALUE = ['-d', '-c', '-z', '-B', '-R', '-F', '-E'];
 
+    /**
+     * Long-form PHP CLI options that consume the following argument as their value.
+     * These are the long aliases of {@see PHP_OPTIONS_WITH_VALUE}. The attached form
+     * (e.g. "--define=foo=bar") needs no special handling; only the space-separated
+     * form (e.g. "--define foo=bar") must skip the following value argument.
+     */
+    private const PHP_LONG_OPTIONS_WITH_VALUE = [
+        '--define',
+        '--php-ini',
+        '--zend-extension',
+        '--process-begin',
+        '--process-code',
+        '--process-file',
+        '--process-end',
+    ];
+
     /** PHP CLI options that execute inline source code instead of a file. */
     private const PHP_INLINE_CODE_OPTIONS = ['-r', '--run'];
 
@@ -318,7 +334,9 @@ class XdebugRunner
                 return $arg;
             }
 
-            if (! in_array($arg, self::PHP_OPTIONS_WITH_VALUE, true) || ! isset($parts[$index + 1])) {
+            $takesValue = in_array($arg, self::PHP_OPTIONS_WITH_VALUE, true)
+                || in_array($arg, self::PHP_LONG_OPTIONS_WITH_VALUE, true);
+            if (! $takesValue || ! isset($parts[$index + 1])) {
                 continue;
             }
 

--- a/src/XdebugRunner.php
+++ b/src/XdebugRunner.php
@@ -20,9 +20,11 @@ use function fwrite;
 use function getenv;
 use function glob;
 use function implode;
+use function in_array;
 use function passthru;
 use function preg_match;
 use function sprintf;
+use function str_starts_with;
 use function trim;
 use function usort;
 
@@ -53,6 +55,12 @@ class XdebugRunner
      * as those are server processes not suitable for CLI script execution.
      */
     private const PHP_BINARY_PATTERN = '#(?:^|[\\\\/])php(?:[-@]?\d+(?:\.\d+)*)?(?:\.exe)?$#i';
+
+    /** PHP CLI options that consume the following argument as their value. */
+    private const PHP_OPTIONS_WITH_VALUE = ['-d', '-c', '-z', '-B', '-R', '-F', '-E'];
+
+    /** PHP CLI options that execute inline source code instead of a file. */
+    private const PHP_INLINE_CODE_OPTIONS = ['-r', '--run'];
 
     private string $mode = 'trace';
 
@@ -273,11 +281,51 @@ class XdebugRunner
             array_shift($workingParts);
         }
 
-        $targetFile = $workingParts[0] ?? '';
+        $targetFile = $this->findLocalFileArgument($workingParts);
 
-        if ($targetFile !== '' && ! file_exists($targetFile)) {
+        if ($targetFile !== null && $targetFile !== '' && ! file_exists($targetFile)) {
             throw new RuntimeException("File not found: '$targetFile'");
         }
+    }
+
+    /** @param string[] $parts Command parts after the PHP binary, if one was present. */
+    private function findLocalFileArgument(array $parts): string|null
+    {
+        for ($index = 0; isset($parts[$index]); $index++) {
+            $arg = $parts[$index];
+
+            if (in_array($arg, self::PHP_INLINE_CODE_OPTIONS, true)) {
+                if (! isset($parts[$index + 1])) {
+                    throw new RuntimeException("Code argument is required after {$arg}");
+                }
+
+                return null;
+            }
+
+            if (str_starts_with($arg, '-r') && $arg !== '-r') {
+                return null;
+            }
+
+            if (str_starts_with($arg, '--run=')) {
+                return null;
+            }
+
+            if ($arg === '--') {
+                return $parts[$index + 1] ?? '';
+            }
+
+            if (! str_starts_with($arg, '-')) {
+                return $arg;
+            }
+
+            if (! in_array($arg, self::PHP_OPTIONS_WITH_VALUE, true) || ! isset($parts[$index + 1])) {
+                continue;
+            }
+
+            $index++;
+        }
+
+        return '';
     }
 
     /** @param string[] $parts */

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -381,12 +381,8 @@ PHP);
         $this->assertStringNotContainsString('strict_types declaration must be the very first statement', $output);
     }
 
-    public function testXcoverageRawBranchPhpRunFiltersBootstrapClosure(): void
+    public function testXcoverageRawBranchPhpRunFailsBeforeExecutingInlineCode(): void
     {
-        if (! XdebugFinder::isXdebugAvailable()) {
-            $this->markTestSkipped('Xdebug not available');
-        }
-
         $command = sprintf(
             'cd %s && ./bin/xcoverage --raw --branch-coverage -- php -r %s 2>&1',
             escapeshellarg(dirname(__DIR__, 2)),
@@ -395,21 +391,9 @@ PHP);
 
         $output = shell_exec($command);
         $this->assertNotNull($output);
-        $this->assertStringContainsString("branch\n", $output);
-
-        $jsonStart = strrpos($output, '{"$schema"');
-        $this->assertNotFalse($jsonStart, $output);
-
-        $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
-        $functions = $coverage['coverage']['Command line code']['functions'] ?? [];
-        $this->assertIsArray($functions);
-
-        foreach (array_keys($functions) as $function) {
-            $this->assertFalse(
-                str_starts_with((string) $function, '{closure:Command line code:'),
-                'Bootstrap shutdown closure leaked into branch coverage',
-            );
-        }
+        $this->assertStringContainsString('--branch-coverage is not supported with PHP inline code (-r)', $output);
+        $this->assertStringNotContainsString("branch\n", $output);
+        $this->assertStringNotContainsString('Segmentation fault', $output);
     }
 
     public function testXprofileSupportsPhpRunOption(): void

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -319,6 +319,124 @@ PHP);
         }
     }
 
+    public function testXcoverageRawSupportsPhpRunOption(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $command = sprintf(
+            'cd %s && ./bin/xcoverage --raw -- php -r %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg('echo strlen("abc"), PHP_EOL;'),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringContainsString("3\n", $output);
+
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('raw', $coverage['mode']);
+        $this->assertSame('line', $coverage['coverage_type']);
+        $this->assertGreaterThanOrEqual(1, $coverage['summary']['files']);
+        $this->assertGreaterThanOrEqual(1, $coverage['summary']['covered_lines']);
+    }
+
+    public function testXcoverageRawPhpRunPreservesLineConstant(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $command = sprintf(
+            'cd %s && ./bin/xcoverage --raw -- php -r %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg('echo __LINE__, PHP_EOL;'),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringStartsWith("1\n", $output);
+    }
+
+    public function testXcoverageRawPhpRunPreservesLeadingStrictTypesDeclare(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $command = sprintf(
+            'cd %s && ./bin/xcoverage --raw -- php -r %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg('declare(strict_types=1); echo __LINE__, PHP_EOL;'),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringStartsWith("1\n", $output);
+        $this->assertStringNotContainsString('strict_types declaration must be the very first statement', $output);
+    }
+
+    public function testXcoverageRawBranchPhpRunFiltersBootstrapClosure(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $command = sprintf(
+            'cd %s && ./bin/xcoverage --raw --branch-coverage -- php -r %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg('if (true) { echo "branch", PHP_EOL; }'),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringContainsString("branch\n", $output);
+
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $coverage = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+        $functions = $coverage['coverage']['Command line code']['functions'] ?? [];
+        $this->assertIsArray($functions);
+
+        foreach (array_keys($functions) as $function) {
+            $this->assertFalse(
+                str_starts_with((string) $function, '{closure:Command line code:'),
+                'Bootstrap shutdown closure leaked into branch coverage',
+            );
+        }
+    }
+
+    public function testXprofileSupportsPhpRunOption(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $command = sprintf(
+            'cd %s && ./bin/xprofile --json -- php -r %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg('echo strlen("abc"), PHP_EOL;'),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+
+        $jsonStart = strrpos($output, '{"specification"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $profile = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('file', $profile);
+        $this->assertArrayHasKey('bottlenecks', $profile);
+        $this->assertSame("3\n", $profile['output']);
+    }
+
     public function testXstepCommandExists(): void
     {
         $this->assertTrue(file_exists(__DIR__ . '/../../bin/xstep'));

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -316,6 +316,16 @@ class McpServerTest extends TestCase
         $this->assertFalse($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php script.php']));
     }
 
+    public function testIsPhpInlineCodeScriptIgnoresRunPastScriptBoundary(): void
+    {
+        // -r belongs to the script's own arguments, not the interpreter.
+        $this->assertFalse($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php app.php -r dry-run']));
+        $this->assertFalse($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php -- -r code']));
+        // Interpreter options before -r must not hide it (value of -d is skipped).
+        $this->assertTrue($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php -d memory_limit=512M -r "echo 1;"']));
+        $this->assertTrue($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php --define memory_limit=512M -r "echo 1;"']));
+    }
+
     public function testExecuteToolCall(): void
     {
         // Test executeToolCall method directly - it should handle exceptions and return formatted result

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -308,6 +308,14 @@ class McpServerTest extends TestCase
         $this->invokePrivateMethod($this->server, 'validatePhpBinaryScript', ['python script.py']);
     }
 
+    public function testIsPhpInlineCodeScriptDetectsRunForms(): void
+    {
+        $this->assertTrue($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php -r "echo 1;"']));
+        $this->assertTrue($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php -recho 1;']));
+        $this->assertTrue($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php --run=echo 1;']));
+        $this->assertFalse($this->invokePrivateMethod($this->server, 'isPhpInlineCodeScript', ['php script.php']));
+    }
+
     public function testExecuteToolCall(): void
     {
         // Test executeToolCall method directly - it should handle exceptions and return formatted result

--- a/tests/Unit/XdebugRunnerTest.php
+++ b/tests/Unit/XdebugRunnerTest.php
@@ -248,6 +248,44 @@ final class XdebugRunnerTest extends TestCase
     }
 
     #[Test]
+    public function buildsProfileCommandWithPhpRunOption(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '-r', 'echo strlen("abc"), PHP_EOL;']);
+        $runner->setMode('profile');
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('-dxdebug.mode=profile', $command);
+        $this->assertStringContainsString('-dxdebug.profiler_output_name=cachegrind.out.%p', $command);
+        $this->assertStringContainsString("'-r'", $command);
+        $this->assertStringContainsString('echo strlen("abc")', $command);
+    }
+
+    #[Test]
+    public function buildsProfileCommandWithAttachedPhpRunOption(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '-recho strlen("abc"), PHP_EOL;']);
+        $runner->setMode('profile');
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('-dxdebug.mode=profile', $command);
+        $this->assertStringContainsString('-recho strlen("abc")', $command);
+    }
+
+    #[Test]
+    public function phpRunOptionRequiresCodeArgument(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '-r']);
+        $runner->setMode('profile');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Code argument is required after -r');
+
+        $runner->buildCommand();
+    }
+
+    #[Test]
     public function buildsDockerCommandWithXdebugArgsInjected(): void
     {
         $runner = new XdebugRunner([
@@ -390,6 +428,17 @@ final class XdebugRunnerTest extends TestCase
 
         $command = $runner->buildCommand();
 
+        $this->assertStringContainsString(__FILE__, $command);
+    }
+
+    #[Test]
+    public function validateLocalFileAcceptsPhpOptionsBeforeExistingFile(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '-d', 'memory_limit=512M', __FILE__]);
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('memory_limit=512M', $command);
         $this->assertStringContainsString(__FILE__, $command);
     }
 

--- a/tests/Unit/XdebugRunnerTest.php
+++ b/tests/Unit/XdebugRunnerTest.php
@@ -443,6 +443,28 @@ final class XdebugRunnerTest extends TestCase
     }
 
     #[Test]
+    public function validateLocalFileAcceptsLongFormPhpOptionBeforeExistingFile(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '--define', 'memory_limit=512M', __FILE__]);
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('memory_limit=512M', $command);
+        $this->assertStringContainsString(__FILE__, $command);
+    }
+
+    #[Test]
+    public function validateLocalFileAcceptsAttachedLongFormPhpOptionBeforeExistingFile(): void
+    {
+        $runner = new XdebugRunner(['script', '--', 'php', '--define=memory_limit=512M', __FILE__]);
+
+        $command = $runner->buildCommand();
+
+        $this->assertStringContainsString('memory_limit=512M', $command);
+        $this->assertStringContainsString(__FILE__, $command);
+    }
+
+    #[Test]
     public function validateLocalFileWithoutPhpPrefix(): void
     {
         $runner = new XdebugRunner(['script', '--', __FILE__]);


### PR DESCRIPTION
## Summary
- support PHP inline code invocations such as `php -r` and `php --run` in local Xdebug command validation
- make raw coverage bootstrap work for inline code while preserving `__LINE__` and leading `declare(strict_types=1)`
- detect inline PHP scripts from MCP coverage calls and add integration/unit coverage

## Validation
- `composer tests`
- `coderabbit review --agent -t uncommitted`
- `./bin/xcoverage --raw -- php -r 'echo __LINE__, PHP_EOL;'`
- `./bin/xprofile --json -- php -r 'echo strlen("abc"), PHP_EOL;'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * xcoverage raw mode now supports collecting coverage for inline PHP passed via -r/--run.
  * xprofile JSON mode supports profiling inline PHP via -r/--run.
  * Help output for xcoverage includes a --raw inline example.

* **Bug Fixes / Behavior**
  * Inline code handling preserves __LINE__ and leading declare(strict_types=1);
  * --branch-coverage is rejected for PHP inline code with a clear error message.

* **Tests**
  * Added integration and unit tests covering inline -r/--run scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->