### PR TITLE
Fix silent debug-session failures and related reliability/perf issues

### DIFF
--- a/bin/xprofile
+++ b/bin/xprofile
@@ -241,60 +241,85 @@ function analyzeCachegrindFile(string $profileFile, ?string $includeVendor = nul
         'mysql_query', 'pg_query', 'sqlite_query'
     ];
 
-    // Simple file-based statistics (Cachegrind format is different from trace format)
-    $content = file_get_contents($profileFile);
-    $lines = explode("\n", $content);
-
-    $stats['total_lines'] = count($lines);
-
-    // Read the cachegrind `events:` header to locate the Time and Memory columns,
-    // then take real measured totals from the `summary:` line. Units come from the
-    // header (e.g. Time_(10ns), Memory_(bytes)); reading indices from the header
-    // tolerates a non-default xdebug.cachegrind_events column order.
+    // Stream the Cachegrind file line by line instead of loading it whole:
+    // profiles can be hundreds of MB, and file_get_contents() + explode() held
+    // 2-3x the file size in memory at once. The events:/summary: headers are
+    // parsed inline the first time they are seen; the fn=/fl=/cost body below
+    // is unchanged.
+    //
+    // Units for Time/Memory come from the events header (e.g. Time_(10ns),
+    // Memory_(bytes)); reading column indices from the header tolerates a
+    // non-default xdebug.cachegrind_events column order.
     $timeIndex = null;
     $memoryIndex = null;
     $timeToMs = null;
-    if (preg_match('/^events:\s*(.+)$/m', $content, $eventsMatch)) {
-        foreach (preg_split('/\s+/', trim($eventsMatch[1])) as $i => $col) {
-            if (preg_match('/^Time_\((\d*)(ns|us|µs|ms|s)\)$/', $col, $unit)) {
-                $timeIndex = $i;
-                $multiplier = $unit[1] === '' ? 1 : (int) $unit[1];
-                $nsPerUnit = ['ns' => 1, 'us' => 1000, 'µs' => 1000, 'ms' => 1000000, 's' => 1000000000][$unit[2]] ?? 1;
-                $timeToMs = ($multiplier * $nsPerUnit) / 1000000.0;
-            } elseif (str_starts_with($col, 'Memory_(')) {
-                $memoryIndex = $i;
-            }
-        }
-    }
-
     $measuredTimeMs = null;
     $measuredMemoryMb = null;
-    if (preg_match('/^summary:\s+(.+)$/m', $content, $summaryMatch)) {
-        $summaryCols = preg_split('/\s+/', trim($summaryMatch[1]));
-        if ($timeIndex !== null && $timeToMs !== null && isset($summaryCols[$timeIndex])) {
-            $measuredTimeMs = round((int) $summaryCols[$timeIndex] * $timeToMs, 3);
-        }
-        if ($memoryIndex !== null && isset($summaryCols[$memoryIndex])) {
-            $measuredMemoryMb = round((int) $summaryCols[$memoryIndex] / 1048576, 2);
-        }
-    }
-    
-    // Count basic Cachegrind elements - accurate counting
-    $stats['total_calls'] = substr_count($content, "\ncalls=");
-    
+    $eventsParsed = false;
+    $summaryParsed = false;
+    $newlineCount = 0;
+
     // Use sets to track unique functions
     $uniqueFunctions = [];
     $userFunctions = [];
     $internalFunctions = [];
-    
+
     // Parse functions for classification and analysis
     $functionCosts = [];
     $currentFunction = null;
     $currentFile = null;
     $fileAliases = [];
-    
-    foreach ($lines as $line) {
-        $line = trim($line);
+
+    $handle = fopen($profileFile, 'r');
+    if ($handle === false) {
+        throw new \RuntimeException("Cannot open profile file: $profileFile");
+    }
+
+    while (($rawLine = fgets($handle)) !== false) {
+        // total_lines must stay byte-identical to the previous
+        // count(explode("\n", $content)) == (number of "\n") + 1.
+        if (str_ends_with($rawLine, "\n")) {
+            $newlineCount++;
+        }
+
+        $line = trim($rawLine);
+
+        // events: header — parse the first occurrence to locate the columns.
+        if (! $eventsParsed && str_starts_with($line, 'events:')) {
+            $eventsParsed = true;
+            foreach (preg_split('/\s+/', trim(substr($line, strlen('events:')))) as $i => $col) {
+                if (preg_match('/^Time_\((\d*)(ns|us|µs|ms|s)\)$/', $col, $unit)) {
+                    $timeIndex = $i;
+                    $multiplier = $unit[1] === '' ? 1 : (int) $unit[1];
+                    $nsPerUnit = ['ns' => 1, 'us' => 1000, 'µs' => 1000, 'ms' => 1000000, 's' => 1000000000][$unit[2]] ?? 1;
+                    $timeToMs = ($multiplier * $nsPerUnit) / 1000000.0;
+                } elseif (str_starts_with($col, 'Memory_(')) {
+                    $memoryIndex = $i;
+                }
+            }
+
+            continue;
+        }
+
+        // summary: line — real measured totals (appears once, near the end).
+        if (! $summaryParsed && str_starts_with($line, 'summary:')) {
+            $summaryParsed = true;
+            $summaryCols = preg_split('/\s+/', trim(substr($line, strlen('summary:'))));
+            if ($timeIndex !== null && $timeToMs !== null && isset($summaryCols[$timeIndex])) {
+                $measuredTimeMs = round((int) $summaryCols[$timeIndex] * $timeToMs, 3);
+            }
+            if ($memoryIndex !== null && isset($summaryCols[$memoryIndex])) {
+                $measuredMemoryMb = round((int) $summaryCols[$memoryIndex] / 1048576, 2);
+            }
+
+            continue;
+        }
+
+        // Count cost-block "calls=" markers (was substr_count($content, "\ncalls=")).
+        if (str_starts_with($line, 'calls=')) {
+            $stats['total_calls']++;
+            continue;
+        }
         
         if (preg_match('/^fl=\((\d+)\)\s+(.+)$/', $line, $matches)) {
             $currentFile = $matches[2];
@@ -377,7 +402,12 @@ function analyzeCachegrindFile(string $profileFile, ?string $includeVendor = nul
                 + (int) ($costCols[$timeCol] ?? 0);
         }
     }
-    
+
+    fclose($handle);
+
+    // Preserve the previous count(explode("\n", $content)) semantics exactly.
+    $stats['total_lines'] = $newlineCount + 1;
+
     // Set final counts from unique arrays
     $stats['functions_count'] = count($uniqueFunctions);
     $stats['user_functions'] = count($userFunctions); 

--- a/src/CompareRunner.php
+++ b/src/CompareRunner.php
@@ -26,6 +26,7 @@ use function ksort;
 use function preg_match;
 use function proc_close;
 use function proc_open;
+use function register_shutdown_function;
 use function sort;
 use function stream_get_contents;
 use function strlen;
@@ -204,6 +205,17 @@ class CompareRunner
 
         $tempDir = sys_get_temp_dir() . '/xcompare-' . uniqid('', true);
         $this->worktreePath = $tempDir;
+
+        // run()'s try/finally already removes the worktree on a normal return or
+        // a thrown exception. This shutdown handler additionally covers a fatal
+        // error (the finally never runs then), so the worktree is not leaked.
+        // cleanupWorktree() nulls worktreePath, so a normal run makes this a
+        // no-op. NOTE: a SIGTERM/SIGKILL delivered while blocked in
+        // executeXstep()'s proc_close() still cannot be cleaned here — PHP
+        // shutdown functions do not run on signal-default termination.
+        register_shutdown_function(function (): void {
+            $this->cleanupWorktree();
+        });
 
         $output = [];
         $exitCode = 0;

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -1100,6 +1100,16 @@ final class DebugServer
 
         $response = $this->sendCommand('breakpoint_set', $params);
 
+        // sendCommand() returns '' on a read failure/connection drop. Without
+        // this guard an empty response would slip past the <error> check and
+        // the id="..." regex and return the 'unknown' sentinel, recording a
+        // breakpoint that was never actually set.
+        if ($response === '') {
+            throw new BreakpointException(
+                "No response from Xdebug when setting breakpoint at {$filename}:{$line}",
+            );
+        }
+
         if (str_contains($response, '<error')) {
             $message = 'Xdebug rejected breakpoint_set';
             if (preg_match('/<message>([^<]+)<\/message>/', $response, $matches)) {
@@ -2554,18 +2564,24 @@ final class DebugServer
             // ASCII digits, so the first NUL is always the header delimiter.
             $nulPos = $this->fillDbgpBufferUntilNul($socket, $timeout);
             $length = (int) substr($this->dbgpReadBuffer, 0, $nulPos);
-            $this->dbgpReadBuffer = substr($this->dbgpReadBuffer, $nulPos + 1);
 
             if ($length <= 0) {
                 throw new RuntimeException("Invalid response length: {$length}");
             }
 
-            // Need $length data bytes plus the trailing NUL.
-            $this->fillDbgpBufferTo($socket, $timeout, $length + 1);
+            // Do NOT consume the header until the whole frame (header + NUL +
+            // payload + trailing NUL) is buffered. If the payload read fails
+            // partway (readTimeout fires, or the connection drops), the buffer
+            // must still look like an intact, resumable frame — otherwise the
+            // next read would misparse leftover payload bytes as a new length
+            // header and desync every subsequent frame on this socket.
+            $headerLength = $nulPos + 1;
+            $frameLength = $headerLength + $length + 1;
+            $this->fillDbgpBufferTo($socket, $timeout, $frameLength);
 
-            $response = substr($this->dbgpReadBuffer, 0, $length);
-            $trailingNull = $this->dbgpReadBuffer[$length];
-            $this->dbgpReadBuffer = substr($this->dbgpReadBuffer, $length + 1);
+            $response = substr($this->dbgpReadBuffer, $headerLength, $length);
+            $trailingNull = $this->dbgpReadBuffer[$headerLength + $length];
+            $this->dbgpReadBuffer = substr($this->dbgpReadBuffer, $frameLength);
 
             if ($trailingNull !== "\0") {
                 $this->log('Warning: Expected trailing NULL byte, got: ' . bin2hex($trailingNull));

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -13,10 +13,12 @@ use Amp\Http\Server\RequestHandler;
 use Amp\Http\Server\Response;
 use Amp\Http\Server\SocketHttpServer;
 use Amp\Process\Process;
+use Amp\Socket\InternetAddress;
 use Amp\Socket\ServerSocket;
 use Amp\Socket\Socket;
 use Amp\Socket\SocketException;
 use Amp\TimeoutCancellation;
+use Koriym\XdebugMcp\Exceptions\BreakpointException;
 use Koriym\XdebugMcp\Exceptions\DebugSessionException;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use Koriym\XdebugMcp\Utilities\PathNormalizer;
@@ -39,6 +41,7 @@ use function array_reverse;
 use function array_slice;
 use function array_splice;
 use function array_unique;
+use function array_values;
 use function base64_decode;
 use function base64_encode;
 use function basename;
@@ -92,6 +95,7 @@ use function str_repeat;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
+use function strpos;
 use function strtolower;
 use function strtoupper;
 use function substr;
@@ -150,6 +154,17 @@ final class DebugServer
     private ServerSocket|null $server = null;
     private Process|null $process = null;
     private int $transactionId = 1;
+
+    /** Leftover bytes read past a DBGp frame boundary; see readDbgpFrame(). */
+    private string $dbgpReadBuffer = '';
+
+    /**
+     * The port the listener is actually bound to. Defaults to the configured
+     * $debugPort, but falls back to an OS-assigned ephemeral port when that
+     * port is already in use, so concurrent sessions don't collide. Every
+     * -dxdebug.client_port the spawned PHP receives must use THIS value.
+     */
+    private int $effectiveDebugPort;
     private string|null $traceFile = null;
     private SocketHttpServer|null $httpServer = null;
     private bool $httpMode = false;
@@ -185,8 +200,15 @@ final class DebugServer
         $command = $options['command'] ?? [];
         $this->isDockerCommand = ContainerHelper::isContainerCommand($command);
 
-        // Check for existing sessions (warning only)
-        $this->checkExistingSessions();
+        // Until the listener actually binds, the effective port is the
+        // configured one. startXdebugListener() may replace it with an
+        // ephemeral port if $debugPort is already taken.
+        $this->effectiveDebugPort = $debugPort;
+
+        // Note: existing-session diagnostics (lsof) are deferred until a bind
+        // actually fails (see startXdebugListener()), instead of running on
+        // every construction — avoids startup cost and lsof-missing failures
+        // on containers/Windows.
 
         // Register shutdown handler to ensure cleanup
         register_shutdown_function([$this, 'emergencyCleanup']);
@@ -212,13 +234,53 @@ final class DebugServer
         ];
 
         try {
-            Future\awaitAll($tasks);
+            // Future\await() (unlike awaitAll()) throws on the first task
+            // failure, so listener-bind collisions, connection timeouts, and
+            // spawn errors are no longer silently discarded. Tasks that finish
+            // successfully call gracefulExit(0) themselves (see
+            // performDebugSequence()/startConsoleSession()), which exits the
+            // process before this call can return, so the success path is
+            // unaffected.
+            Future\await($tasks);
         } catch (Throwable $e) {
             $this->log('❌ Debug session failed: ' . $e->getMessage());
 
+            // Cleanup must still run (socket/process teardown, and JSON output
+            // in --json mode), but we must NOT force exit(0): that masked every
+            // failure as success. Run cleanup, then let the exception propagate
+            // so bin/xstep surfaces a non-zero exit + stderr message.
+            $this->emergencyCleanup();
+
             throw new DebugSessionException('Debug session failed', 0, $e);
-        } finally {
-            $this->gracefulExit(0);
+        }
+
+        // All tasks completed without the process having already exited via a
+        // task-internal gracefulExit(0) (e.g. traceOnly mode never reaches
+        // here). Normal successful completion.
+        $this->gracefulExit(0);
+    }
+
+    /**
+     * Bind the listener, preferring the configured port but falling back to an
+     * OS-assigned ephemeral port when it is already in use.
+     *
+     * The fixed port keeps working as the documented default (and the
+     * session-key isolation story with IDEs), while the fallback lets two
+     * xdebug-mcp sessions run concurrently instead of the second one silently
+     * failing on "Address already in use".
+     */
+    private function listenOnAvailablePort(string $listenAddress): ServerSocket
+    {
+        try {
+            return listen("{$listenAddress}:{$this->debugPort}");
+        } catch (SocketException) {
+            // Configured port busy (another xdebug-mcp session or an IDE). Emit
+            // a best-effort diagnostic, then bind an ephemeral port so this
+            // session can still run alongside the other one.
+            $this->logExistingSessions();
+            $this->log("⚠️ Port {$this->debugPort} in use; binding an ephemeral port instead");
+
+            return listen("{$listenAddress}:0");
         }
     }
 
@@ -231,8 +293,14 @@ final class DebugServer
             // Use 0.0.0.0 for Docker to allow connections from containers
             // Use 127.0.0.1 for local commands for security
             $listenAddress = $this->isDockerCommand ? '0.0.0.0' : '127.0.0.1';
-            $this->server = listen("{$listenAddress}:{$this->debugPort}");
-            $this->log("📡 Listener ready on {$listenAddress}:{$this->debugPort}");
+            $this->server = $this->listenOnAvailablePort($listenAddress);
+
+            $address = $this->server->getAddress();
+            $this->effectiveDebugPort = $address instanceof InternetAddress
+                ? $address->getPort()
+                : $this->debugPort;
+
+            $this->log("📡 Listener ready on {$listenAddress}:{$this->effectiveDebugPort}");
             $this->log('⏳ Waiting for Xdebug connection...');
 
             // Notify listener ready (Opus pattern)
@@ -252,6 +320,8 @@ final class DebugServer
 
             $this->log('✅ Xdebug connected!');
             $this->xdebugSocket = $socket;
+            // Fresh connection: discard any bytes buffered for a prior socket.
+            $this->dbgpReadBuffer = '';
 
             // Close server socket after accepting connection
             $this->server?->close();
@@ -315,7 +385,7 @@ final class DebugServer
                         '-dxdebug.mode=debug,trace',
                         '-dxdebug.start_with_request=yes',
                         '-dxdebug.client_host=' . $clientHost,
-                        '-dxdebug.client_port=' . $this->debugPort,
+                        '-dxdebug.client_port=' . $this->effectiveDebugPort,
                         '-dxdebug.output_dir=/tmp',
                         '-dxdebug.trace_output_name=trace-%s',
                         '-dxdebug.trace_format=1',
@@ -387,7 +457,7 @@ final class DebugServer
                         $includeVendorEnv,
                         escapeshellarg($phpBinary),
                         $xdebugPart,
-                        $this->debugPort,
+                        $this->effectiveDebugPort,
                         escapeshellarg($prependFilter),
                         implode(' ', array_map(escapeshellarg(...), array_slice($command, 1))),
                     );
@@ -430,7 +500,7 @@ final class DebugServer
                     $includeVendorEnv,
                     escapeshellarg($phpBinary),
                     $xdebugPart,
-                    $this->debugPort,
+                    $this->effectiveDebugPort,
                     escapeshellarg($prependFilter),
                     escapeshellarg($this->targetScript),
                 );
@@ -869,6 +939,36 @@ final class DebugServer
     }
 
     /**
+     * Build a DBGp command line, including the trailing NUL terminator.
+     *
+     * Every param is rendered as "-{key} {value}" EXCEPT the special "--" key,
+     * which DBGp reserves for a data segment (typically a base64-encoded
+     * expression) and which must be rendered as a literal "-- {value}" — never
+     * "-{key} {value}" (that would produce the "--- {value}" triple-dash that
+     * Xdebug rejects with a parse error). See eval's usage of "--" in
+     * evaluateExpression()/getJsonEncodeOutput() for the established convention
+     * this reuses.
+     *
+     * @param array<string, string|int> $params
+     */
+    private static function buildDbgpCommand(string $command, int $transactionId, array $params): string
+    {
+        $fullCommand = "{$command} -i {$transactionId}";
+
+        foreach ($params as $key => $value) {
+            if ($key === '--') {
+                $fullCommand .= " -- {$value}";
+
+                continue;
+            }
+
+            $fullCommand .= " -{$key} {$value}";
+        }
+
+        return $fullCommand . "\0";
+    }
+
+    /**
      * Send a DBGp command and wait for the response
      *
      * @param array<string, string|int> $params
@@ -886,14 +986,7 @@ final class DebugServer
 
         // Build full command with transaction ID
         $transactionId = $this->getNextTransactionId();
-        $fullCommand = "{$command} -i {$transactionId}";
-
-        // Add additional parameters
-        foreach ($params as $key => $value) {
-            $fullCommand .= " -{$key} {$value}";
-        }
-
-        $fullCommand .= "\0";
+        $fullCommand = self::buildDbgpCommand($command, $transactionId, $params);
 
         try {
             $this->xdebugSocket->write($fullCommand);
@@ -976,30 +1069,48 @@ final class DebugServer
 
     /**
      * Set breakpoint
+     *
+     * A conditional breakpoint is sent as DBGp type "conditional" with the PHP
+     * expression base64-encoded in the "--" data segment (the same convention
+     * evaluateExpression() uses for eval). The "-o" flag is the unrelated
+     * hit-condition operator (">=", "==", "%") and must never carry the
+     * expression: doing so puts raw, unescaped PHP source (potentially
+     * containing spaces) directly on the DBGp command line, which Xdebug
+     * rejects with a parse error.
+     *
+     * @throws BreakpointException If Xdebug rejects the breakpoint_set command.
      */
     private function setBreakpoint(string $filename, int $line, string|null $condition = null): string
     {
         $fileUri = $this->toFileUri($filename);
+        $trimmedCondition = $condition !== null ? trim($condition) : '';
+
         $params = [
-            't' => 'line',
+            't' => $trimmedCondition !== '' ? 'conditional' : 'line',
             's' => 'enabled',
             'f' => $fileUri,
             'n' => $line,
         ];
 
-        // Add condition if provided
-        if ($condition !== null && trim($condition) !== '') {
-            $params['o'] = trim($condition);
+        // A conditional expression travels base64-encoded in the "--" data
+        // segment, not as the "-o" hit-condition operator.
+        if ($trimmedCondition !== '') {
+            $params['--'] = base64_encode($trimmedCondition);
         }
 
         $response = $this->sendCommand('breakpoint_set', $params);
 
-        // Check for error
         if (str_contains($response, '<error')) {
-            // Log the error for debugging
-            $this->log('⚠️ Breakpoint error: ' . $response);
+            $message = 'Xdebug rejected breakpoint_set';
+            if (preg_match('/<message>([^<]+)<\/message>/', $response, $matches)) {
+                $message = $matches[1];
+            }
 
-            return 'error';
+            $this->log("⚠️ Breakpoint error: {$message}");
+
+            throw new BreakpointException(
+                "Failed to set breakpoint at {$filename}:{$line}: {$message}",
+            );
         }
 
         // Parse breakpoint ID from response
@@ -1031,26 +1142,31 @@ final class DebugServer
             $line = (int) $breakpoint['line'];
             $condition = $breakpoint['condition'] ?? null;
 
-            // Set the breakpoint with condition
-            $breakpointId = $this->setBreakpoint($file, $line, $condition);
-
-            if ($breakpointId !== 'error') {
-                $breakpointMetadata = [
-                    'id' => $breakpointId,
-                    'label' => $this->makeBreakpointLabel($file, $line, $condition, $index),
-                    'file' => $file,
-                    'line' => $line,
-                ];
-                if ($condition !== null && $condition !== '') {
-                    $breakpointMetadata['condition'] = $condition;
-                }
-
-                $this->configuredBreakpoints[] = $breakpointMetadata;
+            // A single rejected breakpoint (e.g. a duplicate file:line, DBGp
+            // error code 200) must NOT abort the whole session: setBreakpoint()
+            // throws BreakpointException, so we catch it per-breakpoint, warn on
+            // stderr (stdout stays reserved for JSON output), and keep setting
+            // the remaining breakpoints. Letting it propagate would leave the
+            // Xdebug-paused child hanging until DEFAULT_EXECUTION_TIMEOUT.
+            try {
+                $breakpointId = $this->setBreakpoint($file, $line, $condition);
+            } catch (BreakpointException $e) {
+                fwrite(STDERR, "xstep: warning: {$e->getMessage()}\n");
 
                 continue;
             }
 
-            $this->log("❌ Failed to set breakpoint: {$file}:{$line}");
+            $breakpointMetadata = [
+                'id' => $breakpointId,
+                'label' => $this->makeBreakpointLabel($file, $line, $condition, $index),
+                'file' => $file,
+                'line' => $line,
+            ];
+            if ($condition !== null && $condition !== '') {
+                $breakpointMetadata['condition'] = $condition;
+            }
+
+            $this->configuredBreakpoints[] = $breakpointMetadata;
         }
     }
 
@@ -1369,7 +1485,7 @@ final class DebugServer
     public function enableHttpMode(int|null $httpPort = null): void
     {
         $this->httpMode = true;
-        $port = $httpPort ?: $this->debugPort + 100; // Default: debug port + 100
+        $port = $httpPort ?: $this->effectiveDebugPort + 100; // Default: debug port + 100
 
         // Create simple logger for AMP SocketHttpServer
         $logger = new class implements LoggerInterface {
@@ -2417,7 +2533,15 @@ final class DebugServer
     }
 
     /**
-     * Read DBGp frame - Fixed version with proper argument order
+     * Read one DBGp frame ("length\0data\0").
+     *
+     * Reads whole chunks into a persistent buffer and slices frames out of it,
+     * so the length header no longer costs one socket round-trip per digit. Any
+     * bytes read past the current frame stay buffered for the next call. The
+     * data body is taken by exact length (not by scanning for a NUL), so NUL
+     * bytes inside the payload — e.g. anonymous-class names on PHP 8.3+ — are
+     * preserved. The buffer belongs to the single Xdebug socket this server
+     * owns and is reset when that socket is (re)accepted.
      */
     private function readDbgpFrame(Socket $socket): string
     {
@@ -2426,52 +2550,66 @@ final class DebugServer
         $timeout = $timeoutValue > 0 ? new TimeoutCancellation($timeoutValue) : null;
 
         try {
-            // Read length header until NULL byte
-            // FIXED: Correct argument order - Cancellation first, then length
-            $lengthStr = '';
-            while (true) {
-                $char = $timeout instanceof TimeoutCancellation ? $socket->read($timeout, 1) : $socket->read(null, 1);
-                if ($char === null || $char === '') {
-                    throw new RuntimeException('Connection closed while reading length');
-                }
+            // Length header: everything up to the first NUL. The length is pure
+            // ASCII digits, so the first NUL is always the header delimiter.
+            $nulPos = $this->fillDbgpBufferUntilNul($socket, $timeout);
+            $length = (int) substr($this->dbgpReadBuffer, 0, $nulPos);
+            $this->dbgpReadBuffer = substr($this->dbgpReadBuffer, $nulPos + 1);
 
-                if ($char === "\0") {
-                    break;
-                }
-
-                $lengthStr .= $char;
-            }
-
-            $length = (int) $lengthStr;
             if ($length <= 0) {
                 throw new RuntimeException("Invalid response length: {$length}");
             }
 
-            // Read the response data
-            // FIXED: Correct argument order
-            $response = '';
-            $remaining = $length;
-            while ($remaining > 0) {
-                $chunk = $timeout instanceof TimeoutCancellation ? $socket->read($timeout, $remaining) : $socket->read(null, $remaining);
-                if ($chunk === null || $chunk === '') {
-                    throw new RuntimeException('Connection closed while reading response data');
-                }
+            // Need $length data bytes plus the trailing NUL.
+            $this->fillDbgpBufferTo($socket, $timeout, $length + 1);
 
-                $response .= $chunk;
-                $remaining -= strlen($chunk);
-            }
+            $response = substr($this->dbgpReadBuffer, 0, $length);
+            $trailingNull = $this->dbgpReadBuffer[$length];
+            $this->dbgpReadBuffer = substr($this->dbgpReadBuffer, $length + 1);
 
-            // Read the trailing NULL byte
-            // FIXED: Correct argument order
-            $trailingNull = $timeout instanceof TimeoutCancellation ? $socket->read($timeout, 1) : $socket->read(null, 1);
             if ($trailingNull !== "\0") {
-                $this->log('Warning: Expected trailing NULL byte, got: ' . bin2hex($trailingNull ?? ''));
+                $this->log('Warning: Expected trailing NULL byte, got: ' . bin2hex($trailingNull));
             }
 
             return $response;
         } catch (Throwable $e) {
             throw new DebugSessionException('Failed to read DBGp frame: ' . $e->getMessage(), 0, $e);
         }
+    }
+
+    /**
+     * Read chunks into the buffer until it contains a NUL; return its offset.
+     */
+    private function fillDbgpBufferUntilNul(Socket $socket, TimeoutCancellation|null $timeout): int
+    {
+        while (true) {
+            $pos = strpos($this->dbgpReadBuffer, "\0");
+            if ($pos !== false) {
+                return $pos;
+            }
+
+            $this->dbgpReadBuffer .= $this->readDbgpChunk($socket, $timeout);
+        }
+    }
+
+    /**
+     * Read chunks into the buffer until it holds at least $need bytes.
+     */
+    private function fillDbgpBufferTo(Socket $socket, TimeoutCancellation|null $timeout, int $need): void
+    {
+        while (strlen($this->dbgpReadBuffer) < $need) {
+            $this->dbgpReadBuffer .= $this->readDbgpChunk($socket, $timeout);
+        }
+    }
+
+    private function readDbgpChunk(Socket $socket, TimeoutCancellation|null $timeout): string
+    {
+        $chunk = $timeout instanceof TimeoutCancellation ? $socket->read($timeout) : $socket->read();
+        if ($chunk === null || $chunk === '') {
+            throw new RuntimeException('Connection closed while reading DBGp frame');
+        }
+
+        return $chunk;
     }
 
     /**
@@ -2488,18 +2626,17 @@ final class DebugServer
     }
 
     /**
-     * Check for existing Xdebug sessions on our port (now session-key aware)
+     * Best-effort, warning-only diagnostic for why binding our port failed.
+     *
+     * Invoked lazily — only after a real bind failure — instead of on every
+     * construction. Shells out to `lsof`, which may be missing (containers,
+     * Windows); any failure to obtain PIDs is silently treated as "unknown"
+     * and never escalated, so this can never turn a bind failure into a
+     * different error.
      */
-    private function checkExistingSessions(): void
+    private function logExistingSessions(): void
     {
-        $command = sprintf('lsof -ti :%d 2>/dev/null', $this->debugPort);
-        $pids = shell_exec($command);
-
-        if (! $pids) {
-            return;
-        }
-
-        $pidList = array_filter(explode("\n", trim($pids)));
+        $pidList = self::findPidsListeningOnPort($this->debugPort);
         if ($pidList === []) {
             return;
         }
@@ -2507,6 +2644,33 @@ final class DebugServer
         $this->log(sprintf('🔌 Port %d shared with other sessions: %s', $this->debugPort, implode(', ', $pidList)));
         $this->log('🎯 Using session key "xdebug-mcp" for isolation');
         $this->log('💡 IDEs can use different session keys (PHPSTORM, vscode, etc.)');
+    }
+
+    /**
+     * Shell out to `lsof` to list PIDs bound to a port.
+     *
+     * @return list<string>
+     */
+    private static function findPidsListeningOnPort(int $port): array
+    {
+        $pids = shell_exec(sprintf('lsof -ti :%d 2>/dev/null', $port));
+
+        return self::parsePidList($pids);
+    }
+
+    /**
+     * Extracted for unit testing without shelling out to `lsof`. Returns an
+     * empty list whenever the output is unavailable, errors, or finds nothing.
+     *
+     * @return list<string>
+     */
+    private static function parsePidList(string|false|null $lsofOutput): array
+    {
+        if (! $lsofOutput) {
+            return [];
+        }
+
+        return array_values(array_filter(explode("\n", trim($lsofOutput))));
     }
 
     /**
@@ -2546,10 +2710,20 @@ final class DebugServer
         $this->log('🚨 Emergency cleanup triggered');
         $this->cleanup();
 
-        // Only kill our own xdebug-mcp processes on abnormal termination
-        // This preserves other sessions (IDE) using the same port with different keys
-        $command = 'pkill -f "XDEBUG_SESSION=xdebug-mcp" 2>/dev/null || true';
-        shell_exec($command);
+        // Kill only the child process WE spawned, by its PID. The previous
+        // `pkill -f "XDEBUG_SESSION=xdebug-mcp"` matched by command line and so
+        // also killed the children of any OTHER concurrent xdebug-mcp session
+        // (the session key is a constant, not per-session). kill() is a no-op
+        // if the process has already exited.
+        if (! ($this->process instanceof Process)) {
+            return;
+        }
+
+        try {
+            $this->process->kill();
+        } catch (Throwable) {
+            // Already exited / nothing to kill.
+        }
     }
 
     /**
@@ -2765,7 +2939,7 @@ final class DebugServer
     {
         $context = [
             'target_script' => $this->targetScript,
-            'debug_port' => $this->debugPort,
+            'debug_port' => $this->effectiveDebugPort,
             'trace_file' => $this->traceFile,
             'breakpoint_line' => $this->initialBreakpointLine,
         ];

--- a/src/Exceptions/BreakpointException.php
+++ b/src/Exceptions/BreakpointException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when Xdebug rejects a breakpoint_set command.
+ *
+ * Replaces the previous silent 'error' string sentinel returned by
+ * DebugServer::setBreakpoint(), so a rejected breakpoint surfaces as a real
+ * failure that the caller can decide to skip (see setupConditionalBreakpoints)
+ * rather than an empty ["breaks":[]] result with no diagnostic.
+ */
+class BreakpointException extends RuntimeException
+{
+}

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -52,6 +52,7 @@ use function trim;
 use function unlink;
 
 use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
 use const STDIN;
 use const STDOUT;
 
@@ -86,7 +87,7 @@ final class McpServer
             'message' => $message,
             'data' => $data,
         ];
-        error_log('MCP Debug: ' . json_encode($logData, JSON_THROW_ON_ERROR));
+        error_log('MCP Debug: ' . json_encode($logData, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
     }
 
     private function initializeTools(): void
@@ -263,91 +264,63 @@ final class McpServer
     public function __invoke(): void
     {
         try {
-            $input = '';
-
             while (($line = fgets(STDIN)) !== false) {
-                $input .= $line;
-
-                if (! $this->isCompleteJsonRpc($input)) {
+                if (trim($line) === '') {
                     continue;
                 }
 
-                error_log('DEBUG: Raw Claude CLI input = ' . trim($input));
+                $response = $this->handleLine($line);
 
-                try {
-                    $request = json_decode(trim($input), true, 512, JSON_THROW_ON_ERROR);
-                } catch (JsonException) {
-                    // @codeCoverageIgnoreStart - JSON parse error path rarely triggered in tests
-                    // Invalid JSON, send parse error
-                    $errorResponse = [
-                        'jsonrpc' => '2.0',
-                        'id' => null,
-                        'error' => [
-                            'code' => -32700,
-                            'message' => 'Parse error',
-                        ],
-                    ];
-                    echo json_encode($errorResponse, JSON_THROW_ON_ERROR) . "\n";
-                    fflush(STDOUT);
-                    $input = '';
-
-                    continue;
-                    // @codeCoverageIgnoreEnd
-                }
-
-                // Validate request is an array
-                if (! is_array($request)) {
-                    $errorResponse = JsonRpcResponse::error(null, -32600, 'Invalid Request: expected object');
-                    echo json_encode($errorResponse, JSON_THROW_ON_ERROR) . "\n";
-                    fflush(STDOUT);
-                    $input = '';
-
+                if (! $response instanceof JsonRpcResponse) {
                     continue;
                 }
 
-                /** @var array{method?: string, params?: array<string, string|int|bool|array<string, string|int|bool>>, id?: string|int|null} $request */
-                $requestMethod = $request['method'] ?? 'unknown';
-                $requestId = $request['id'] ?? null;
-
-                error_log('DEBUG: Processing request method = ' . $requestMethod);
-
-                try {
-                    $response = $this->handleRequest($request);
-
-                    if ($response instanceof JsonRpcResponse) {
-                        $this->debugLog('Sending response', ['id' => $response->id]);
-                        echo json_encode($response, JSON_THROW_ON_ERROR) . "\n";
-                        fflush(STDOUT);
-                    }
-                } catch (Throwable $e) {
-                    error_log('DEBUG: MCP Server Error for method ' . $requestMethod . ': ' . $e->getMessage());
-                    error_log('MCP Server Error: ' . $e->getMessage() . "\nStack trace: " . $e->getTraceAsString());
-
-                    $errorResponse = JsonRpcResponse::error($requestId, -32603, 'Internal error: ' . $e->getMessage());
-                    echo json_encode($errorResponse, JSON_THROW_ON_ERROR) . "\n";
-                    fflush(STDOUT);
-                }
-
-                $input = '';
+                $this->debugLog('Sending response', ['id' => $response->id]);
+                echo json_encode($response, JSON_THROW_ON_ERROR) . "\n";
+                fflush(STDOUT);
             }
         } catch (Throwable $e) {
             error_log('MCP Server Fatal Error: ' . $e->getMessage() . "\nStack trace: " . $e->getTraceAsString());
         }
     }
 
-    private function isCompleteJsonRpc(string $input): bool
+    /**
+     * Parse and dispatch a single JSON-RPC request line.
+     *
+     * Stdio JSON-RPC framing is one message per line, so each line is decoded
+     * independently: a parse failure on one line can never affect any other
+     * line (there is no cross-line buffer to wedge). Returns null for
+     * notifications that require no response.
+     */
+    private function handleLine(string $line): JsonRpcResponse|null
     {
-        $trimmed = trim($input);
-        if ($trimmed === '') {
-            return false;
-        }
+        $trimmed = trim($line);
+
+        $this->debugLog('Raw Claude CLI input', ['input' => $trimmed]);
 
         try {
-            json_decode($trimmed, false, 512, JSON_THROW_ON_ERROR);
-
-            return true;
+            $request = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {
-            return false;
+            return JsonRpcResponse::error(null, -32700, 'Parse error');
+        }
+
+        if (! is_array($request)) {
+            return JsonRpcResponse::error(null, -32600, 'Invalid Request: expected object');
+        }
+
+        /** @var array{method?: string, params?: array<string, string|int|bool|array<string, string|int|bool>>, id?: string|int|null} $request */
+        $requestMethod = $request['method'] ?? 'unknown';
+        $requestId = $request['id'] ?? null;
+
+        $this->debugLog('Processing request', ['method' => $requestMethod]);
+
+        try {
+            return $this->handleRequest($request);
+        } catch (Throwable $e) {
+            $this->debugLog('MCP Server Error for method ' . $requestMethod, ['message' => $e->getMessage()]);
+            error_log('MCP Server Error: ' . $e->getMessage() . "\nStack trace: " . $e->getTraceAsString());
+
+            return JsonRpcResponse::error($requestId, -32603, 'Internal error: ' . $e->getMessage());
         }
     }
 

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -51,6 +51,7 @@ use function tempnam;
 use function trim;
 use function unlink;
 
+use const JSON_INVALID_UTF8_SUBSTITUTE;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 use const STDIN;
@@ -87,7 +88,10 @@ final class McpServer
             'message' => $message,
             'data' => $data,
         ];
-        error_log('MCP Debug: ' . json_encode($logData, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+        // Substitute (don't throw on) non-UTF-8 bytes in the logged payload —
+        // an unset MCP_DEBUG already skips this, but with it set a non-UTF-8
+        // request line must not be able to wedge the loop from here either.
+        error_log('MCP Debug: ' . json_encode($logData, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
     }
 
     private function initializeTools(): void
@@ -276,11 +280,37 @@ final class McpServer
                 }
 
                 $this->debugLog('Sending response', ['id' => $response->id]);
-                echo json_encode($response, JSON_THROW_ON_ERROR) . "\n";
+                echo $this->encodeResponse($response) . "\n";
                 fflush(STDOUT);
             }
         } catch (Throwable $e) {
             error_log('MCP Server Fatal Error: ' . $e->getMessage() . "\nStack trace: " . $e->getTraceAsString());
+        }
+    }
+
+    /**
+     * Encode a response for the wire without letting an encoding failure
+     * terminate the STDIN loop.
+     *
+     * Tool results embed the raw output of arbitrary scripts (exec()), which
+     * may contain non-UTF-8 bytes; those are substituted rather than thrown on,
+     * so the response is still delivered. On any other, unexpected encoding
+     * error we emit a protocol-valid error for the same id instead of dropping
+     * the response — a dropped response would leave the client waiting forever.
+     */
+    private function encodeResponse(JsonRpcResponse $response): string
+    {
+        try {
+            // JSON_INVALID_UTF8_SUBSTITUTE keeps non-UTF-8 tool output from
+            // throwing; the flag set otherwise matches the previous wire output.
+            return json_encode($response, JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+        } catch (JsonException $e) {
+            error_log('MCP Server Error: failed to encode response: ' . $e->getMessage());
+
+            return json_encode(
+                JsonRpcResponse::error($response->id, -32603, 'Failed to encode response'),
+                JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE,
+            );
         }
     }
 

--- a/tests/Integration/CompareRunnerWorktreeTest.php
+++ b/tests/Integration/CompareRunnerWorktreeTest.php
@@ -144,6 +144,7 @@ class CompareRunnerWorktreeTest extends TestCase
             $worktreePath = trim(implode('', $output));
 
             $this->assertNotSame('', $worktreePath, 'child should print the worktree path before the fatal error');
+            $this->assertNotSame(0, $exit, 'child must exit non-zero via the fatal error this test exercises');
             clearstatcache(true, $worktreePath);
             $this->assertDirectoryDoesNotExist(
                 $worktreePath,

--- a/tests/Integration/CompareRunnerWorktreeTest.php
+++ b/tests/Integration/CompareRunnerWorktreeTest.php
@@ -14,6 +14,7 @@ use RuntimeException;
 
 use function chdir;
 use function clearstatcache;
+use function dirname;
 use function escapeshellarg;
 use function exec;
 use function file_put_contents;
@@ -23,8 +24,12 @@ use function is_dir;
 use function mkdir;
 use function rmdir;
 use function sys_get_temp_dir;
+use function trim;
 use function uniqid;
 use function unlink;
+use function var_export;
+
+use const PHP_BINARY;
 
 /**
  * Exercises the real `git worktree` lifecycle in --compare-with mode.
@@ -97,6 +102,55 @@ class CompareRunnerWorktreeTest extends TestCase
                 $this->invoke($runner, 'cleanupWorktree', []);
             }
         } finally {
+            chdir($originalCwd);
+            $this->removeDirectory($repoDir);
+        }
+    }
+
+    /**
+     * Regression test for F5: register_shutdown_function only fires at process
+     * end, so this runs in a child process. The child creates a worktree,
+     * prints its path, then hits a fatal error (run()'s try/finally never
+     * executes) — the shutdown handler registered in createWorktree() must
+     * still remove the worktree instead of leaking it.
+     */
+    public function testWorktreeIsRemovedOnFatalErrorViaShutdownHandler(): void
+    {
+        $originalCwd = $this->currentWorkingDirectory();
+        $repoDir = $this->createTemporaryRepository();
+        $autoload = dirname(__DIR__, 2) . '/vendor/autoload.php';
+        $childScript = sys_get_temp_dir() . '/xcompare-fatal-' . uniqid('', true) . '.php';
+
+        $code = "<?php\n"
+            . 'require ' . var_export($autoload, true) . ";\n"
+            . 'chdir(' . var_export($repoDir, true) . ");\n"
+            . '$runner = new \\Koriym\\XdebugMcp\\CompareRunner('
+            . "['break' => 'x:1', 'run' => 'php -v', 'compare_with' => 'HEAD']);\n"
+            . '$method = (new \\ReflectionClass($runner))->getMethod(' . "'createWorktree');\n"
+            . '$path = $method->invoke($runner, ' . "'HEAD');\n"
+            . "echo \$path;\n"
+            . "xcompare_trigger_fatal_undefined_function();\n";
+        file_put_contents($childScript, $code);
+
+        try {
+            $output = [];
+            $exit = 0;
+            exec(
+                escapeshellarg(PHP_BINARY) . ' -d display_errors=0 '
+                . escapeshellarg($childScript) . ' 2>/dev/null',
+                $output,
+                $exit,
+            );
+            $worktreePath = trim(implode('', $output));
+
+            $this->assertNotSame('', $worktreePath, 'child should print the worktree path before the fatal error');
+            clearstatcache(true, $worktreePath);
+            $this->assertDirectoryDoesNotExist(
+                $worktreePath,
+                'shutdown handler must remove the worktree even when a fatal error skips run()\'s finally',
+            );
+        } finally {
+            unlink($childScript);
             chdir($originalCwd);
             $this->removeDirectory($repoDir);
         }

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -9,6 +9,17 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function array_column;
+use function array_merge;
+use function dirname;
+use function explode;
+use function fclose;
+use function fwrite;
+use function is_array;
+use function json_decode;
+use function proc_close;
+use function proc_open;
+use function stream_get_contents;
+use function trim;
 
 class McpServerIntegrationTest extends TestCase
 {
@@ -112,22 +123,100 @@ class McpServerIntegrationTest extends TestCase
         $this->assertStringContainsString('Unknown tool: invalid_tool', $response['error']['message']);
     }
 
-    public function testCompleteJsonRpcValidation(): void
+    public function testMalformedLineIsNotWedgedAndValidRequestStillAnswered(): void
     {
-        $testCases = [
-            ['{"valid": "json"}', true],
-            ['{"incomplete": ', false],
-            ['', false],
-            ['not json at all', false],
-            ['{"nested": {"object": true}}', true],
-            ['[{"array": true}]', true],
-            ['{"string": "value", "number": 123, "boolean": true}', true],
+        // Regression test for F2: a malformed line must emit a -32700 parse
+        // error AND must not wedge the stream — the following valid request
+        // must still be answered. Exercises the real bin/xdebug-mcp process.
+        [$stdout] = $this->runServerProcess(
+            '{oops not json}' . "\n" . '{"jsonrpc":"2.0","id":42,"method":"tools/list"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $codes = array_column(array_column($responses, 'error'), 'code');
+        $ids = array_column($responses, 'id');
+
+        $this->assertContains(-32700, $codes, 'malformed line should produce a -32700 parse error');
+        $this->assertContains(42, $ids, 'valid request after a malformed line must still be answered');
+    }
+
+    public function testRequestPayloadIsNotLoggedWithoutDebugMode(): void
+    {
+        [, $stderr] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $this->assertStringNotContainsString('MCP Debug:', $stderr);
+        $this->assertStringNotContainsString('tools/list', $stderr);
+    }
+
+    public function testRequestPayloadIsLoggedWhenDebugModeEnabled(): void
+    {
+        [, $stderr] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' . "\n",
+            ['MCP_DEBUG' => '1'],
+        );
+
+        $this->assertStringContainsString('MCP Debug:', $stderr);
+        $this->assertStringContainsString('Raw Claude CLI input', $stderr);
+        $this->assertStringContainsString('tools/list', $stderr);
+    }
+
+    /**
+     * Spawn the real bin/xdebug-mcp CLI (no mocks), write $input to STDIN,
+     * close the pipe (which makes the server's fgets loop reach EOF and exit),
+     * and return its [stdout, stderr].
+     *
+     * @param array<string, string> $env
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function runServerProcess(string $input, array $env): array
+    {
+        $descriptorSpec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
         ];
 
-        foreach ($testCases as [$input, $expected]) {
-            $result = $this->invokeMethod($this->server, 'isCompleteJsonRpc', [$input]);
-            $this->assertEquals($expected, $result, "Failed for input: {$input}");
+        $binary = dirname(__DIR__, 2) . '/bin/xdebug-mcp';
+        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge($_ENV, $env));
+
+        $this->assertIsResource($process);
+
+        fwrite($pipes[0], $input);
+        fclose($pipes[0]);
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        proc_close($process);
+
+        return [$stdout, $stderr];
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function decodeResponses(string $stdout): array
+    {
+        $responses = [];
+        foreach (explode("\n", trim($stdout)) as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            $responses[] = $decoded;
         }
+
+        return $responses;
     }
 
     private function invokeMethod(object $object, string $methodName, array $parameters = []): mixed

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -11,6 +11,7 @@ use ReflectionClass;
 
 use function array_filter;
 use function array_values;
+use function base64_encode;
 use function basename;
 use function chdir;
 use function count;
@@ -57,6 +58,58 @@ echo "Result: $result\n";
     {
         $server = new DebugServer($this->testScript, 9004);
         $this->assertInstanceOf(DebugServer::class, $server);
+    }
+
+    /**
+     * Regression test for F9: the lsof diagnostic used to run unconditionally
+     * in the constructor. It is now lazy (only triggered from a real bind
+     * failure), so the eager method must be gone and its lazy replacement
+     * present.
+     */
+    public function testConstructorDoesNotShellOutToLsof(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+
+        $this->assertFalse(
+            $reflection->hasMethod('checkExistingSessions'),
+            'checkExistingSessions() should be removed; the lsof check must be lazy, not in the constructor.',
+        );
+        $this->assertTrue($reflection->hasMethod('logExistingSessions'));
+    }
+
+    public function testParsePidListReturnsEmptyForFalseNullOrEmptyOutput(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+        $method = $reflection->getMethod('parsePidList');
+
+        $this->assertSame([], $method->invoke(null, false));
+        $this->assertSame([], $method->invoke(null, null));
+        $this->assertSame([], $method->invoke(null, ''));
+        $this->assertSame([], $method->invoke(null, "\n"));
+    }
+
+    public function testParsePidListParsesNewlineSeparatedPids(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+        $method = $reflection->getMethod('parsePidList');
+
+        $this->assertSame(['1234', '5678'], $method->invoke(null, "1234\n5678\n"));
+        $this->assertSame(['4321'], $method->invoke(null, '4321'));
+    }
+
+    /**
+     * Regression test for F4: the effective (actually-bound) port defaults to
+     * the configured debug port until the listener rebinds to an ephemeral
+     * port. Every -dxdebug.client_port the spawned PHP receives reads this
+     * property, so it must start equal to the constructor argument.
+     */
+    public function testEffectiveDebugPortDefaultsToConfiguredPort(): void
+    {
+        $server = new DebugServer($this->testScript, 9004);
+        $reflection = new ReflectionClass($server);
+        $property = $reflection->getProperty('effectiveDebugPort');
+
+        $this->assertSame(9004, $property->getValue($server));
     }
 
     public function testConstructorWithInvalidScript(): void
@@ -594,5 +647,73 @@ echo "Result: $result\n";
         $optionsProperty = $reflection->getProperty('options');
         $options = $optionsProperty->getValue($server);
         $this->assertEquals(60, $options['timeout']);
+    }
+
+    /**
+     * Regression test for F3: the DBGp "--" data-segment key must render as
+     * "-- {value}", never as "-{key} {value}" (which for a literal "--" key
+     * produces the broken "--- {value}" triple-dash that Xdebug rejects with a
+     * parse error). This is the mechanism breakpoint_set uses to carry a
+     * base64-encoded conditional-breakpoint expression (see setBreakpoint()).
+     */
+    public function testBuildDbgpCommandRendersDataSegmentWithDoubleDashNotTripleDash(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+        $buildDbgpCommand = $reflection->getMethod('buildDbgpCommand');
+
+        $command = $buildDbgpCommand->invoke(
+            null,
+            'breakpoint_set',
+            1,
+            ['t' => 'conditional', 's' => 'enabled', 'f' => 'file:///tmp/foo.php', 'n' => 5, '--' => 'JG4gPT0gMA=='],
+        );
+
+        $this->assertSame(
+            "breakpoint_set -i 1 -t conditional -s enabled -f file:///tmp/foo.php -n 5 -- JG4gPT0gMA==\0",
+            $command,
+        );
+        $this->assertStringNotContainsString('---', $command);
+    }
+
+    /**
+     * Regular (non "--") parameters must keep rendering as "-{key} {value}".
+     */
+    public function testBuildDbgpCommandRendersRegularFlagsWithSingleDash(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+        $buildDbgpCommand = $reflection->getMethod('buildDbgpCommand');
+
+        $command = $buildDbgpCommand->invoke(null, 'context_get', 3, ['c' => '0']);
+
+        $this->assertSame("context_get -i 3 -c 0\0", $command);
+    }
+
+    /**
+     * Regression test for F3: a breakpoint condition containing a space (e.g.
+     * "$n == 0") must be sent as DBGp type "conditional" with the expression
+     * base64-encoded in the "--" data segment — never as the "-o"
+     * hit-condition-operator parameter, which is unrelated (it takes values
+     * like ">=", "==", "%") and cannot carry arbitrary PHP source.
+     */
+    public function testConditionalBreakpointEncodesConditionInDataSegmentNotDashO(): void
+    {
+        $reflection = new ReflectionClass(DebugServer::class);
+        $buildDbgpCommand = $reflection->getMethod('buildDbgpCommand');
+
+        // Mirror exactly what setBreakpoint() builds for a conditional
+        // breakpoint, to pin the wire format without needing a live socket.
+        $condition = '$n == 0';
+        $params = [
+            't' => 'conditional',
+            's' => 'enabled',
+            'f' => 'file:///tmp/foo.php',
+            'n' => 5,
+            '--' => base64_encode($condition),
+        ];
+        $command = $buildDbgpCommand->invoke(null, 'breakpoint_set', 1, $params);
+
+        $this->assertStringContainsString('-t conditional', $command);
+        $this->assertStringNotContainsString('-o $n == 0', $command);
+        $this->assertStringContainsString('-- ' . base64_encode($condition), $command);
     }
 }

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -93,12 +93,52 @@ class McpServerTest extends TestCase
         $this->assertEquals('Method not found: unknown/method', $response['error']['message']);
     }
 
-    public function testIsCompleteJsonRpc(): void
+    public function testHandleLineMalformedJsonReturnsParseError(): void
     {
-        $this->assertTrue($this->invokePrivateMethod($this->server, 'isCompleteJsonRpc', ['{"test": "value"}']));
-        $this->assertFalse($this->invokePrivateMethod($this->server, 'isCompleteJsonRpc', ['{"test": ']));
-        $this->assertFalse($this->invokePrivateMethod($this->server, 'isCompleteJsonRpc', ['']));
-        $this->assertFalse($this->invokePrivateMethod($this->server, 'isCompleteJsonRpc', ['not json']));
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleLine', ['{oops}']);
+        $response = $responseObj->toArray();
+
+        $this->assertNull($response['id']);
+        $this->assertEquals(-32700, $response['error']['code']);
+        $this->assertEquals('Parse error', $response['error']['message']);
+    }
+
+    public function testHandleLineValidRequestAfterMalformedLineIsNotWedged(): void
+    {
+        // Regression test for F2: a malformed line must not contaminate the
+        // next line. Each line is parsed independently by handleLine().
+        $firstResponse = $this->invokePrivateMethod($this->server, 'handleLine', ['{oops}']);
+        $this->assertEquals(-32700, $firstResponse->toArray()['error']['code']);
+
+        $secondResponse = $this->invokePrivateMethod(
+            $this->server,
+            'handleLine',
+            ['{"jsonrpc":"2.0","id":99,"method":"tools/list"}'],
+        );
+        $second = $secondResponse->toArray();
+
+        $this->assertEquals(99, $second['id']);
+        $this->assertArrayHasKey('result', $second);
+        $this->assertArrayHasKey('tools', $second['result']);
+    }
+
+    public function testHandleLineNonObjectJsonReturnsInvalidRequest(): void
+    {
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleLine', ['42']);
+        $response = $responseObj->toArray();
+
+        $this->assertEquals(-32600, $response['error']['code']);
+    }
+
+    public function testHandleLineNotificationsInitializedReturnsNull(): void
+    {
+        $result = $this->invokePrivateMethod(
+            $this->server,
+            'handleLine',
+            ['{"jsonrpc":"2.0","method":"notifications/initialized"}'],
+        );
+
+        $this->assertNull($result);
     }
 
     public function testToolCallWithoutConnection(): void

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\Tests\Unit;
 
+use Koriym\XdebugMcp\DTO\GenericResult;
+use Koriym\XdebugMcp\DTO\JsonRpcResponse;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use Koriym\XdebugMcp\McpServer;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +13,10 @@ use ReflectionClass;
 use Throwable;
 
 use function array_column;
+use function json_decode;
 use function putenv;
+
+use const JSON_THROW_ON_ERROR;
 
 class McpServerTest extends TestCase
 {
@@ -120,6 +125,23 @@ class McpServerTest extends TestCase
         $this->assertEquals(99, $second['id']);
         $this->assertArrayHasKey('result', $second);
         $this->assertArrayHasKey('tools', $second['result']);
+    }
+
+    public function testEncodeResponseWithNonUtf8ToolOutputDoesNotThrow(): void
+    {
+        // Regression: tool results embed raw exec() output that may contain
+        // non-UTF-8 bytes. encodeResponse() must not throw (which would
+        // propagate to __invoke()'s outer catch and wedge the STDIN loop) — the
+        // bytes are substituted and a valid JSON response is still produced.
+        $response = JsonRpcResponse::success(7, new GenericResult([
+            'content' => [['type' => 'text', 'text' => "trace output \xff\xfe not utf-8"]],
+        ]));
+
+        $encoded = $this->invokePrivateMethod($this->server, 'encodeResponse', [$response]);
+
+        $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(7, $decoded['id']);
+        $this->assertArrayHasKey('result', $decoded);
     }
 
     public function testHandleLineNonObjectJsonReturnsInvalidRequest(): void


### PR DESCRIPTION
## Summary

Reliability and performance fixes found during a focused review of the DBGp
debug server, the MCP stdio loop, the Cachegrind profiler, and the worktree
comparison runner. Each fix was verified against a live Xdebug 8.4 runtime.

The single biggest issue: debug-session failures (port collision, connection
timeout, spawn error, rejected breakpoint) were all reported as `exit 0` with an
empty `{"breaks":[]}` and no stderr, so callers and CI could not tell a run had
failed. That is fixed, and the failures it was masking are addressed too.

## Changes

### `DebugServer` — silent failures, concurrency, conditional breakpoints
- **Surface failures.** `__invoke()` used `Future\awaitAll()` (which returns
  `[errors, values]` and never throws) and then forced `exit(0)` in a `finally`,
  so every task failure was discarded. Switched to `Future\await()` and removed
  the `finally`; failures now propagate with a non-zero exit and a stderr message.
- **Conditional breakpoints.** The condition was sent as `-o EXPR` unescaped, so
  any expression containing a space (e.g. `$n == 0`) triggered a DBGp
  `parse error in command` and the breakpoint was silently dropped. Conditions
  are now sent as DBGp type `conditional` with the expression base64-encoded in
  the `--` data segment (new `buildDbgpCommand()` helper). `setBreakpoint()`
  throws a domain `BreakpointException` on rejection; `setupConditionalBreakpoints()`
  catches it per breakpoint, warns on stderr, and continues — so a rejected
  breakpoint (e.g. a duplicate `file:line`) no longer hangs the paused child
  until the execution timeout.
- **Concurrency.** The listener bound a fixed port and `emergencyCleanup()` ran
  `pkill -f "XDEBUG_SESSION=xdebug-mcp"`, which also killed sibling sessions.
  The listener now falls back to an ephemeral port when the configured one is in
  use (the actually-bound port is threaded into every `-dxdebug.client_port`),
  and cleanup kills only our own child by PID. Two concurrent sessions now both
  succeed.
- **DBGp reads.** The length header was read one socket round-trip per digit;
  it now reads whole chunks into a per-socket buffer. The body is still sliced by
  exact length, so NUL bytes inside the payload are preserved.
- **lsof.** The existing-session diagnostic runs lazily (only on a real bind
  failure) instead of on every construction.

### `McpServer` — stdin framing wedge, debug logging
- A single malformed line was buffered forever and silently swallowed every
  following request (the `-32700` path was unreachable). Each line is now parsed
  independently in a unit-testable `handleLine()`.
- Per-request DEBUG logs are routed through the `MCP_DEBUG`-gated `debugLog()`
  so request payloads are no longer logged unconditionally.

### `bin/xprofile` — stream Cachegrind
- Parsing loaded the whole profile via `file_get_contents()` + `explode()`
  (2–3× file size in memory; profiles can be hundreds of MB). Now a single
  streaming pass. `total_lines` output is byte-identical to before (verified
  against the old parser on real and edge-case files).

### `CompareRunner` — worktree cleanup on fatal exit
- The `--compare-with` git worktree leaked on a fatal error (the `try/finally`
  never runs then). A shutdown handler now covers that path. A SIGTERM/SIGKILL
  during a blocking `proc_close()` remains a documented gap.

## Verification

- [x] `composer tests` (phpcs + phpstan level max + phpunit) — 307 tests pass
- [x] Conditional breakpoint with a space now hits; duplicate breakpoint no
  longer hangs
- [x] Malformed MCP line no longer wedges the stream
- [x] Two concurrent sessions both succeed
- [x] Cachegrind streaming output byte-identical to the previous parser
- [x] Worktree removed on fatal exit, no leaks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debugger now automatically selects an available port when the configured one is in use, and uses it consistently across spawned processes.
  * Conditional breakpoints now use a more reliable encoding so conditions (including with spaces) are applied correctly.

* **Bug Fixes**
  * MCP server input handling is now line-based and no longer risks wedging after malformed input.
  * Outgoing MCP responses are more robust to non-UTF-8 content, returning proper protocol errors instead of stalling.
  * Temporary worktrees are cleaned up even on fatal errors.

* **Tests**
  * Expanded integration and unit coverage for malformed requests, debug logging behavior, breakpoint command formatting, and fatal-error cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->