### PR TITLE
Harden xcompare worktree and error handling

### DIFF
--- a/bin/xcompare
+++ b/bin/xcompare
@@ -218,6 +218,11 @@ function showCompareHelp(): void
         $options['include_vendor'] = $includeVendor;
     }
 
-    $runner = new CompareRunner($options);
-    $runner->output();
+    try {
+        $runner = new CompareRunner($options);
+        $runner->output();
+    } catch (\Throwable $e) {
+        fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+        exit(1);
+    }
 })();

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
             "psalm --clear-cache"
         ],
         "sa": [
-            "phpstan"
+            "php -d memory_limit=512M ./vendor/bin/phpstan"
         ],
         "test-json": "./bin/test-json",
         "demo": "./demo/run-demo.sh",

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Koriym\XdebugMcp;
 
 use InvalidArgumentException;
+use JsonException;
 use RuntimeException;
 
 use function array_diff_key;
@@ -17,14 +18,19 @@ use function fclose;
 use function file_get_contents;
 use function fwrite;
 use function implode;
+use function is_array;
 use function is_resource;
 use function json_decode;
 use function json_encode;
+use function ksort;
 use function preg_match;
 use function proc_close;
 use function proc_open;
 use function sort;
 use function stream_get_contents;
+use function strlen;
+use function strpos;
+use function substr;
 use function sys_get_temp_dir;
 use function tempnam;
 use function trim;
@@ -65,10 +71,10 @@ class CompareRunner
      */
     public function run(): array
     {
-        [$commandA, $commandB, $labelA, $labelB] = $this->resolveCommands();
-        $cwdB = $this->worktreePath;
-
         try {
+            [$commandA, $commandB, $labelA, $labelB] = $this->resolveCommands();
+            $cwdB = $this->worktreePath;
+
             $resultA = $this->executeXstep($commandA);
             $resultB = $this->executeXstep($commandB, $cwdB);
         } finally {
@@ -197,12 +203,16 @@ class CompareRunner
         }
 
         $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid('', true);
+        $this->worktreePath = $tempDir;
 
         $output = [];
         $exitCode = 0;
-        exec('git worktree add ' . escapeshellarg($tempDir) . ' ' . escapeshellarg($ref) . ' 2>&1', $output, $exitCode);
+        exec('git worktree add --detach ' . escapeshellarg($tempDir) . ' ' . escapeshellarg($ref) . ' 2>&1', $output, $exitCode);
 
         if ($exitCode !== 0) {
+            exec('git worktree remove ' . escapeshellarg($tempDir) . ' --force >/dev/null 2>&1');
+            $this->worktreePath = null;
+
             throw new RuntimeException('Failed to create worktree for ref: ' . $ref . "\n" . implode("\n", $output));
         }
 
@@ -280,7 +290,8 @@ class CompareRunner
         }
 
         if ($exitCode !== 0) {
-            $suffix = $stderr !== '' ? "\n{$stderr}" : '';
+            $detail = $this->summarizeProcessError($stderr);
+            $suffix = $detail !== '' ? "\n{$detail}" : '';
 
             throw new RuntimeException("xstep failed (exit {$exitCode}) for command: {$command}{$suffix}");
         }
@@ -290,9 +301,74 @@ class CompareRunner
         }
 
         /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
-        $result = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        $result = $this->decodeXstepOutput($stdout, $command);
 
         return $result;
+    }
+
+    /**
+     * Decode xstep JSON and include a stdout excerpt when parsing fails.
+     *
+     * @return array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>}
+     */
+    private function decodeXstepOutput(string $stdout, string $command): array
+    {
+        try {
+            $result = json_decode($stdout, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $excerpt = $this->excerpt($stdout);
+
+            throw new RuntimeException(
+                "xstep returned invalid JSON for command: {$command}\n"
+                . $e->getMessage() . "\n"
+                . "stdout excerpt:\n{$excerpt}",
+                0,
+                $e,
+            );
+        }
+
+        if (! is_array($result)) {
+            $excerpt = $this->excerpt($stdout);
+
+            throw new RuntimeException(
+                "xstep returned non-array JSON for command: {$command}\n"
+                . "stdout excerpt:\n{$excerpt}",
+            );
+        }
+
+        /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
+        return $result;
+    }
+
+    private function summarizeProcessError(string $stderr): string
+    {
+        $stderr = trim($stderr);
+        if ($stderr === '') {
+            return '';
+        }
+
+        if (preg_match('/PHP Fatal error:\s+Uncaught [^:]+:\s+(.*?)(?:\s+in\s+[^\n]+)?\nStack trace:/s', $stderr, $m)) {
+            return $this->excerpt(trim($m[1]));
+        }
+
+        $stackTracePosition = strpos($stderr, "\nStack trace:");
+        if ($stackTracePosition !== false) {
+            $stderr = substr($stderr, 0, $stackTracePosition);
+        }
+
+        $fatalDuplicatePosition = strpos($stderr, "\nFatal error:");
+        if ($fatalDuplicatePosition !== false) {
+            $stderr = substr($stderr, 0, $fatalDuplicatePosition);
+        }
+
+        return $this->excerpt(trim($stderr));
+    }
+
+    private function excerpt(string $text): string
+    {
+        $maxBytes = 1000;
+
+        return strlen($text) > $maxBytes ? substr($text, 0, $maxBytes) . '...' : $text;
     }
 
     /**
@@ -399,6 +475,7 @@ class CompareRunner
         sort($onlyInB);
 
         sort($unchanged);
+        ksort($changed);
 
         return [
             'changed' => $changed,

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -210,10 +210,20 @@ class CompareRunner
         exec('git worktree add --detach ' . escapeshellarg($tempDir) . ' ' . escapeshellarg($ref) . ' 2>&1', $output, $exitCode);
 
         if ($exitCode !== 0) {
-            exec('git worktree remove ' . escapeshellarg($tempDir) . ' --force >/dev/null 2>&1');
-            $this->worktreePath = null;
+            $cleanupOutput = [];
+            $cleanupExit = 0;
+            exec('git worktree remove ' . escapeshellarg($tempDir) . ' --force 2>&1', $cleanupOutput, $cleanupExit);
+            if ($cleanupExit === 0) {
+                $this->worktreePath = null;
+            }
 
-            throw new RuntimeException('Failed to create worktree for ref: ' . $ref . "\n" . implode("\n", $output));
+            $cleanupDetail = $cleanupExit !== 0
+                ? "\nFailed to cleanup partial worktree:\n" . implode("\n", $cleanupOutput)
+                : '';
+
+            throw new RuntimeException(
+                'Failed to create worktree for ref: ' . $ref . "\n" . implode("\n", $output) . $cleanupDetail,
+            );
         }
 
         return $tempDir;

--- a/tests/Integration/Cli/XcompareCliTest.php
+++ b/tests/Integration/Cli/XcompareCliTest.php
@@ -110,4 +110,18 @@ class XcompareCliTest extends TestCase
         $this->assertStringContainsString('--run=', $joined);
         $this->assertStringContainsString('MODE 2:', $joined);
     }
+
+    public function testCliRuntimeErrorDoesNotEmitStackTrace(): void
+    {
+        $output = [];
+        $exitCode = 0;
+        exec('php ' . __DIR__ . '/../../../bin/xcompare --break=missing.php:1 --run-a="php missing.php" --run-b="php missing.php" 2>&1', $output, $exitCode);
+
+        $joined = implode("\n", $output);
+        $this->assertNotSame(0, $exitCode);
+        $this->assertStringContainsString('Error: xstep failed', $joined);
+        $this->assertStringContainsString('Breakpoint file not found: missing.php', $joined);
+        $this->assertStringNotContainsString('Stack trace:', $joined);
+        $this->assertStringNotContainsString('Fatal error:', $joined);
+    }
 }

--- a/tests/Integration/CompareRunnerWorktreeTest.php
+++ b/tests/Integration/CompareRunnerWorktreeTest.php
@@ -4,68 +4,101 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\Tests\Integration;
 
+use FilesystemIterator;
 use Koriym\XdebugMcp\CompareRunner;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use ReflectionClass;
 use RuntimeException;
 
+use function chdir;
 use function clearstatcache;
+use function escapeshellarg;
 use function exec;
-use function trim;
+use function file_put_contents;
+use function getcwd;
+use function implode;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
 
 /**
  * Exercises the real `git worktree` lifecycle in --compare-with mode.
- *
- * Skipped when the test run is not inside a git work tree (e.g. a tarball
- * install), since the whole code path only ever runs inside one.
  */
 class CompareRunnerWorktreeTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $output = [];
-        $exit = 0;
-        exec('git rev-parse --is-inside-work-tree 2>/dev/null', $output, $exit);
-        $insideWorkTree = $exit === 0 && trim($output[0] ?? '') === 'true';
-        if ($insideWorkTree) {
-            return;
-        }
-
-        $this->markTestSkipped('not inside a git work tree');
-    }
-
     public function testCreateWorktreeCreatesAndCleanupRemovesIt(): void
     {
+        $originalCwd = $this->currentWorkingDirectory();
+        $repoDir = $this->createTemporaryRepository();
         $runner = $this->newRunner();
 
-        $path = $this->invoke($runner, 'createWorktree', ['HEAD']);
-        $this->assertIsString($path);
-        $this->assertDirectoryExists($path);
+        try {
+            chdir($repoDir);
+            $path = $this->invoke($runner, 'createWorktree', ['HEAD']);
+            $this->assertIsString($path);
+            $this->assertDirectoryExists($path);
 
-        // cleanupWorktree() keys off the private $worktreePath property, which is
-        // normally set by resolveCompareWithMode(). Set it directly here so we can
-        // exercise cleanup in isolation without running a full xstep.
-        $ref = new ReflectionClass($runner);
-        $prop = $ref->getProperty('worktreePath');
-        $prop->setValue($runner, $path);
+            $this->invoke($runner, 'cleanupWorktree', []);
+            clearstatcache(true, $path);
+            $this->assertDirectoryDoesNotExist($path);
+        } finally {
+            chdir($originalCwd);
+            $this->removeDirectory($repoDir);
+        }
+    }
 
-        $this->invoke($runner, 'cleanupWorktree', []);
-        clearstatcache(true, $path);
-        $this->assertDirectoryDoesNotExist($path);
+    public function testCreateWorktreeUsesDetachedCheckoutForAlreadyCheckedOutBranch(): void
+    {
+        $originalCwd = $this->currentWorkingDirectory();
+        $repoDir = $this->createTemporaryRepository();
+        $worktreePath = null;
+        $runner = $this->newRunner();
+
+        try {
+            chdir($repoDir);
+            $worktreePath = $this->invoke($runner, 'createWorktree', ['main']);
+            $this->assertIsString($worktreePath);
+            $this->assertDirectoryExists($worktreePath);
+
+            $output = [];
+            $exit = 0;
+            exec('git -C ' . escapeshellarg($worktreePath) . ' symbolic-ref -q HEAD 2>&1', $output, $exit);
+            $this->assertNotSame(0, $exit, 'comparison worktree should be detached');
+        } finally {
+            if ($worktreePath !== null) {
+                $this->invoke($runner, 'cleanupWorktree', []);
+            }
+
+            chdir($originalCwd);
+            $this->removeDirectory($repoDir);
+        }
     }
 
     public function testCreateWorktreeFailsForUnknownRef(): void
     {
+        $originalCwd = $this->currentWorkingDirectory();
+        $repoDir = $this->createTemporaryRepository();
         $runner = $this->newRunner();
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failed to create worktree for ref');
 
         try {
-            $this->invoke($runner, 'createWorktree', ['definitely-not-a-real-ref-xcompare']);
+            chdir($repoDir);
+            try {
+                $this->invoke($runner, 'createWorktree', ['definitely-not-a-real-ref-xcompare']);
+            } finally {
+                // Harmless if createWorktree() failed before registering a worktree.
+                $this->invoke($runner, 'cleanupWorktree', []);
+            }
         } finally {
-            // Defensive: if git somehow left a dir behind, clean up.
-            $this->invoke($runner, 'cleanupWorktree', []);
+            chdir($originalCwd);
+            $this->removeDirectory($repoDir);
         }
     }
 
@@ -85,5 +118,63 @@ class CompareRunnerWorktreeTest extends TestCase
         $m = $ref->getMethod($method);
 
         return $m->invokeArgs($runner, $args);
+    }
+
+    private function runCommand(string $command): void
+    {
+        $output = [];
+        $exit = 0;
+        exec($command . ' 2>&1', $output, $exit);
+
+        $this->assertSame(0, $exit, implode("\n", $output));
+    }
+
+    private function currentWorkingDirectory(): string
+    {
+        $cwd = getcwd();
+        $this->assertIsString($cwd);
+
+        return $cwd;
+    }
+
+    private function createTemporaryRepository(): string
+    {
+        $repoDir = sys_get_temp_dir() . '/xcompare-repo-' . uniqid('', true);
+        mkdir($repoDir);
+
+        $this->runCommand('git -C ' . escapeshellarg($repoDir) . ' init');
+        file_put_contents($repoDir . '/fixture.txt', "fixture\n");
+        $this->runCommand('git -C ' . escapeshellarg($repoDir) . ' add fixture.txt');
+        $this->runCommand(
+            'git -C ' . escapeshellarg($repoDir)
+            . ' -c user.email=xcompare@example.com -c user.name=xcompare commit -m init',
+        );
+        $this->runCommand('git -C ' . escapeshellarg($repoDir) . ' branch -M main');
+
+        return $repoDir;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            $pathname = $item->getPathname();
+            if ($item->isDir() && ! $item->isLink()) {
+                rmdir($pathname);
+                continue;
+            }
+
+            unlink($pathname);
+        }
+
+        rmdir($path);
     }
 }

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 
+use function array_keys;
 use function array_merge;
 use function json_decode;
 use function ob_get_clean;
@@ -57,6 +58,18 @@ class CompareRunnerTest extends TestCase
         $this->assertSame(['$y'], $diff['unchanged']);
         $this->assertSame([], $diff['only_in_a']);
         $this->assertSame([], $diff['only_in_b']);
+    }
+
+    public function testComputeDiffSortsChangedVariables(): void
+    {
+        $runner = $this->createRunner();
+
+        $varsA = ['$z' => 'int: 1', '$a' => 'int: 1'];
+        $varsB = ['$z' => 'int: 2', '$a' => 'int: 2'];
+
+        $diff = $this->invokeMethod($runner, 'computeDiff', [$varsA, $varsB]);
+
+        $this->assertSame(['$a', '$z'], array_keys($diff['changed']));
     }
 
     public function testComputeDiffWithOnlyInA(): void
@@ -607,5 +620,27 @@ class CompareRunnerTest extends TestCase
         $this->assertIsArray($decoded);
         $this->assertArrayHasKey('$schema', $decoded);
         $this->assertArrayHasKey('diff', $decoded);
+    }
+
+    public function testDecodeXstepOutputReportsInvalidJsonExcerpt(): void
+    {
+        $runner = $this->createRunner();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('xstep returned invalid JSON for command: php bad.php');
+        $this->expectExceptionMessage('stdout excerpt:');
+        $this->expectExceptionMessage('not-json');
+
+        $this->invokeMethod($runner, 'decodeXstepOutput', ['not-json', 'php bad.php']);
+    }
+
+    public function testDecodeXstepOutputRejectsNonArrayJson(): void
+    {
+        $runner = $this->createRunner();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('xstep returned non-array JSON for command: php bad.php');
+
+        $this->invokeMethod($runner, 'decodeXstepOutput', ['null', 'php bad.php']);
     }
 }


### PR DESCRIPTION
## Summary
- make xcompare comparison worktrees detached and clean them up reliably
- improve xstep JSON/error diagnostics while keeping CLI runtime errors concise
- stabilize xcompare diff ordering and add regression coverage
- raise Composer static-analysis memory for the project test gate

## Validation
- composer tests

## Self-review
- Inspected PR patch with gh pr diff --patch.
- Confirmed PR is rebased onto latest origin/1.x.
- CI checks are passing while the PR is draft.

## Notes
- CodeRabbit CLI review was not run; GitHub-side CodeRabbit is available and will be re-checked after marking ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Bug Fixes**
  * Improved CLI error handling with clearer messages and no stack traces on runtime failures.
  * More robust JSON parsing/validation with better error excerpts for invalid output.
  * Deterministic diff output ordering for consistent results.
  * Safer git worktree creation/cleanup with improved failure recovery.

* **Tests**
  * Added integration coverage to ensure runtime errors don’t emit stack traces.
  * Expanded unit tests for diff ordering and JSON decoding error behavior.

* **Chores**
  * Updated the analysis script to run with a higher PHP memory limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->