### PR TITLE
Slim down xstep step-recording JSON output

### DIFF
--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -37,6 +37,7 @@
         "stack": {
           "type": "array",
           "description": "Call stack at this stop, ordered innermost-first: index 0 is the current frame where execution stopped; each later entry is its caller. Read the stop location and function from stack[0] — the former per-step `location` and `function` fields were removed as duplicates of it.",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/stack_frame"
           }
@@ -51,7 +52,7 @@
         },
         "diff": {
           "type": "object",
-          "description": "Variable changes since the previous recorded stop. Scalar changes include before/after values; array/object changes may include shallow key diffs. Variables absent from `diff` are unchanged from the previous step: reconstruct the full current state by applying successive diffs onto the most recent 'full' frame's snapshot. On a stack-frame change the previous frame's locals appear as `removed` and the new frame's variables as `added` (carrying their current values in `after`), so the 'unchanged' rule applies within one frame's scope — restart reconstruction from those `added` values on a frame change.",
+          "description": "Variable changes since the previous recorded stop. Scalar changes include before/after values; array/object changes may include shallow key diffs. Variables absent from `diff` are unchanged from the previous step: reconstruct the full current state by applying successive diffs onto the most recent 'full' frame's snapshot. A stack-frame change is visible through `stack[0]`; diff entries still represent name/value changes from the previous recorded stop, so same-name/same-value variables may remain absent from `diff` and should be carried forward unless a new 'full' frame is emitted.",
           "additionalProperties": {
             "$ref": "#/definitions/variable_diff"
           }

--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -47,7 +47,7 @@
         },
         "variables": {
           "type": "object",
-          "description": "Full variable snapshot at the breakpoint. Present only on 'full' frames; omitted on 'diff' frames because the values are recoverable from `diff` (each entry's `after`, with removed variables marked change 'removed')."
+          "description": "Full variable snapshot at the breakpoint. Present only on 'full' frames; omitted on 'diff' frames because values are recoverable from `diff` (`after` for added/changed entries, and `change: 'removed'` with `before` for deletions)."
         },
         "diff": {
           "type": "object",

--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -36,7 +36,7 @@
         },
         "stack": {
           "type": "array",
-          "description": "Short stack summary for the current stop",
+          "description": "Call stack at this stop, ordered innermost-first: index 0 is the current frame where execution stopped; each later entry is its caller. Read the stop location and function from stack[0] — the former per-step `location` and `function` fields were removed as duplicates of it.",
           "items": {
             "$ref": "#/definitions/stack_frame"
           }
@@ -47,11 +47,11 @@
         },
         "variables": {
           "type": "object",
-          "description": "Full variable snapshot at the breakpoint. Present only on 'full' frames; omitted on 'diff' frames because values are recoverable from `diff` (`after` for added/changed entries, and `change: 'removed'` with `before` for deletions)."
+          "description": "Full variable snapshot at the breakpoint. Present only on 'full' frames; omitted on 'diff' frames because values are recoverable from `diff` (`after` for added/changed entries, and `change: 'removed'` with `before` for deletions). Each value is a rendered 'type: value' string, e.g. 'int: 0', 'array: [1, 2, 3]', 'uninitialized: ' (same format used by diff before/after)."
         },
         "diff": {
           "type": "object",
-          "description": "Variable changes since the previous recorded stop. Scalar changes include before/after values; array/object changes may include shallow key diffs.",
+          "description": "Variable changes since the previous recorded stop. Scalar changes include before/after values; array/object changes may include shallow key diffs. Variables absent from `diff` are unchanged from the previous step: reconstruct the full current state by applying successive diffs onto the most recent 'full' frame's snapshot. On a stack-frame change the previous frame's locals appear as `removed` and the new frame's variables as `added` (carrying their current values in `after`), so the 'unchanged' rule applies within one frame's scope — restart reconstruction from those `added` values on a frame change.",
           "additionalProperties": {
             "$ref": "#/definitions/variable_diff"
           }
@@ -59,7 +59,7 @@
         "recording_type": {
           "type": "string",
           "enum": ["full", "diff"],
-          "description": "Present only in step-recording mode (--break + --steps). 'full' marks the first recorded step and contains the complete variable snapshot; 'diff' marks subsequent steps and contains only the changes from the previous step (added, modified, or deleted entries — deletions are encoded as '[DELETED]')."
+          "description": "Present only in step-recording mode (--break + --steps). 'full' marks the first recorded step and carries the complete variable snapshot in `variables`; 'diff' marks subsequent steps and carries only the changes in `diff` (added, changed, or removed entries; removals use change 'removed' with a `before` value). On 'diff' steps the `variables` field is omitted, and a step with no variable changes carries an empty or absent `diff`."
         },
         "watches": {
           "type": "array",
@@ -108,10 +108,11 @@
     },
     "stack_frame": {
       "type": "object",
+      "description": "One call-stack frame. Frames are ordered innermost-first within `stack` (index 0 = current frame).",
       "properties": {
-        "function": { "type": "string" },
-        "file": { "type": "string" },
-        "line": { "type": "integer" }
+        "function": { "type": "string", "description": "Function or method name (Class::method, or '{main}' for the top-level script scope)" },
+        "file": { "type": "string", "description": "Source file basename" },
+        "line": { "type": "integer", "description": "Current execution line for the frame at index 0; the call-site line for caller frames" }
       },
       "required": ["function", "file", "line"]
     },

--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -5,6 +5,10 @@
   "description": "Debug state at breakpoints plus execution trace. Breakpoints show 'crime scene photo', trace shows 'surveillance footage'.",
   "type": "object",
   "properties": {
+    "breakpoint": {
+      "$ref": "#/definitions/breakpoint_reference",
+      "description": "Breakpoint shared by all recorded steps, emitted once at the top level (step-recording mode). For multi-breakpoint runs the attribution appears per-step inside each break instead."
+    },
     "breaks": {
       "type": "array",
       "description": "Breakpoints hit during execution",
@@ -30,18 +34,6 @@
           "type": "integer",
           "description": "Sequential step number"
         },
-        "location": {
-          "type": "object",
-          "properties": {
-            "file": { "type": "string" },
-            "line": { "type": "integer" }
-          },
-          "required": ["file", "line"]
-        },
-        "function": {
-          "type": "string",
-          "description": "Current function or method name from the top stack frame"
-        },
         "stack": {
           "type": "array",
           "description": "Short stack summary for the current stop",
@@ -50,11 +42,12 @@
           }
         },
         "breakpoint": {
-          "$ref": "#/definitions/breakpoint_reference"
+          "$ref": "#/definitions/breakpoint_reference",
+          "description": "Per-step breakpoint attribution for multi-breakpoint runs. In step-recording mode the shared breakpoint is emitted once at the top level instead of here."
         },
         "variables": {
           "type": "object",
-          "description": "Variable values at breakpoint. In step-recording mode (--break + --steps) the contents depend on recording_type: a 'full' frame carries every variable, while a 'diff' frame carries only variables that were added, changed, or removed since the previous step (deleted variables appear with the value '[DELETED]'). When present, diff adds before/after and shallow key-level details."
+          "description": "Full variable snapshot at the breakpoint. Present only on 'full' frames; omitted on 'diff' frames because the values are recoverable from `diff` (each entry's `after`, with removed variables marked change 'removed')."
         },
         "diff": {
           "type": "object",
@@ -96,7 +89,7 @@
           }
         }
       },
-      "required": ["location", "variables"]
+      "required": ["stack"]
     },
     "breakpoint_reference": {
       "type": "object",

--- a/skills/xdebug/SKILL.md
+++ b/skills/xdebug/SKILL.md
@@ -71,7 +71,14 @@ Trace execution forward from start to finish. Captures complete execution flow, 
 Stop at breakpoint, step forward N times, record variable changes at each step. See how variable values affect branching ("this variable was X, so it went into this branch").
 
 **Output**: JSON with `$schema` URL for semantic details.
-**Key fields**: `{breaks: [{step, location, variables}]}` - Variables show diff only (changed values).
+**Key fields**: `{breakpoint, breaks: [{step, stack, variables?, diff?, recording_type}]}`
+
+**Reading the output** (slim by design — no field duplicates another):
+- `breakpoint` sits at the top level, shared by every step (not repeated per break).
+- A break's stop location and function are `stack[0]` (file/line/function). `stack` is innermost-first: index 0 is the current frame, the rest are its callers; each `line` is the stop line for index 0 and the call-site line for callers.
+- `recording_type: "full"` (first step) carries the complete `variables` snapshot. `"diff"` steps carry only `diff` and omit `variables`.
+- To get current values, apply successive `diff`s onto the last `full` snapshot; variables absent from a `diff` are unchanged. On a stack-frame change scope resets — old locals appear as `removed`, new ones as `added` with their values.
+- Values are rendered as `"type: value"` strings, e.g. `"int: 0"`, `"array: [1, 2, 3]"`.
 
 ```bash
 ~/.composer/vendor/bin/xstep --break=file.php:line --steps=N [--context=TEXT] [--include-vendor=PATTERNS] -- command

--- a/skills/xdebug/SKILL.md
+++ b/skills/xdebug/SKILL.md
@@ -70,15 +70,7 @@ Trace execution forward from start to finish. Captures complete execution flow, 
 
 Stop at breakpoint, step forward N times, record variable changes at each step. See how variable values affect branching ("this variable was X, so it went into this branch").
 
-**Output**: JSON with `$schema` URL for semantic details.
-**Key fields**: `{breakpoint, breaks: [{step, stack, variables?, diff?, recording_type}]}`
-
-**Reading the output** (slim by design — no field duplicates another):
-- `breakpoint` sits at the top level, shared by every step (not repeated per break).
-- A break's stop location and function are `stack[0]` (file/line/function). `stack` is innermost-first: index 0 is the current frame, the rest are its callers; each `line` is the stop line for index 0 and the call-site line for callers.
-- `recording_type: "full"` (first step) carries the complete `variables` snapshot. `"diff"` steps carry only `diff` and omit `variables`.
-- To get current values, apply successive `diff`s onto the last `full` snapshot; variables absent from a `diff` are unchanged. On a stack-frame change scope resets — old locals appear as `removed`, new ones as `added` with their values.
-- Values are rendered as `"type: value"` strings, e.g. `"int: 0"`, `"array: [1, 2, 3]"`.
+**Output**: Slim, deduplicated JSON with a `$schema` URL — fields you might expect inline can live elsewhere, so **read the linked schema to interpret the structure and reconstruct variable state**. The schema is the source of truth; do not infer the format from examples.
 
 ```bash
 ~/.composer/vendor/bin/xstep --break=file.php:line --steps=N [--context=TEXT] [--include-vendor=PATTERNS] -- command

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -265,7 +265,7 @@ class CompareRunner
      * file to avoid a stdout/stderr pipe-fill deadlock, and `$cwd` sets
      * the process working directory (worktree for --compare-with).
      *
-     * @return array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>}
+     * @return array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>}
      */
     protected function executeXstep(string $command, string|null $cwd = null): array
     {
@@ -310,7 +310,7 @@ class CompareRunner
             throw new RuntimeException("xstep returned no output for command: {$command}");
         }
 
-        /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
+        /** @var array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>} $result */
         $result = $this->decodeXstepOutput($stdout, $command);
 
         return $result;
@@ -319,7 +319,7 @@ class CompareRunner
     /**
      * Decode xstep JSON and include a stdout excerpt when parsing fails.
      *
-     * @return array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>}
+     * @return array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>}
      */
     private function decodeXstepOutput(string $stdout, string $command): array
     {
@@ -346,7 +346,7 @@ class CompareRunner
             );
         }
 
-        /** @var array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result */
+        /** @var array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>} $result */
         return $result;
     }
 
@@ -406,7 +406,7 @@ class CompareRunner
     /**
      * Extract variables from the first breakpoint in xstep result
      *
-     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
+     * @param array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>} $result
      *
      * @return array<string, string>
      */
@@ -426,8 +426,8 @@ class CompareRunner
      * When the breakpoint was not hit, fall back to the requested location so
      * consumers see where xcompare was looking rather than an empty sentinel.
      *
-     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
-     * @param array{file: string, line: int}                                                                            $fallback
+     * @param array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>} $result
+     * @param array{file: string, line: int}                                                                                                 $fallback
      *
      * @return array{file: string, line: int}
      */
@@ -438,13 +438,18 @@ class CompareRunner
             return $fallback;
         }
 
-        return $breaks[0]['location'] ?? $fallback;
+        $frame = $breaks[0]['stack'][0] ?? null;
+        if ($frame === null) {
+            return $fallback;
+        }
+
+        return ['file' => $frame['file'], 'line' => $frame['line']];
     }
 
     /**
      * Extract execution status
      *
-     * @param array{breaks?: list<array{location?: array{file: string, line: int}, variables?: array<string, string>}>} $result
+     * @param array{breaks?: list<array{stack?: list<array{function: string, file: string, line: int}>, variables?: array<string, string>}>} $result
      */
     private function extractStatus(array $result): string
     {

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -3495,9 +3495,15 @@ final class DebugServer
                 'line' => $topFrame['line'],
             ];
 
+            // Keep the fallback frame in `stack` when XML parsing yields no frames,
+            // so the machine-readable file/line is never lost (stack[0] is the contract).
+            $stack = $stackFrames !== []
+                ? array_slice($stackFrames, 0, self::STACK_CONTEXT_LIMIT)
+                : [$topFrame];
+
             return [
                 'step' => $breakNumber,
-                'stack' => array_slice($stackFrames, 0, self::STACK_CONTEXT_LIMIT),
+                'stack' => $stack,
                 'breakpoint' => $breakpoint !== null
                     ? ['id' => $breakpoint['id'], 'label' => $breakpoint['label']]
                     : $this->breakpointReferenceForLocation($location),

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -116,17 +116,16 @@ use const STDERR;
  *                     Integration tests exist but require specific Xdebug runtime setup.
  *                     Coverage: 1.39% (1/72 methods), 0.71% (9/1266 lines) - remaining
  *                     uncovered code paths require actual debugging sessions.
- * @phpstan-type DebugLocation array{file: string, line: int}
  * @phpstan-type StackFrame array{function: string, file: string, line: int}
  * @phpstan-type BreakpointRef array{id: string, label: string}
  * @phpstan-type ShallowKeyDiff array{added: array<string, string>, removed: array<string, string>, changed: array<string, array{before: string, after: string}>}
  * @phpstan-type VariableDiffEntry array{change: string, type: string, before?: string, after?: string, keys?: ShallowKeyDiff}
  * @phpstan-type VariableDiff array<string, VariableDiffEntry>
  * @phpstan-type WatchChange array{expression: string, value: string, previous: string|null, reason: string}
- * @phpstan-type DebugBreak array{step: int, location: DebugLocation, function: string, stack: list<StackFrame>, breakpoint: BreakpointRef, variables: array<string, string>, recording_type?: string, diff?: VariableDiff, watches?: list<WatchChange>}
+ * @phpstan-type DebugBreak array{step: int, stack: list<StackFrame>, breakpoint?: BreakpointRef, variables?: array<string, string>, recording_type?: string, diff?: VariableDiff, watches?: list<WatchChange>}
  * @phpstan-type TraceInfo array{file: string, lines: int, functions: int, max_depth: int, db_queries: int, error?: string}
  * @phpstan-type OutputDebugInfo array{trace_files_found: int, search_patterns: list<string>, latest_file: string|null}
- * @phpstan-type XstepJsonOutput array{'$schema': string, breaks: list<DebugBreak>, trace?: TraceInfo, context?: string, debug?: OutputDebugInfo}
+ * @phpstan-type XstepJsonOutput array{'$schema': string, breakpoint?: BreakpointRef, breaks: list<DebugBreak>, trace?: TraceInfo, context?: string, debug?: OutputDebugInfo}
  * @phpstan-type ShallowJsonValue string|int|float|bool|array<array-key, string|int|float|bool|array<array-key, string|int|float|bool|null>|null>|null
  * @phpstan-type ShallowJsonMap array<array-key, ShallowJsonValue>
  * @see https://xdebug.org/docs/step_debug
@@ -160,6 +159,9 @@ final class DebugServer
     private array $breaks = [];
     private bool $isDockerCommand = false;
     private bool $stepRecordingOutputDone = false;
+
+    /** @var BreakpointRef|null Breakpoint shared by every recorded step; emitted once at top level */
+    private array|null $recordedBreakpoint = null;
 
     /** @var list<array{id: string, label: string, file: string, line: int, condition?: string}> */
     private array $configuredBreakpoints = [];
@@ -710,13 +712,11 @@ final class DebugServer
                 continue;
             }
 
-            // Record the step
+            // Record the step (breakpoint is identical across steps, captured once)
+            $this->recordedBreakpoint ??= $breakpoint;
             $step = $this->createRecordedBreak(
                 $stepCount,
-                $location,
-                $topFrame,
                 $stackFrames,
-                $breakpoint,
                 $variablesToRecord,
                 $recordingType,
                 $variableDiff,
@@ -791,10 +791,7 @@ final class DebugServer
     }
 
     /**
-     * @param DebugLocation         $location
-     * @param StackFrame            $topFrame
      * @param list<StackFrame>      $stackFrames
-     * @param BreakpointRef         $breakpoint
      * @param array<string, string> $variables
      * @param VariableDiff          $variableDiff
      * @param list<WatchChange>     $watchData
@@ -803,24 +800,25 @@ final class DebugServer
      */
     private function createRecordedBreak(
         int $step,
-        array $location,
-        array $topFrame,
         array $stackFrames,
-        array $breakpoint,
         array $variables,
         string $recordingType,
         array $variableDiff,
         array $watchData,
     ): array {
+        // location and function are dropped: both duplicate stack[0]. breakpoint is
+        // identical across steps and emitted once at the top level (see outputStepRecordingResults).
         $debugBreak = [
             'step' => $step,
-            'location' => $location,
-            'function' => $topFrame['function'],
             'stack' => array_slice($stackFrames, 0, self::STACK_CONTEXT_LIMIT),
-            'breakpoint' => $breakpoint,
-            'variables' => $variables,
             'recording_type' => $recordingType,
         ];
+
+        // Full frames carry the complete snapshot; diff frames are reconstructable
+        // from the `diff` entries, so the duplicate `variables` map is omitted.
+        if ($recordingType !== 'diff') {
+            $debugBreak['variables'] = $variables;
+        }
 
         if ($variableDiff !== []) {
             $debugBreak['diff'] = $variableDiff;
@@ -2654,10 +2652,13 @@ final class DebugServer
 
         $this->stepRecordingOutputDone = true;
 
-        $result = [
-            '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xstep.json',
-            'breaks' => $this->breaks,
-        ];
+        $result = ['$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xstep.json'];
+
+        if ($this->recordedBreakpoint !== null) {
+            $result['breakpoint'] = $this->recordedBreakpoint;
+        }
+
+        $result['breaks'] = $this->breaks;
 
         // Preserve caller-provided context in JSON output
         if (($this->options['context'] ?? '') !== '') {
@@ -3471,7 +3472,7 @@ final class DebugServer
      *
      * @param array{id: string, label: string, file: string, line: int, condition?: string}|null $breakpoint
      *
-     * @return array{step: int, location: array{file: string, line: int}, function: string, stack: list<array{function: string, file: string, line: int}>, breakpoint: array{id: string, label: string}, variables: array<string, string>}|null
+     * @return array{step: int, stack: list<array{function: string, file: string, line: int}>, breakpoint: array{id: string, label: string}, variables: array<string, string>}|null
      */
     private function captureCurrentDebugState(int $breakNumber, array|null $breakpoint = null): array|null
     {
@@ -3496,8 +3497,6 @@ final class DebugServer
 
             return [
                 'step' => $breakNumber,
-                'location' => $location,
-                'function' => $topFrame['function'],
                 'stack' => array_slice($stackFrames, 0, self::STACK_CONTEXT_LIMIT),
                 'breakpoint' => $breakpoint !== null
                     ? ['id' => $breakpoint['id'], 'label' => $breakpoint['label']]
@@ -3581,12 +3580,13 @@ final class DebugServer
             $this->log(str_repeat('=', 60));
 
             foreach ($breaks as $break) {
-                $loc = $break['location'];
-                $this->log("📍 Step {$break['step']}: {$loc['file']}:{$loc['line']}");
+                $frame = $break['stack'][0] ?? ['file' => '', 'line' => 0];
+                $this->log("📍 Step {$break['step']}: {$frame['file']}:{$frame['line']}");
 
-                if ($break['variables'] !== []) {
+                $variables = $break['variables'] ?? [];
+                if ($variables !== []) {
                     $this->log('📊 Variables:');
-                    foreach ($break['variables'] as $name => $value) {
+                    foreach ($variables as $name => $value) {
                         $this->log("  {$name} = {$value}");
                     }
                 }

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -142,7 +142,7 @@ final class McpServer
             ),
             'xstep' => new McpTool(
                 'xstep',
-                'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Variables: full snapshot on the first step, diff-only afterwards. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}; stack[0] is the current frame (stop file/line/function), later frames are callers. Variables: full snapshot on the first step, diff-only afterwards (variables absent from a diff are unchanged). Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                 [
                     'type' => 'object',
                     'properties' => [
@@ -446,7 +446,7 @@ final class McpServer
                 ],
                 [
                     'name' => 'xstep',
-                    'description' => 'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Variables: full snapshot on the first step, diff-only afterwards. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                    'description' => 'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}; stack[0] is the current frame (stop file/line/function), later frames are callers. Variables: full snapshot on the first step, diff-only afterwards (variables absent from a diff are unchanged). Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                     'arguments' => [
                         [
                             'name' => 'script',

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -142,7 +142,7 @@ final class McpServer
             ),
             'xstep' => new McpTool(
                 'xstep',
-                'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breaks: [{step, location, variables}]}. Variables show diff only. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Variables: full snapshot on the first step, diff-only afterwards. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                 [
                     'type' => 'object',
                     'properties' => [

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -142,7 +142,7 @@ final class McpServer
             ),
             'xstep' => new McpTool(
                 'xstep',
-                'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}; stack[0] is the current frame (stop file/line/function), later frames are callers. Variables: full snapshot on the first step, diff-only afterwards (variables absent from a diff are unchanged). Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                'Step debugging with breakpoints. Returns slim JSON with a $schema URL; read that schema for field semantics and variable-state reconstruction (the shape is deduplicated, not self-evident). Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                 [
                     'type' => 'object',
                     'properties' => [
@@ -446,7 +446,7 @@ final class McpServer
                 ],
                 [
                     'name' => 'xstep',
-                    'description' => 'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}; stack[0] is the current frame (stop file/line/function), later frames are callers. Variables: full snapshot on the first step, diff-only afterwards (variables absent from a diff are unchanged). Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                    'description' => 'Step debugging with breakpoints. Returns slim JSON with a $schema URL; read that schema for field semantics and variable-state reconstruction (the shape is deduplicated, not self-evident). Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                     'arguments' => [
                         [
                             'name' => 'script',

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -446,7 +446,7 @@ final class McpServer
                 ],
                 [
                     'name' => 'xstep',
-                    'description' => 'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breaks: [{step, location, variables}]}. Variables show diff only. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
+                    'description' => 'Step debugging with breakpoints. Returns JSON with $schema URL for semantic details. Key fields: {breakpoint, breaks: [{step, stack, variables, diff}]}. Variables: full snapshot on the first step, diff-only afterwards. Breakpoint: file.php:line or file.php:line:condition. Vendor excluded by default.',
                     'arguments' => [
                         [
                             'name' => 'script',

--- a/tests/Unit/CompareRunnerTest.php
+++ b/tests/Unit/CompareRunnerTest.php
@@ -234,8 +234,8 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner(['break' => 'calc.php:25:$x>0']);
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'calc.php', 'line' => 25], 'variables' => ['$x' => 'int: 5']]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'calc.php', 'line' => 25], 'variables' => ['$x' => 'int: 5']]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'calc.php', 'line' => 25]], 'variables' => ['$x' => 'int: 5']]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'calc.php', 'line' => 25]], 'variables' => ['$x' => 'int: 5']]]],
         ]);
 
         $result = $runner->run();
@@ -321,7 +321,7 @@ class CompareRunnerTest extends TestCase
             'breaks' => [
                 [
                     'step' => 1,
-                    'location' => ['file' => 'test.php', 'line' => 10],
+                    'stack' => [['function' => '{main}', 'file' => 'test.php', 'line' => 10]],
                     'variables' => ['$x' => 'int: 10', '$y' => 'int: 20'],
                     'recording_type' => 'full',
                 ],
@@ -354,7 +354,7 @@ class CompareRunnerTest extends TestCase
 
         $result = [
             'breaks' => [
-                ['location' => ['file' => 'test.php', 'line' => 10]],
+                ['stack' => [['function' => '{main}', 'file' => 'test.php', 'line' => 10]]],
             ],
         ];
 
@@ -369,7 +369,7 @@ class CompareRunnerTest extends TestCase
         $result = [
             'breaks' => [
                 [
-                    'location' => ['file' => 'src/test.php', 'line' => 42],
+                    'stack' => [['function' => '{main}', 'file' => 'src/test.php', 'line' => 42]],
                     'variables' => [],
                 ],
             ],
@@ -410,7 +410,7 @@ class CompareRunnerTest extends TestCase
 
         $result = [
             'breaks' => [
-                ['location' => ['file' => 'test.php', 'line' => 1], 'variables' => []],
+                ['stack' => [['function' => '{main}', 'file' => 'test.php', 'line' => 1]], 'variables' => []],
             ],
         ];
 
@@ -434,7 +434,7 @@ class CompareRunnerTest extends TestCase
                 'breaks' => [
                     [
                         'step' => 1,
-                        'location' => ['file' => 'test.php', 'line' => 10],
+                        'stack' => [['function' => '{main}', 'file' => 'test.php', 'line' => 10]],
                         'variables' => ['$x' => 'int: 1', '$sum' => 'int: 0'],
                         'recording_type' => 'full',
                     ],
@@ -445,7 +445,7 @@ class CompareRunnerTest extends TestCase
                 'breaks' => [
                     [
                         'step' => 1,
-                        'location' => ['file' => 'test.php', 'line' => 10],
+                        'stack' => [['function' => '{main}', 'file' => 'test.php', 'line' => 10]],
                         'variables' => ['$x' => 'int: 2', '$sum' => 'int: 0'],
                         'recording_type' => 'full',
                     ],
@@ -490,8 +490,8 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner(['context' => 'Testing context output']);
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
         ]);
 
         $result = $runner->run();
@@ -504,8 +504,8 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner(['context' => '']);
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
         ]);
 
         $result = $runner->run();
@@ -520,8 +520,8 @@ class CompareRunnerTest extends TestCase
             'label_b' => 'Edge case',
         ]);
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
         ]);
 
         $result = $runner->run();
@@ -534,8 +534,8 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner();
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
         ]);
 
         $result = $runner->run();
@@ -549,7 +549,7 @@ class CompareRunnerTest extends TestCase
         $runner = $this->createFakeRunner();
         $runner->setFakeResults([
             'php test.php 1' => ['breaks' => []],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 10], 'variables' => ['$x' => 'int: 1']]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 10]], 'variables' => ['$x' => 'int: 1']]]],
         ]);
 
         $result = $runner->run();
@@ -567,7 +567,7 @@ class CompareRunnerTest extends TestCase
             'php test.php 1' => [
                 'breaks' => [
                     [
-                        'location' => ['file' => 'f.php', 'line' => 10],
+                        'stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 10]],
                         'variables' => ['$a' => 'int: 1', '$shared' => 'int: 0'],
                     ],
                 ],
@@ -575,7 +575,7 @@ class CompareRunnerTest extends TestCase
             'php test.php 2' => [
                 'breaks' => [
                     [
-                        'location' => ['file' => 'f.php', 'line' => 10],
+                        'stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 10]],
                         'variables' => ['$b' => 'int: 2', '$shared' => 'int: 0'],
                     ],
                 ],
@@ -594,7 +594,7 @@ class CompareRunnerTest extends TestCase
         $runner = $this->createFakeRunner();
         // Only set result for run_a, not run_b
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => []]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => []]]],
         ]);
 
         $this->expectException(RuntimeException::class);
@@ -607,8 +607,8 @@ class CompareRunnerTest extends TestCase
     {
         $runner = $this->createFakeRunner();
         $runner->setFakeResults([
-            'php test.php 1' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => ['$x' => 'int: 1']]]],
-            'php test.php 2' => ['breaks' => [['location' => ['file' => 'f.php', 'line' => 1], 'variables' => ['$x' => 'int: 2']]]],
+            'php test.php 1' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => ['$x' => 'int: 1']]]],
+            'php test.php 2' => ['breaks' => [['stack' => [['function' => '{main}', 'file' => 'f.php', 'line' => 1]], 'variables' => ['$x' => 'int: 2']]]],
         ]);
 
         ob_start();

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -408,6 +408,37 @@ echo "Result: $result\n";
         $this->assertCount(1, $decoded['breaks']);
     }
 
+    public function testStepRecordingHoistsBreakpointToTopLevelAndOmitsPerStepFields(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+        $reflection = new ReflectionClass($server);
+
+        $reflection->getProperty('breaks')->setValue($server, [
+            [
+                'step' => 1,
+                'stack' => [['function' => 'foo', 'file' => basename($this->testScript), 'line' => 10]],
+                'recording_type' => 'full',
+                'variables' => ['$a' => 'int: 1'],
+            ],
+        ]);
+        $reflection->getProperty('recordedBreakpoint')->setValue($server, ['id' => '1', 'label' => 'bp1 fixture:10']);
+
+        $outputStepRec = $reflection->getMethod('outputStepRecordingResults');
+
+        ob_start();
+        $outputStepRec->invoke($server);
+        $stdout = ob_get_clean();
+
+        $decoded = json_decode($stdout, true);
+        $this->assertIsArray($decoded);
+        // Breakpoint is hoisted to the top level, emitted once for the whole run.
+        $this->assertSame(['id' => '1', 'label' => 'bp1 fixture:10'], $decoded['breakpoint']);
+        // Per-step breaks no longer carry the redundant location/function/breakpoint fields.
+        $this->assertArrayNotHasKey('location', $decoded['breaks'][0]);
+        $this->assertArrayNotHasKey('function', $decoded['breaks'][0]);
+        $this->assertArrayNotHasKey('breakpoint', $decoded['breaks'][0]);
+    }
+
     public function testJsonOutputCanBePrettyPrintedWithTwoSpaces(): void
     {
         $server = new DebugServer($this->testScript, 9004, null, ['pretty' => true], true);

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -381,7 +381,7 @@ echo "Result: $result\n";
         $breaks = [
             [
                 'step' => 1,
-                'location' => ['file' => basename($this->testScript), 'line' => 3],
+                'stack' => [['function' => '{main}', 'file' => basename($this->testScript), 'line' => 3]],
                 'variables' => ['$x' => '10'],
             ],
         ];
@@ -416,7 +416,7 @@ echo "Result: $result\n";
         $breaks = [
             [
                 'step' => 1,
-                'location' => ['file' => basename($this->testScript), 'line' => 3],
+                'stack' => [['function' => '{main}', 'file' => basename($this->testScript), 'line' => 3]],
                 'variables' => ['$x' => '10'],
             ],
         ];

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -433,6 +433,11 @@ echo "Result: $result\n";
         $this->assertIsArray($decoded);
         // Breakpoint is hoisted to the top level, emitted once for the whole run.
         $this->assertSame(['id' => '1', 'label' => 'bp1 fixture:10'], $decoded['breakpoint']);
+        // stack replaces per-step location/function — pin its contents so it can't silently vanish.
+        $this->assertSame(
+            [['function' => 'foo', 'file' => basename($this->testScript), 'line' => 10]],
+            $decoded['breaks'][0]['stack'],
+        );
         // Per-step breaks no longer carry the redundant location/function/breakpoint fields.
         $this->assertArrayNotHasKey('location', $decoded['breaks'][0]);
         $this->assertArrayNotHasKey('function', $decoded['breaks'][0]);

--- a/tests/Unit/XstepSchemaTest.php
+++ b/tests/Unit/XstepSchemaTest.php
@@ -22,6 +22,7 @@ final class XstepSchemaTest extends TestCase
         $this->assertIsString($schemaJson);
 
         /** @var array{
+         *     properties: array<string, mixed>,
          *     definitions: array{
          *         breakpoint: array{
          *             properties: array<string, array<string, mixed>>,
@@ -34,14 +35,19 @@ final class XstepSchemaTest extends TestCase
         $breakpoint = $schema['definitions']['breakpoint'];
         $properties = $breakpoint['properties'];
 
-        $this->assertArrayHasKey('location', $properties);
-        $this->assertArrayHasKey('function', $properties);
+        // location and function are dropped (duplicate stack[0]); variables is now optional (omitted on diff frames)
+        $this->assertArrayNotHasKey('location', $properties);
+        $this->assertArrayNotHasKey('function', $properties);
         $this->assertArrayHasKey('stack', $properties);
         $this->assertArrayHasKey('breakpoint', $properties);
         $this->assertArrayHasKey('variables', $properties);
         $this->assertArrayHasKey('diff', $properties);
-        $this->assertContains('location', $breakpoint['required']);
-        $this->assertContains('variables', $breakpoint['required']);
+        $this->assertContains('stack', $breakpoint['required']);
+        $this->assertNotContains('location', $breakpoint['required']);
+        $this->assertNotContains('variables', $breakpoint['required']);
+
+        // breakpoint is emitted once at the top level in step-recording mode
+        $this->assertArrayHasKey('breakpoint', $schema['properties']);
 
         $this->assertArrayHasKey('recording_type', $properties);
         $this->assertSame('string', $properties['recording_type']['type']);


### PR DESCRIPTION
## Summary

The `xstep --steps` (step-recording) JSON output carried structural redundancy that wasted tokens for AI consumers. This removes fields that duplicate data already present elsewhere, with **zero information loss** — every dropped field is reconstructable from what remains.

Investigation confirmed the only machine consumer of xstep output is the in-repo `CompareRunner` (xcompare), which calls `bin/xstep --steps=1` and reads only `breaks[0]`. No external tool depends on the schema, so the default output is slimmed directly and `CompareRunner` follows in the same change.

## What changed

- **Drop per-step `location` / `function`** — both duplicate `stack[0]` (file/line and function name).
- **Omit `variables` on diff steps** — identical to each `diff` entry's `after`; kept on the first (`full`) step.
- **Emit the shared `breakpoint` once at the top level** — it was repeated identically on every step.

`CompareRunner.extractLocation` now derives the location from `stack[0]`. Schema (`docs/schemas/xstep.json`), PHPStan types, the MCP tool description and tests follow.

## Measured impact

Same command on both sides (`xstep --break=tests/fixtures/debug_test.php:18 --steps=12 -- php tests/fixtures/debug_test.php`); before = prior commit, after = this branch:

| | before | after | reduction |
|---|---|---|---|
| output size | 6673 B | 4632 B | **-30.5%** |

The reduction grows with step count: the removed redundancy is per-step, while the remaining overhead is fixed.

### Structure before / after

Top-level keys:

    before: ["$schema","breaks","context","trace"]
    after : ["$schema","breakpoint","breaks","context","trace"]

`breaks[]` full step:

    before: [breakpoint, function, location, recording_type, stack, step, variables]
    after : [recording_type, stack, step, variables]

`breaks[]` diff step:

    before: [breakpoint, diff, function, location, recording_type, stack, step, variables]
    after : [diff, recording_type, stack, step]

## Verification

- ✅ `composer tests` — 293 tests, 800 assertions, 0 failures (PHPStan, Psalm, cs included)
- ✅ xcompare regression: `extractLocation` resolves `debug_test.php:18` from `stack[0]`
- ✅ Schema validity and `XstepSchemaTest` updated for the new shape

## Out of scope (future PR)

Stack delta-encoding (a further ~13-22% by estimate) is deliberately deferred: it introduces a diff-decoding rule that trades AI readability for tokens, and warrants measuring real-session stack dominance first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated step-recording and breakpoint output to use `stack` frame details (`function`/`file`/`line`) instead of `location` fields.
  * Clarified variable semantics: `recording_type` now controls full snapshots vs diff-only output (including removals).
  * In step-recording mode, breakpoint metadata is hoisted to a single top-level `breakpoint`, while step entries focus on `step` + `stack`.
* **Documentation**
  * Refreshed the `xstep` tool/schema descriptions for top-level `breakpoint`, `breaks[].stack`, and full-vs-diff behavior.
* **Tests**
  * Updated fixtures and expectations for the new `stack`-based JSON and verified top-level breakpoint hoisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->