### PR TITLE
Report actual and requested debug port in xstep JSON output

### DIFF
--- a/docs/schemas/xstep.json
+++ b/docs/schemas/xstep.json
@@ -22,6 +22,14 @@
     "context": {
       "type": "string",
       "description": "Optional analysis context"
+    },
+    "debug_port": {
+      "type": "integer",
+      "description": "Port the debug listener actually bound to. Normally equal to the configured/default port (9004), but differs when that port was already in use and the listener fell back to an OS-assigned ephemeral port (see requested_port)."
+    },
+    "requested_port": {
+      "type": "integer",
+      "description": "Configured debug port that was requested but unavailable. Present only when a port fallback occurred, i.e. when this differs from debug_port."
     }
   },
   "required": ["breaks", "trace"],

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -129,7 +129,7 @@ use const STDERR;
  * @phpstan-type DebugBreak array{step: int, stack: list<StackFrame>, breakpoint?: BreakpointRef, variables?: array<string, string>, recording_type?: string, diff?: VariableDiff, watches?: list<WatchChange>}
  * @phpstan-type TraceInfo array{file: string, lines: int, functions: int, max_depth: int, db_queries: int, error?: string}
  * @phpstan-type OutputDebugInfo array{trace_files_found: int, search_patterns: list<string>, latest_file: string|null}
- * @phpstan-type XstepJsonOutput array{'$schema': string, breakpoint?: BreakpointRef, breaks: list<DebugBreak>, trace?: TraceInfo, context?: string, debug?: OutputDebugInfo}
+ * @phpstan-type XstepJsonOutput array{'$schema': string, breakpoint?: BreakpointRef, breaks: list<DebugBreak>, trace?: TraceInfo, context?: string, debug?: OutputDebugInfo, debug_port?: int, requested_port?: int}
  * @phpstan-type ShallowJsonValue string|int|float|bool|array<array-key, string|int|float|bool|array<array-key, string|int|float|bool|null>|null>|null
  * @phpstan-type ShallowJsonMap array<array-key, ShallowJsonValue>
  * @see https://xdebug.org/docs/step_debug
@@ -2803,6 +2803,28 @@ final class DebugServer
         ) ?? $json;
     }
 
+    /**
+     * Add the actually-bound debug port to the JSON result, so a caller only
+     * seeing --json output can still tell which port Xdebug is listening on.
+     *
+     * `requested_port` is only included when it differs from `debug_port` —
+     * i.e. when startXdebugListener() fell back to an ephemeral port because
+     * the configured one was already in use (see listenOnAvailablePort()).
+     *
+     * @param XstepJsonOutput $result
+     *
+     * @return XstepJsonOutput
+     */
+    private function addPortInfoToResult(array $result): array
+    {
+        $result['debug_port'] = $this->effectiveDebugPort;
+        if ($this->effectiveDebugPort !== $this->debugPort) {
+            $result['requested_port'] = $this->debugPort;
+        }
+
+        return $result;
+    }
+
     private function getMaxValueBytes(): int|null
     {
         $maxValueBytes = $this->options['maxValueBytes'] ?? null;
@@ -2903,6 +2925,8 @@ final class DebugServer
                 'error' => $e->getMessage(),
             ];
         }
+
+        $result = $this->addPortInfoToResult($result);
 
         echo $this->encodeJsonOutput($result) . "\n";
     }
@@ -3763,6 +3787,8 @@ final class DebugServer
 
         // Output format based on jsonMode or jsonOutput option
         if ($this->jsonMode || ($this->options['jsonOutput'] ?? false)) {
+            $debugState = $this->addPortInfoToResult($debugState);
+
             echo $this->encodeJsonOutput($debugState) . "\n";
 
             // Mark step-recording output as done only after JSON was successfully

--- a/tests/Unit/DebugServerTest.php
+++ b/tests/Unit/DebugServerTest.php
@@ -525,6 +525,129 @@ echo "Result: $result\n";
         $this->assertCount(1, $decoded['breaks']);
     }
 
+    /**
+     * Regression test for the Nit split out of PR #89: when the listener
+     * bound the configured port directly (no fallback), --json output must
+     * still report debug_port, but must NOT include requested_port — there
+     * was nothing to fall back from.
+     */
+    public function testMultipleBreakResultsJsonIncludesDebugPortWithoutFallback(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+        $reflection = new ReflectionClass($server);
+
+        $breaks = [
+            [
+                'step' => 1,
+                'stack' => [['function' => '{main}', 'file' => basename($this->testScript), 'line' => 3]],
+                'variables' => ['$x' => '10'],
+            ],
+        ];
+
+        $outputMultiple = $reflection->getMethod('outputMultipleBreakResults');
+
+        ob_start();
+        $outputMultiple->invoke($server, $breaks);
+        $stdout = ob_get_clean();
+
+        $decoded = json_decode($stdout, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(9004, $decoded['debug_port']);
+        $this->assertArrayNotHasKey('requested_port', $decoded);
+    }
+
+    /**
+     * Regression test for the Nit split out of PR #89: when
+     * listenOnAvailablePort() fell back to an ephemeral port (configured port
+     * busy), --json output must report BOTH the actually-bound debug_port and
+     * the originally requested_port, so a caller seeing only JSON can tell a
+     * fallback happened without reading human-readable logs.
+     */
+    public function testMultipleBreakResultsJsonIncludesRequestedPortOnFallback(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+        $reflection = new ReflectionClass($server);
+
+        // Simulate startXdebugListener() having fallen back to an ephemeral
+        // port: effectiveDebugPort diverges from the configured debugPort.
+        $reflection->getProperty('effectiveDebugPort')->setValue($server, 62612);
+
+        $breaks = [
+            [
+                'step' => 1,
+                'stack' => [['function' => '{main}', 'file' => basename($this->testScript), 'line' => 3]],
+                'variables' => ['$x' => '10'],
+            ],
+        ];
+
+        $outputMultiple = $reflection->getMethod('outputMultipleBreakResults');
+
+        ob_start();
+        $outputMultiple->invoke($server, $breaks);
+        $stdout = ob_get_clean();
+
+        $decoded = json_decode($stdout, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(62612, $decoded['debug_port']);
+        $this->assertSame(9004, $decoded['requested_port']);
+    }
+
+    /**
+     * Same debug_port/requested_port contract as the multiple-breakpoint
+     * path, but for the other JSON emission site: outputStepRecordingResults()
+     * (the --steps recording path). Both output methods must stay consistent.
+     */
+    public function testStepRecordingResultsJsonIncludesDebugPortWithoutFallback(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+        $reflection = new ReflectionClass($server);
+
+        $reflection->getProperty('breaks')->setValue($server, [
+            [
+                'step' => 1,
+                'stack' => [['function' => 'foo', 'file' => basename($this->testScript), 'line' => 10]],
+                'variables' => ['$a' => 'int: 1'],
+            ],
+        ]);
+
+        $outputStepRec = $reflection->getMethod('outputStepRecordingResults');
+
+        ob_start();
+        $outputStepRec->invoke($server);
+        $stdout = ob_get_clean();
+
+        $decoded = json_decode($stdout, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(9004, $decoded['debug_port']);
+        $this->assertArrayNotHasKey('requested_port', $decoded);
+    }
+
+    public function testStepRecordingResultsJsonIncludesRequestedPortOnFallback(): void
+    {
+        $server = new DebugServer($this->testScript, 9004, null, [], true);
+        $reflection = new ReflectionClass($server);
+
+        $reflection->getProperty('effectiveDebugPort')->setValue($server, 62612);
+        $reflection->getProperty('breaks')->setValue($server, [
+            [
+                'step' => 1,
+                'stack' => [['function' => 'foo', 'file' => basename($this->testScript), 'line' => 10]],
+                'variables' => ['$a' => 'int: 1'],
+            ],
+        ]);
+
+        $outputStepRec = $reflection->getMethod('outputStepRecordingResults');
+
+        ob_start();
+        $outputStepRec->invoke($server);
+        $stdout = ob_get_clean();
+
+        $decoded = json_decode($stdout, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(62612, $decoded['debug_port']);
+        $this->assertSame(9004, $decoded['requested_port']);
+    }
+
     public function testVariableDisplayCanBeTruncatedByBytes(): void
     {
         $server = new DebugServer($this->testScript, 9004, null, [], true);


### PR DESCRIPTION
## Summary

Split out from an independent review of PR #89 (merged): a Nit noting that when the debug listener falls back from the configured port (9004) to an OS-assigned ephemeral port (see `listenOnAvailablePort()` / `effectiveDebugPort`, introduced in #89), that fact is only surfaced through `log()`, which is a silent no-op in `--json` mode (the default for `xstep`). A caller that only sees the JSON output - e.g. an AI client - had no way to learn a fallback happened or which port Xdebug actually bound to.

This PR adds two fields to xstep's JSON output:

- `debug_port` - the port the listener actually bound to. Always present.
- `requested_port` - the originally configured port. Present only when it differs from `debug_port`, i.e. only when a fallback occurred.

Both `outputStepRecordingResults()` and `outputMultipleBreakResults()` (the two JSON emission paths) now populate these via a shared `addPortInfoToResult()` helper, keeping the two paths consistent. The `XstepJsonOutput` phpstan-type and the public `docs/schemas/xstep.json` schema are updated to match. Field naming follows the existing `debug_port` precedent in `getCurrentDebugContext()`.

Note: this was originally planned as a stacked PR on top of PR #89's branch, but #89 merged into `1.x` while this change was being prepared, so it is now rebased directly onto `1.x` as a normal PR.

## Test plan

- [x] `vendor/bin/phpunit --no-coverage` - full suite passes (312 tests, 851 assertions, 7 pre-existing skips)
- [x] `composer cs` (phpcs) - 0 violations
- [x] `composer sa` (phpstan level max, `src/`) - 0 errors
- [x] Added 4 unit tests in `tests/Unit/DebugServerTest.php` covering both output methods x both cases (no fallback / fallback), using reflection to set `effectiveDebugPort`/`debugPort` directly (no mocks)
- [x] Manually verified with a real Xdebug session: ran `bin/xstep` normally and confirmed `debug_port` appears without `requested_port`; then occupied port 9004 with another process and confirmed both `debug_port` (ephemeral) and `requested_port: 9004` appear correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step/debug JSON output now includes the actual port being used for debugging.
  * When a fallback port is assigned, the original requested port is also included for clarity.

* **Documentation**
  * Updated the JSON schema to describe the new port-related fields in step output.

* **Bug Fixes**
  * Improved consistency in debug output across single-step and multi-breakpoint flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->