### PR TITLE
Support MCP 2026-07-28 (stateless) protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now recommends the Skill integration over the MCP server for AI coding agents (with a comparison table and guidance on when MCP is the right choice), and correctly documents that MCP exposes all one-shot tools including `xcompare`.
 
 ### Fixed
-- `McpServerIntegrationTest` process spawner now forwards the real environment (`getenv()`) to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment.
+- `McpServerIntegrationTest` process spawner now forwards the real environment (`getenv()`) to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment; inherited `XDEBUG_MODE`/`XDEBUG_CONFIG`/`XDEBUG_TRIGGER` are stripped since they take precedence over the tools' own on-demand Xdebug configuration.
 - MCP requests with non-object `params` now return -32602 (Invalid params) instead of an internal error (-32603) that leaked method signatures and file paths to the client.
 - Stateless request detection now keys on the presence of `io.modelcontextprotocol/protocolVersion` only; other keys under the reserved prefix (e.g. `logLevel`) no longer cause spurious -32602 rejections.
 - `initialize` never names the stateless 2026-07-28 revision (which has no handshake); negotiation stays within legacy revisions, falling back to 2025-11-25.
+- The -32022 (UnsupportedProtocolVersion) error data now matches the 2026-07-28 schema: `data: {supported, requested}`.
+- Notifications (requests without an `id`) are never answered, per JSON-RPC 2.0 §4.1 — previously malformed notifications could receive error responses.
 
 ## [0.12.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- MCP protocol version 2026-07-28 (stateless) support: `server/discover` RPC, per-request `_meta` protocol fields (`io.modelcontextprotocol/protocolVersion`, `clientCapabilities`) with -32022/-32602 validation, `resultType` on every result, server identity in result `_meta`, and `ttlMs`/`cacheScope` cache hints on list endpoints. Legacy `initialize` handshake clients (2025-11-25 and earlier) remain supported (dual-era).
+- Protocol-level integration tests that spawn the real `bin/xdebug-mcp` process and exercise the stateless workflows end to end: `server/discover` probe, handshake-less `tools/list`/`tools/call`, unsupported-version (-32022) and missing-`_meta` (-32602) errors, and the legacy `initialize` flow.
+
+### Fixed
+- `McpServerIntegrationTest` process spawner now forwards `PATH`/`HOME` to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment.
+
 ## [0.12.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP protocol version 2026-07-28 (stateless) support: `server/discover` RPC, per-request `_meta` protocol fields (`io.modelcontextprotocol/protocolVersion`, `clientCapabilities`) with -32022/-32602 validation, `resultType` on every result, server identity in result `_meta`, and `ttlMs`/`cacheScope` cache hints on list endpoints. Legacy `initialize` handshake clients (2025-11-25 and earlier) remain supported (dual-era).
 - Protocol-level integration tests that spawn the real `bin/xdebug-mcp` process and exercise the stateless workflows end to end: `server/discover` probe, handshake-less `tools/list`/`tools/call`, unsupported-version (-32022) and missing-`_meta` (-32602) errors, and the legacy `initialize` flow.
 
+### Changed
+- README now recommends the Skill integration over the MCP server for AI coding agents (with a comparison table and guidance on when MCP is the right choice), and correctly documents that MCP exposes all one-shot tools including `xcompare`.
+
 ### Fixed
 - `McpServerIntegrationTest` process spawner now forwards `PATH`/`HOME` to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now recommends the Skill integration over the MCP server for AI coding agents (with a comparison table and guidance on when MCP is the right choice), and correctly documents that MCP exposes all one-shot tools including `xcompare`.
 
 ### Fixed
-- `McpServerIntegrationTest` process spawner now forwards `PATH`/`HOME` to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment.
+- `McpServerIntegrationTest` process spawner now forwards the real environment (`getenv()`) to the server process, so MCP tool calls that locate `php`/Xdebug work when PHPUnit runs with a minimal environment.
+- MCP requests with non-object `params` now return -32602 (Invalid params) instead of an internal error (-32603) that leaked method signatures and file paths to the client.
+- Stateless request detection now keys on the presence of `io.modelcontextprotocol/protocolVersion` only; other keys under the reserved prefix (e.g. `logLevel`) no longer cause spurious -32602 rejections.
+- `initialize` never names the stateless 2026-07-28 revision (which has no handshake); negotiation stays within legacy revisions, falling back to 2025-11-25.
 
 ## [0.12.0] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ composer global require koriym/xdebug-mcp
 
 ### 3. (Optional) Wire up an AI assistant
 
-**Claude Code** — install the plugin:
+Two integrations are available. **We recommend the Skill**: these tools are stateless one-shot CLI commands by design, so letting the agent run them directly — guided by the Skill's usage notes — is the simplest and most accurate path. Choose MCP when your client has no shell access or no Skill support.
+
+| | Skill (recommended) | MCP server |
+|---|---|---|
+| How it works | The agent reads `SKILL.md` and runs the CLI tools directly | The client calls the tools over JSON-RPC (stdio) |
+| Setup | Plugin install, or copy one directory | Register in the client's MCP config |
+| Best for | AI coding agents with shell access (Claude Code, Codex, ...) | MCP-capable clients without shell/Skill support (e.g. Claude Desktop) |
+
+**Claude Code** — install the plugin (which bundles the Skill):
 
 ```text
 /plugin marketplace add koriym/xdebug-mcp
@@ -146,7 +154,7 @@ flowchart LR
 | `xback` | Call stack at breakpoint | "Show me how we got to this error" |
 | `xcompare` | Compare variable states across two runs | "Compare input 10 vs 0" or "Compare with main branch" |
 
-All tools in this table are available as CLI commands. MCP currently exposes the core one-shot analysis tools: `xtrace`, `xprofile`, `xstep`, `xcoverage`, and `xback`. `xcompare` is CLI-only.
+All tools in this table are available both as CLI commands and as MCP tools. `xrepl` (the interactive debugger below) is CLI-only.
 
 ## CLI Usage
 
@@ -205,7 +213,9 @@ Schemas live under [docs/schemas/](docs/schemas/). AI assistants — and humans 
 
 ## MCP Configuration
 
-For any MCP-capable client, register `xdebug-mcp` in that client's MCP config (e.g. `.mcp.json`). MCP exposes `xtrace`, `xprofile`, `xstep`, `xcoverage`, and `xback`:
+For AI coding agents with shell access, the [Skill](#3-optional-wire-up-an-ai-assistant) is the recommended integration. Register the MCP server instead when your client supports MCP but cannot run shell commands or Skills (e.g. Claude Desktop), or when you want a schema-validated tool interface shared across MCP clients.
+
+Add `xdebug-mcp` to the client's MCP config (e.g. `.mcp.json`). MCP exposes all one-shot tools: `xtrace`, `xprofile`, `xstep`, `xcoverage`, `xback`, and `xcompare`:
 
 ```json
 {
@@ -306,7 +316,7 @@ Looking for a different approach? [kpanuragh/xdebug-mcp](https://github.com/kpan
 
 ## Why "xdebug-mcp"?
 
-This project started as an MCP (Model Context Protocol) server for AI-powered PHP debugging. MCP is still supported for any MCP-capable client, but the CLI is now the primary interface. The core MCP tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`) also work as standalone CLI commands; `xcompare` and `xrepl` are CLI-only tools.
+This project started as an MCP (Model Context Protocol) server for AI-powered PHP debugging. MCP is still supported for any MCP-capable client, but the CLI is now the primary interface. The MCP tools (`xstep`, `xtrace`, `xprofile`, `xcoverage`, `xback`, `xcompare`) also work as standalone CLI commands; `xrepl` is CLI-only.
 
 ## Resources
 

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -12,4 +12,12 @@ final class Constants
     public const DEFAULT_HOST = '127.0.0.1';
     public const XDEBUG_DEBUG_PORT = 9004;
     public const GLOBAL_STATE_FILE = '/tmp/xdebug-mcp-global-state.json';
+
+    /** MCP server identity reported in serverInfo */
+    public const MCP_SERVER_NAME = 'xdebug-mcp-server';
+    public const MCP_SERVER_VERSION = '2.0.0';
+
+    /** Cache hints (CacheableResult) for static list endpoints such as tools/list */
+    public const MCP_LIST_CACHE_TTL_MS = 3600000;
+    public const MCP_LIST_CACHE_SCOPE = 'public';
 }

--- a/src/DTO/DiscoverResult.php
+++ b/src/DTO/DiscoverResult.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for MCP 2026-07-28 server/discover (SEP-2575)
+ *
+ * @phpstan-import-type Capabilities from Types
+ */
+final class DiscoverResult implements JsonRpcResultInterface
+{
+    /**
+     * @param list<string> $supportedVersions
+     * @param Capabilities $capabilities
+     */
+    public function __construct(
+        public readonly array $supportedVersions,
+        public readonly array $capabilities,
+        public readonly string $instructions,
+        public readonly int $ttlMs,
+        public readonly string $cacheScope,
+    ) {
+    }
+
+    /** @return array{supportedVersions: list<string>, capabilities: Capabilities, instructions: string, ttlMs: int, cacheScope: string} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'supportedVersions' => $this->supportedVersions,
+            'capabilities' => $this->capabilities,
+            'instructions' => $this->instructions,
+            'ttlMs' => $this->ttlMs,
+            'cacheScope' => $this->cacheScope,
+        ];
+    }
+}

--- a/src/DTO/GenericResult.php
+++ b/src/DTO/GenericResult.php
@@ -9,16 +9,18 @@ namespace Koriym\XdebugMcp\DTO;
  *
  * Use this when a specific result DTO doesn't exist yet.
  * Prefer creating specific DTOs for type safety where practical.
+ *
+ * @phpstan-import-type JsonObject from Types
  */
 final class GenericResult implements JsonRpcResultInterface
 {
-    /** @param array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null> $data */
+    /** @param JsonObject $data */
     public function __construct(
         private readonly array $data,
     ) {
     }
 
-    /** @return array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null> */
+    /** @return JsonObject */
     public function jsonSerialize(): array
     {
         return $this->data;

--- a/src/DTO/InitializeResult.php
+++ b/src/DTO/InitializeResult.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for the legacy initialize handshake (2025-11-25 and earlier)
+ *
+ * @phpstan-import-type Capabilities from Types
+ */
+final class InitializeResult implements JsonRpcResultInterface
+{
+    /**
+     * @param Capabilities                         $capabilities
+     * @param array{name: string, version: string} $serverInfo
+     */
+    public function __construct(
+        public readonly string $protocolVersion,
+        public readonly array $capabilities,
+        public readonly array $serverInfo,
+        public readonly string $instructions,
+    ) {
+    }
+
+    /** @return array{protocolVersion: string, capabilities: Capabilities, serverInfo: array{name: string, version: string}, instructions: string} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'protocolVersion' => $this->protocolVersion,
+            'capabilities' => $this->capabilities,
+            'serverInfo' => $this->serverInfo,
+            'instructions' => $this->instructions,
+        ];
+    }
+}

--- a/src/DTO/JsonRpcError.php
+++ b/src/DTO/JsonRpcError.php
@@ -11,18 +11,26 @@ use JsonSerializable;
  */
 final class JsonRpcError implements JsonSerializable
 {
+    /** @param array{supportedVersions?: list<string>}|null $data */
     public function __construct(
         public readonly int $code,
         public readonly string $message,
+        public readonly array|null $data = null,
     ) {
     }
 
-    /** @return array{code: int, message: string} */
+    /** @return array{code: int, message: string, data?: array{supportedVersions?: list<string>}} */
     public function jsonSerialize(): array
     {
-        return [
+        $error = [
             'code' => $this->code,
             'message' => $this->message,
         ];
+
+        if ($this->data !== null) {
+            $error['data'] = $this->data;
+        }
+
+        return $error;
     }
 }

--- a/src/DTO/JsonRpcError.php
+++ b/src/DTO/JsonRpcError.php
@@ -11,7 +11,7 @@ use JsonSerializable;
  */
 final class JsonRpcError implements JsonSerializable
 {
-    /** @param array{supportedVersions?: list<string>}|null $data */
+    /** @param array{supported?: list<string>, requested?: string}|null $data */
     public function __construct(
         public readonly int $code,
         public readonly string $message,
@@ -19,7 +19,7 @@ final class JsonRpcError implements JsonSerializable
     ) {
     }
 
-    /** @return array{code: int, message: string, data?: array{supportedVersions?: list<string>}} */
+    /** @return array{code: int, message: string, data?: array{supported?: list<string>, requested?: string}} */
     public function jsonSerialize(): array
     {
         $error = [

--- a/src/DTO/JsonRpcResponse.php
+++ b/src/DTO/JsonRpcResponse.php
@@ -27,13 +27,13 @@ final class JsonRpcResponse implements JsonSerializable
         return new self(id: $id, result: $result);
     }
 
-    /** @param array{supportedVersions?: list<string>}|null $data */
+    /** @param array{supported?: list<string>, requested?: string}|null $data */
     public static function error(string|int|null $id, int $code, string $message, array|null $data = null): self
     {
         return new self(id: $id, error: new JsonRpcError($code, $message, $data));
     }
 
-    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supportedVersions?: list<string>}}} */
+    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supported?: list<string>, requested?: string}}} */
     public function jsonSerialize(): array
     {
         $response = [
@@ -81,7 +81,7 @@ final class JsonRpcResponse implements JsonSerializable
         return $data;
     }
 
-    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supportedVersions?: list<string>}}} */
+    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supported?: list<string>, requested?: string}}} */
     public function toArray(): array
     {
         return $this->jsonSerialize();

--- a/src/DTO/JsonRpcResponse.php
+++ b/src/DTO/JsonRpcResponse.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Koriym\XdebugMcp\DTO;
 
 use JsonSerializable;
+use Koriym\XdebugMcp\Constants;
+
+use function is_array;
 
 /**
  * JSON-RPC 2.0 Response
@@ -24,12 +27,13 @@ final class JsonRpcResponse implements JsonSerializable
         return new self(id: $id, result: $result);
     }
 
-    public static function error(string|int|null $id, int $code, string $message): self
+    /** @param array{supportedVersions?: list<string>}|null $data */
+    public static function error(string|int|null $id, int $code, string $message, array|null $data = null): self
     {
-        return new self(id: $id, error: new JsonRpcError($code, $message));
+        return new self(id: $id, error: new JsonRpcError($code, $message, $data));
     }
 
-    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string}} */
+    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supportedVersions?: list<string>}}} */
     public function jsonSerialize(): array
     {
         $response = [
@@ -38,7 +42,7 @@ final class JsonRpcResponse implements JsonSerializable
         ];
 
         if ($this->result instanceof JsonRpcResultInterface) {
-            $response['result'] = $this->result->jsonSerialize();
+            $response['result'] = $this->serializeResult($this->result);
         }
 
         if ($this->error instanceof JsonRpcError) {
@@ -48,7 +52,36 @@ final class JsonRpcResponse implements JsonSerializable
         return $response;
     }
 
-    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string}} */
+    /**
+     * Serialize a result and attach the MCP 2026-07-28 protocol fields:
+     * every result carries resultType ("complete" for ordinary results) and
+     * identifies the server in _meta (io.modelcontextprotocol/serverInfo).
+     * Both are ignored by legacy clients, so they are added unconditionally.
+     *
+     * @return array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>
+     */
+    private function serializeResult(JsonRpcResultInterface $result): array
+    {
+        $data = $result->jsonSerialize();
+        if (! isset($data['resultType'])) {
+            $data['resultType'] = 'complete';
+        }
+
+        $meta = $data['_meta'] ?? [];
+        if (! is_array($meta)) {
+            $meta = [];
+        }
+
+        $meta['io.modelcontextprotocol/serverInfo'] ??= [
+            'name' => Constants::MCP_SERVER_NAME,
+            'version' => Constants::MCP_SERVER_VERSION,
+        ];
+        $data['_meta'] = $meta;
+
+        return $data;
+    }
+
+    /** @return array{jsonrpc: string, id: string|int|null, result?: array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null>, error?: array{code: int, message: string, data?: array{supportedVersions?: list<string>}}} */
     public function toArray(): array
     {
         return $this->jsonSerialize();

--- a/src/DTO/JsonRpcResultInterface.php
+++ b/src/DTO/JsonRpcResultInterface.php
@@ -11,9 +11,11 @@ use JsonSerializable;
  *
  * All JSON-RPC result DTOs must implement this interface to ensure
  * they can be properly serialized in responses.
+ *
+ * @phpstan-import-type JsonObject from Types
  */
 interface JsonRpcResultInterface extends JsonSerializable
 {
-    /** @return array<string, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|array<array-key, bool|float|int|string|null>|null>|null>|null>|null> */
+    /** @return JsonObject */
     public function jsonSerialize(): array;
 }

--- a/src/DTO/PromptExecutionResult.php
+++ b/src/DTO/PromptExecutionResult.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for prompts/get tool executions
+ *
+ * Carries the assistant message text plus tool-specific debug data
+ * (keys vary per tool: command, exit_code, output, breakpoints, ...).
+ *
+ * @phpstan-import-type JsonObject from Types
+ * @phpstan-import-type TextContent from Types
+ */
+final class PromptExecutionResult implements JsonRpcResultInterface
+{
+    /** @param JsonObject $debugData */
+    public function __construct(
+        public readonly string $text,
+        public readonly array $debugData,
+    ) {
+    }
+
+    /** @return array{messages: list<array{role: string, content: TextContent}>, debug_data: JsonObject} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'messages' => [
+                [
+                    'role' => 'assistant',
+                    'content' => [
+                        'type' => 'text',
+                        'text' => $this->text,
+                    ],
+                ],
+            ],
+            'debug_data' => $this->debugData,
+        ];
+    }
+}

--- a/src/DTO/PromptsListResult.php
+++ b/src/DTO/PromptsListResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for prompts/list
+ *
+ * @phpstan-import-type PromptShape from Types
+ */
+final class PromptsListResult implements JsonRpcResultInterface
+{
+    /** @param list<PromptShape> $prompts */
+    public function __construct(
+        public readonly array $prompts,
+        public readonly int $ttlMs,
+        public readonly string $cacheScope,
+    ) {
+    }
+
+    /** @return array{prompts: list<PromptShape>, ttlMs: int, cacheScope: string} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'prompts' => $this->prompts,
+            'ttlMs' => $this->ttlMs,
+            'cacheScope' => $this->cacheScope,
+        ];
+    }
+}

--- a/src/DTO/ResourcesListResult.php
+++ b/src/DTO/ResourcesListResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for resources/list (this server exposes no resources)
+ *
+ * @phpstan-import-type JsonObject from Types
+ */
+final class ResourcesListResult implements JsonRpcResultInterface
+{
+    /** @param list<JsonObject> $resources */
+    public function __construct(
+        public readonly array $resources,
+        public readonly int $ttlMs,
+        public readonly string $cacheScope,
+    ) {
+    }
+
+    /** @return array{resources: list<JsonObject>, ttlMs: int, cacheScope: string} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'resources' => $this->resources,
+            'ttlMs' => $this->ttlMs,
+            'cacheScope' => $this->cacheScope,
+        ];
+    }
+}

--- a/src/DTO/ToolCallResult.php
+++ b/src/DTO/ToolCallResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Result DTO for tools/call — a single text content block
+ *
+ * @phpstan-import-type TextContent from Types
+ */
+final class ToolCallResult implements JsonRpcResultInterface
+{
+    public function __construct(
+        public readonly string $text,
+    ) {
+    }
+
+    /** @return array{content: list<TextContent>} */
+    public function jsonSerialize(): array
+    {
+        return [
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => $this->text,
+                ],
+            ],
+        ];
+    }
+}

--- a/src/DTO/ToolsListResult.php
+++ b/src/DTO/ToolsListResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\DTO;
 
+use Koriym\XdebugMcp\Constants;
+
 use function array_map;
 
 /**
@@ -17,7 +19,7 @@ final class ToolsListResult implements JsonRpcResultInterface
     ) {
     }
 
-    /** @return array{tools: list<array{name: string, description: string, inputSchema: array{type: string, properties: array<string, array{type: string, description: string, default?: string|int}>, required: list<string>}}>} */
+    /** @return array{tools: list<array{name: string, description: string, inputSchema: array{type: string, properties: array<string, array{type: string, description: string, default?: string|int}>, required: list<string>}}>, ttlMs: int, cacheScope: string} */
     public function jsonSerialize(): array
     {
         return [
@@ -25,6 +27,9 @@ final class ToolsListResult implements JsonRpcResultInterface
                 static fn (McpTool $tool): array => $tool->jsonSerialize(),
                 $this->tools,
             ),
+            // MCP 2026-07-28 CacheableResult: the tool list is static
+            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
+            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
         ];
     }
 }

--- a/src/DTO/Types.php
+++ b/src/DTO/Types.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\XdebugMcp\DTO;
+
+/**
+ * Domain types for JSON-RPC / MCP payloads (PHPStan)
+ *
+ * JSON values are recursive by nature, but PHPStan type aliases cannot be
+ * recursive, so the nesting depth is bounded explicitly. The bound matches
+ * the previous hand-written inline shapes and covers every tool result.
+ *
+ * @phpstan-type JsonScalar = bool|float|int|string|null
+ * @phpstan-type JsonValue1 = bool|float|int|string|array<array-key, JsonScalar>|null
+ * @phpstan-type JsonValue2 = bool|float|int|string|array<array-key, JsonValue1>|null
+ * @phpstan-type JsonValue3 = bool|float|int|string|array<array-key, JsonValue2>|null
+ * @phpstan-type JsonValue = bool|float|int|string|array<array-key, JsonValue3>|null
+ * @phpstan-type JsonObject = array<string, JsonValue>
+ * @phpstan-type Capabilities = array{tools: array{listChanged: bool}, resources: array{listChanged: bool}, prompts: array{listChanged: bool}}
+ * @phpstan-type TextContent = array{type: string, text: string}
+ * @phpstan-type PromptArgumentShape = array{name: string, description: string, required: bool}
+ * @phpstan-type PromptShape = array{name: string, description: string, arguments: list<PromptArgumentShape>}
+ * @phpstan-type ErrorData = array{supported?: list<string>, requested?: string}
+ * @phpstan-type JsonRpcErrorShape = array{code: int, message: string, data?: ErrorData}
+ * @phpstan-type JsonRpcResponseShape = array{jsonrpc: string, id: string|int|null, result?: JsonObject, error?: JsonRpcErrorShape}
+ */
+final class Types
+{
+}

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -17,6 +17,7 @@ use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 use Throwable;
 
 use function array_filter;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
@@ -61,6 +62,11 @@ use const STDOUT;
 
 final class McpServer
 {
+    /** Supported MCP protocol versions, oldest first (dual-era: legacy + stateless) */
+    private const SUPPORTED_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28'];
+    private const LATEST_VERSION = '2026-07-28';
+    private const INSTRUCTIONS = 'PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, analyze coverage, or compare executions of PHP code. Tools: xtrace (execution flow), xstep (breakpoint debugging), xprofile (performance), xcoverage (test coverage), xback (stack traces), xcompare (breakpoint variable comparison across two runs).';
+
     /** @var array<string, McpTool> */
     protected array $tools = [];
     private bool $debugMode = false;
@@ -400,9 +406,18 @@ final class McpServer
         $params = $request['params'] ?? [];
         $id = $request['id'] ?? null;
 
+        // MCP 2026-07-28 (stateless): requests carrying io.modelcontextprotocol/*
+        // _meta keys must declare a supported protocol version (SEP-2575).
+        // Requests without them are legacy (initialize-era) and pass through.
+        $metaError = $this->validateProtocolMeta($id, $params);
+        if ($metaError instanceof JsonRpcResponse) {
+            return $metaError;
+        }
+
         try {
             return match ($method) {
                 'initialize' => $this->handleInitialize($id, $params),
+                'server/discover' => $this->handleServerDiscover($id),
                 'tools/list' => $this->handleToolsList($id),
                 'tools/call' => $this->handleToolCall($id, $params),
                 'resources/list' => $this->handleResourcesList($id),
@@ -417,16 +432,56 @@ final class McpServer
         }
     }
 
+    /**
+     * Validate MCP 2026-07-28 per-request protocol fields.
+     *
+     * A request whose _meta contains io.modelcontextprotocol/* keys is a
+     * "modern" stateless request: it must declare protocolVersion and
+     * clientCapabilities (-32602 if missing), and the version must be one
+     * this server implements (-32022 UnsupportedProtocolVersion otherwise).
+     * Returns null when the request is valid or legacy (no modern _meta).
+     *
+     * @param array<string, string|int|bool|array<string, string|int|bool>> $params
+     */
+    private function validateProtocolMeta(string|int|null $id, array $params): JsonRpcResponse|null
+    {
+        $meta = $params['_meta'] ?? null;
+        if (! is_array($meta)) {
+            return null;
+        }
+
+        $hasProtocolKeys = false;
+        foreach (array_keys($meta) as $key) {
+            if (str_starts_with((string) $key, 'io.modelcontextprotocol/')) {
+                $hasProtocolKeys = true;
+                break;
+            }
+        }
+
+        if (! $hasProtocolKeys) {
+            return null;
+        }
+
+        $version = $meta['io.modelcontextprotocol/protocolVersion'] ?? null;
+        if (! is_string($version) || ! isset($meta['io.modelcontextprotocol/clientCapabilities'])) {
+            return JsonRpcResponse::error($id, -32602, 'Invalid params: missing required _meta fields (io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities)');
+        }
+
+        if (! in_array($version, self::SUPPORTED_VERSIONS, true)) {
+            return JsonRpcResponse::error($id, -32022, "Unsupported protocol version: {$version}", ['supportedVersions' => self::SUPPORTED_VERSIONS]);
+        }
+
+        return null;
+    }
+
     /** @param array<string, string|int|bool|array<string, string|int|bool>> $params */
     private function handleInitialize(string|int|null $id, array $params): JsonRpcResponse
     {
-        // Use the protocol version requested by the client, defaulting to latest
-        $clientVersion = $params['protocolVersion'] ?? '2025-06-18';
-
-        // Ensure we support the requested version
-        $supportedVersions = ['2024-11-05', '2025-03-26', '2025-06-18'];
-        if (! in_array($clientVersion, $supportedVersions, true)) {
-            $clientVersion = '2025-06-18';
+        // Legacy handshake (2025-11-25 and earlier): use the protocol version
+        // requested by the client, defaulting to latest when unsupported
+        $clientVersion = $params['protocolVersion'] ?? self::LATEST_VERSION;
+        if (! is_string($clientVersion) || ! in_array($clientVersion, self::SUPPORTED_VERSIONS, true)) {
+            $clientVersion = self::LATEST_VERSION;
         }
 
         return JsonRpcResponse::success($id, new GenericResult([
@@ -437,10 +492,30 @@ final class McpServer
                 'prompts' => ['listChanged' => true],
             ],
             'serverInfo' => [
-                'name' => 'xdebug-mcp-server',
-                'version' => '2.0.0',
+                'name' => Constants::MCP_SERVER_NAME,
+                'version' => Constants::MCP_SERVER_VERSION,
             ],
-            'instructions' => 'PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, analyze coverage, or compare executions of PHP code. Tools: xtrace (execution flow), xstep (breakpoint debugging), xprofile (performance), xcoverage (test coverage), xback (stack traces), xcompare (breakpoint variable comparison across two runs).',
+            'instructions' => self::INSTRUCTIONS,
+        ]));
+    }
+
+    /**
+     * MCP 2026-07-28 server/discover (SEP-2575): advertise supported protocol
+     * versions, capabilities, and identity. Also used by dual-era clients as
+     * the stdio backward-compatibility probe.
+     */
+    private function handleServerDiscover(string|int|null $id): JsonRpcResponse
+    {
+        return JsonRpcResponse::success($id, new GenericResult([
+            'supportedVersions' => self::SUPPORTED_VERSIONS,
+            'capabilities' => [
+                'tools' => ['listChanged' => true],
+                'resources' => ['listChanged' => false],
+                'prompts' => ['listChanged' => true],
+            ],
+            'instructions' => self::INSTRUCTIONS,
+            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
+            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
         ]));
     }
 
@@ -453,6 +528,8 @@ final class McpServer
     {
         return JsonRpcResponse::success($id, new GenericResult([
             'resources' => [],
+            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
+            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
         ]));
     }
 
@@ -637,6 +714,8 @@ final class McpServer
                     ],
                 ],
             ],
+            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
+            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
         ]));
     }
 

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -17,7 +17,6 @@ use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 use Throwable;
 
 use function array_filter;
-use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
@@ -64,7 +63,12 @@ final class McpServer
 {
     /** Supported MCP protocol versions, oldest first (dual-era: legacy + stateless) */
     private const SUPPORTED_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28'];
-    private const LATEST_VERSION = '2026-07-28';
+
+    /** Legacy (initialize-handshake) revisions, oldest first */
+    private const LEGACY_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25'];
+
+    /** Latest legacy revision — the fallback for initialize requests; the stateless 2026-07-28 has no handshake and must not be named in an initialize result */
+    private const LATEST_LEGACY_VERSION = '2025-11-25';
     private const INSTRUCTIONS = 'PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, analyze coverage, or compare executions of PHP code. Tools: xtrace (execution flow), xstep (breakpoint debugging), xprofile (performance), xcoverage (test coverage), xback (stack traces), xcompare (breakpoint variable comparison across two runs).';
 
     /** @var array<string, McpTool> */
@@ -383,7 +387,7 @@ final class McpServer
             return JsonRpcResponse::error(null, -32600, 'Invalid Request: expected object');
         }
 
-        /** @var array{method?: string, params?: array<string, string|int|bool|array<string, string|int|bool>>, id?: string|int|null} $request */
+        /** @var array{method?: string, params?: string|int|bool|array<string, string|int|bool|array<string, string|int|bool>>|null, id?: string|int|null} $request */
         $requestMethod = $request['method'] ?? 'unknown';
         $requestId = $request['id'] ?? null;
 
@@ -399,16 +403,23 @@ final class McpServer
         }
     }
 
-    /** @param array{method?: string, params?: array<string, string|int|bool|array<string, string|int|bool>>, id?: string|int|null} $request */
+    /** @param array{method?: string, params?: string|int|bool|array<string, string|int|bool|array<string, string|int|bool>>|null, id?: string|int|null} $request */
     private function handleRequest(array $request): JsonRpcResponse|null
     {
         $method = $request['method'] ?? '';
         $params = $request['params'] ?? [];
         $id = $request['id'] ?? null;
 
-        // MCP 2026-07-28 (stateless): requests carrying io.modelcontextprotocol/*
-        // _meta keys must declare a supported protocol version (SEP-2575).
-        // Requests without them are legacy (initialize-era) and pass through.
+        // params is decoded JSON — it may be a scalar even though handlers
+        // expect an object; reject before it reaches typed signatures
+        if (! is_array($params)) {
+            return JsonRpcResponse::error($id, -32602, 'Invalid params: expected object');
+        }
+
+        // MCP 2026-07-28 (stateless): requests carrying the
+        // io.modelcontextprotocol/protocolVersion _meta key must declare a
+        // supported protocol version (SEP-2575). Requests without it are
+        // legacy (initialize-era) and pass through.
         $metaError = $this->validateProtocolMeta($id, $params);
         if ($metaError instanceof JsonRpcResponse) {
             return $metaError;
@@ -435,11 +446,13 @@ final class McpServer
     /**
      * Validate MCP 2026-07-28 per-request protocol fields.
      *
-     * A request whose _meta contains io.modelcontextprotocol/* keys is a
-     * "modern" stateless request: it must declare protocolVersion and
-     * clientCapabilities (-32602 if missing), and the version must be one
-     * this server implements (-32022 UnsupportedProtocolVersion otherwise).
-     * Returns null when the request is valid or legacy (no modern _meta).
+     * The stateless marker is the io.modelcontextprotocol/protocolVersion
+     * _meta key: when present, clientCapabilities is also required (-32602 if
+     * missing) and the version must be one this server implements (-32022
+     * UnsupportedProtocolVersion otherwise). Other keys under the reserved
+     * io.modelcontextprotocol/ prefix (logLevel, subscriptionId, ...) may
+     * legitimately appear on their own, so they are not treated as markers.
+     * Returns null when the request is valid or legacy (no protocolVersion).
      *
      * @param array<string, string|int|bool|array<string, string|int|bool>> $params
      */
@@ -450,19 +463,11 @@ final class McpServer
             return null;
         }
 
-        $hasProtocolKeys = false;
-        foreach (array_keys($meta) as $key) {
-            if (str_starts_with((string) $key, 'io.modelcontextprotocol/')) {
-                $hasProtocolKeys = true;
-                break;
-            }
-        }
-
-        if (! $hasProtocolKeys) {
+        $version = $meta['io.modelcontextprotocol/protocolVersion'] ?? null;
+        if ($version === null) {
             return null;
         }
 
-        $version = $meta['io.modelcontextprotocol/protocolVersion'] ?? null;
         if (! is_string($version) || ! isset($meta['io.modelcontextprotocol/clientCapabilities'])) {
             return JsonRpcResponse::error($id, -32602, 'Invalid params: missing required _meta fields (io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities)');
         }
@@ -477,11 +482,12 @@ final class McpServer
     /** @param array<string, string|int|bool|array<string, string|int|bool>> $params */
     private function handleInitialize(string|int|null $id, array $params): JsonRpcResponse
     {
-        // Legacy handshake (2025-11-25 and earlier): use the protocol version
-        // requested by the client, defaulting to latest when unsupported
-        $clientVersion = $params['protocolVersion'] ?? self::LATEST_VERSION;
-        if (! is_string($clientVersion) || ! in_array($clientVersion, self::SUPPORTED_VERSIONS, true)) {
-            $clientVersion = self::LATEST_VERSION;
+        // Legacy handshake: negotiate within the legacy (initialize-era)
+        // revisions only — the stateless 2026-07-28 has no handshake and
+        // must not be named in an initialize result
+        $clientVersion = $params['protocolVersion'] ?? self::LATEST_LEGACY_VERSION;
+        if (! is_string($clientVersion) || ! in_array($clientVersion, self::LEGACY_VERSIONS, true)) {
+            $clientVersion = self::LATEST_LEGACY_VERSION;
         }
 
         return JsonRpcResponse::success($id, new GenericResult([

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -17,6 +17,7 @@ use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 use Throwable;
 
 use function array_filter;
+use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function array_values;
@@ -407,8 +408,15 @@ final class McpServer
     private function handleRequest(array $request): JsonRpcResponse|null
     {
         $method = $request['method'] ?? '';
-        $params = $request['params'] ?? [];
         $id = $request['id'] ?? null;
+
+        // JSON-RPC 2.0 §4.1: a notification (no id member) must never be
+        // answered — not even with an error
+        if (! array_key_exists('id', $request)) {
+            return null;
+        }
+
+        $params = $request['params'] ?? [];
 
         // params is decoded JSON — it may be a scalar even though handlers
         // expect an object; reject before it reaches typed signatures
@@ -463,17 +471,22 @@ final class McpServer
             return null;
         }
 
-        $version = $meta['io.modelcontextprotocol/protocolVersion'] ?? null;
-        if ($version === null) {
+        if (! array_key_exists('io.modelcontextprotocol/protocolVersion', $meta)) {
             return null;
         }
 
-        if (! is_string($version) || ! isset($meta['io.modelcontextprotocol/clientCapabilities'])) {
-            return JsonRpcResponse::error($id, -32602, 'Invalid params: missing required _meta fields (io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities)');
+        $version = $meta['io.modelcontextprotocol/protocolVersion'];
+        if (! is_string($version)) {
+            return JsonRpcResponse::error($id, -32602, 'Invalid params: io.modelcontextprotocol/protocolVersion must be a string');
+        }
+
+        if (! isset($meta['io.modelcontextprotocol/clientCapabilities'])) {
+            return JsonRpcResponse::error($id, -32602, 'Invalid params: missing required _meta field (io.modelcontextprotocol/clientCapabilities)');
         }
 
         if (! in_array($version, self::SUPPORTED_VERSIONS, true)) {
-            return JsonRpcResponse::error($id, -32022, "Unsupported protocol version: {$version}", ['supportedVersions' => self::SUPPORTED_VERSIONS]);
+            // UnsupportedProtocolVersionError: data shape per 2026-07-28 schema
+            return JsonRpcResponse::error($id, -32022, "Unsupported protocol version: {$version}", ['supported' => self::SUPPORTED_VERSIONS, 'requested' => $version]);
         }
 
         return null;

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -62,11 +62,11 @@ use const STDOUT;
 
 final class McpServer
 {
-    /** Supported MCP protocol versions, oldest first (dual-era: legacy + stateless) */
-    private const SUPPORTED_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25', '2026-07-28'];
-
     /** Legacy (initialize-handshake) revisions, oldest first */
     private const LEGACY_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25'];
+
+    /** Supported MCP protocol versions, oldest first (dual-era: legacy + stateless) */
+    private const SUPPORTED_VERSIONS = [...self::LEGACY_VERSIONS, '2026-07-28'];
 
     /** Latest legacy revision — the fallback for initialize requests; the stateless 2026-07-28 has no handshake and must not be named in an initialize result */
     private const LATEST_LEGACY_VERSION = '2025-11-25';

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace Koriym\XdebugMcp;
 
 use JsonException;
-use Koriym\XdebugMcp\DTO\GenericResult;
+use Koriym\XdebugMcp\DTO\DiscoverResult;
+use Koriym\XdebugMcp\DTO\InitializeResult;
 use Koriym\XdebugMcp\DTO\JsonRpcError;
 use Koriym\XdebugMcp\DTO\JsonRpcResponse;
 use Koriym\XdebugMcp\DTO\McpTool;
+use Koriym\XdebugMcp\DTO\PromptExecutionResult;
+use Koriym\XdebugMcp\DTO\PromptsListResult;
+use Koriym\XdebugMcp\DTO\ResourcesListResult;
+use Koriym\XdebugMcp\DTO\ToolCallResult;
 use Koriym\XdebugMcp\DTO\ToolsListResult;
 use Koriym\XdebugMcp\Exceptions\FileNotFoundException;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
@@ -71,6 +76,13 @@ final class McpServer
     /** Latest legacy revision — the fallback for initialize requests; the stateless 2026-07-28 has no handshake and must not be named in an initialize result */
     private const LATEST_LEGACY_VERSION = '2025-11-25';
     private const INSTRUCTIONS = 'PHP debugging and analysis tools using Xdebug. Use when asked to trace, debug, profile, analyze coverage, or compare executions of PHP code. Tools: xtrace (execution flow), xstep (breakpoint debugging), xprofile (performance), xcoverage (test coverage), xback (stack traces), xcompare (breakpoint variable comparison across two runs).';
+
+    /** Server capabilities advertised by initialize and server/discover */
+    private const CAPABILITIES = [
+        'tools' => ['listChanged' => true],
+        'resources' => ['listChanged' => false],
+        'prompts' => ['listChanged' => true],
+    ];
 
     /** @var array<string, McpTool> */
     protected array $tools = [];
@@ -503,19 +515,15 @@ final class McpServer
             $clientVersion = self::LATEST_LEGACY_VERSION;
         }
 
-        return JsonRpcResponse::success($id, new GenericResult([
-            'protocolVersion' => $clientVersion,
-            'capabilities' => [
-                'tools' => ['listChanged' => true],
-                'resources' => ['listChanged' => false],
-                'prompts' => ['listChanged' => true],
-            ],
-            'serverInfo' => [
+        return JsonRpcResponse::success($id, new InitializeResult(
+            $clientVersion,
+            self::CAPABILITIES,
+            [
                 'name' => Constants::MCP_SERVER_NAME,
                 'version' => Constants::MCP_SERVER_VERSION,
             ],
-            'instructions' => self::INSTRUCTIONS,
-        ]));
+            self::INSTRUCTIONS,
+        ));
     }
 
     /**
@@ -525,17 +533,13 @@ final class McpServer
      */
     private function handleServerDiscover(string|int|null $id): JsonRpcResponse
     {
-        return JsonRpcResponse::success($id, new GenericResult([
-            'supportedVersions' => self::SUPPORTED_VERSIONS,
-            'capabilities' => [
-                'tools' => ['listChanged' => true],
-                'resources' => ['listChanged' => false],
-                'prompts' => ['listChanged' => true],
-            ],
-            'instructions' => self::INSTRUCTIONS,
-            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
-            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
-        ]));
+        return JsonRpcResponse::success($id, new DiscoverResult(
+            self::SUPPORTED_VERSIONS,
+            self::CAPABILITIES,
+            self::INSTRUCTIONS,
+            Constants::MCP_LIST_CACHE_TTL_MS,
+            Constants::MCP_LIST_CACHE_SCOPE,
+        ));
     }
 
     private function handleToolsList(string|int|null $id): JsonRpcResponse
@@ -545,17 +549,17 @@ final class McpServer
 
     private function handleResourcesList(string|int|null $id): JsonRpcResponse
     {
-        return JsonRpcResponse::success($id, new GenericResult([
-            'resources' => [],
-            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
-            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
-        ]));
+        return JsonRpcResponse::success($id, new ResourcesListResult(
+            [],
+            Constants::MCP_LIST_CACHE_TTL_MS,
+            Constants::MCP_LIST_CACHE_SCOPE,
+        ));
     }
 
     private function handlePromptsList(string|int|null $id): JsonRpcResponse
     {
-        return JsonRpcResponse::success($id, new GenericResult([
-            'prompts' => [
+        return JsonRpcResponse::success($id, new PromptsListResult(
+            [
                 [
                     'name' => 'xtrace',
                     'description' => 'Trace PHP execution flow. Returns JSON with $schema URL for semantic details and AI analysis strategies. Key fields: {lines, functions, max_depth, db_queries}. Vendor excluded by default.',
@@ -733,9 +737,9 @@ final class McpServer
                     ],
                 ],
             ],
-            'ttlMs' => Constants::MCP_LIST_CACHE_TTL_MS,
-            'cacheScope' => Constants::MCP_LIST_CACHE_SCOPE,
-        ]));
+            Constants::MCP_LIST_CACHE_TTL_MS,
+            Constants::MCP_LIST_CACHE_SCOPE,
+        ));
     }
 
     /** @param array<string, string|int|bool|array<string, string|int|bool>> $params */
@@ -949,14 +953,7 @@ final class McpServer
         try {
             $result = $this->executeToolCall($toolName, $arguments);
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'content' => [
-                    [
-                        'type' => 'text',
-                        'text' => $result,
-                    ],
-                ],
-            ]));
+            return JsonRpcResponse::success($id, new ToolCallResult($result));
         } catch (Throwable $e) {
             return JsonRpcResponse::error($id, -32000, $e->getMessage());
         }
@@ -1068,17 +1065,9 @@ final class McpServer
                 throw new InvalidArgumentException('Permission denied accessing: ' . $script);
             }
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Forward Trace execution ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$originalScript}\n**Context**: {$context}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Output**:\n```\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Forward Trace execution ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$originalScript}\n**Context**: {$context}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Output**:\n```\n" . $outputText . "\n```",
+                [
                     'command' => $cmd,
                     'exit_code' => $returnCode,
                     'output' => $outputText,
@@ -1086,7 +1075,7 @@ final class McpServer
                     'script' => $script,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling difficult to test without mocking shell commands
             return JsonRpcResponse::error($id, -32000, 'xtrace execution failed: ' . $e->getMessage());
@@ -1188,17 +1177,9 @@ final class McpServer
                 throw new InvalidArgumentException('Debug error: ' . $matches[1]);
             }
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Forward Trace debugging ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Breakpoints**: {$breakpoints}\n**Steps**: {$steps}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Debug Output**:\n```\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Forward Trace debugging ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Breakpoints**: {$breakpoints}\n**Steps**: {$steps}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Debug Output**:\n```\n" . $outputText . "\n```",
+                [
                     'command' => $cmd,
                     'exit_code' => $returnCode,
                     'output' => $outputText,
@@ -1208,7 +1189,7 @@ final class McpServer
                     'steps' => $steps,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling difficult to test without mocking shell commands
             return JsonRpcResponse::error($id, -32000, 'xstep execution failed: ' . $e->getMessage());
@@ -1251,17 +1232,9 @@ final class McpServer
                 throw new InvalidArgumentException('Permission denied accessing: ' . $script);
             }
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Performance profiling ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Profile Analysis**:\n```\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Performance profiling ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Profile Analysis**:\n```\n" . $outputText . "\n```",
+                [
                     'command' => $cmd,
                     'exit_code' => $returnCode,
                     'output' => $outputText,
@@ -1269,7 +1242,7 @@ final class McpServer
                     'script' => $script,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling path requires shell command failures which are difficult to reproduce consistently in tests
             return JsonRpcResponse::error($id, -32000, 'xprofile execution failed: ' . $e->getMessage());
@@ -1335,17 +1308,9 @@ final class McpServer
                 throw new InvalidArgumentException('Permission denied accessing: ' . $script);
             }
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Code coverage analysis ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Format**: json\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Coverage Report**:\n```\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Code coverage analysis ' . ($returnCode === 0 ? 'completed' : 'failed') . ":\n\n**Script**: {$script}\n**Context**: {$context}\n**Format**: json\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Coverage Report**:\n```\n" . $outputText . "\n```",
+                [
                     'command' => $cmd,
                     'exit_code' => $returnCode,
                     'output' => $outputText,
@@ -1353,7 +1318,7 @@ final class McpServer
                     'script' => $script,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling path requires coverage collection failures which are environment-dependent and difficult to test reliably
             return JsonRpcResponse::error($id, -32000, 'xcoverage execution failed: ' . $e->getMessage());
@@ -1416,17 +1381,9 @@ final class McpServer
                 throw new InvalidArgumentException('Permission denied accessing: ' . $script);
             }
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Stack trace (backtrace) ' . ($returnCode === 0 ? 'retrieved' : 'failed') . ":\n\n**Script**: {$originalScript}\n**Context**: {$context}\n**Breakpoint**: {$breakpoint}\n**Depth**: {$depth}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Stack Trace**:\n```\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Stack trace (backtrace) ' . ($returnCode === 0 ? 'retrieved' : 'failed') . ":\n\n**Script**: {$originalScript}\n**Context**: {$context}\n**Breakpoint**: {$breakpoint}\n**Depth**: {$depth}\n**Command**: `{$cmd}`\n**Exit Code**: {$returnCode}\n\n**Stack Trace**:\n```\n" . $outputText . "\n```",
+                [
                     'command' => $cmd,
                     'exit_code' => $returnCode,
                     'output' => $outputText,
@@ -1436,7 +1393,7 @@ final class McpServer
                     'depth' => $depth,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling path requires backtrace failures which are environment-dependent
             return JsonRpcResponse::error($id, -32000, 'xback execution failed: ' . $e->getMessage());
@@ -1499,22 +1456,14 @@ final class McpServer
 
             $outputText = json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
-            return JsonRpcResponse::success($id, new GenericResult([
-                'messages' => [
-                    [
-                        'role' => 'assistant',
-                        'content' => [
-                            'type' => 'text',
-                            'text' => 'Breakpoint comparison completed:' . "\n\n" .
-                                '**Breakpoint**: ' . $breakpoint . "\n" .
-                                '**Run A**: ' . $runA . "\n" .
-                                '**Run B**: ' . $runB . "\n" .
-                                '**Context**: ' . $context . "\n\n" .
-                                '**Result**:' . "\n```json\n" . $outputText . "\n```",
-                        ],
-                    ],
-                ],
-                'debug_data' => [
+            return JsonRpcResponse::success($id, new PromptExecutionResult(
+                'Breakpoint comparison completed:' . "\n\n" .
+                    '**Breakpoint**: ' . $breakpoint . "\n" .
+                    '**Run A**: ' . $runA . "\n" .
+                    '**Run B**: ' . $runB . "\n" .
+                    '**Context**: ' . $context . "\n\n" .
+                    '**Result**:' . "\n```json\n" . $outputText . "\n```",
+                [
                     'breakpoint' => $breakpoint,
                     'run_a' => $runA,
                     'run_b' => $runB,
@@ -1524,7 +1473,7 @@ final class McpServer
                     'output' => $outputText,
                     'timestamp' => date('Y-m-d H:i:s'),
                 ],
-            ]));
+            ));
         } catch (Throwable $e) {
             // @codeCoverageIgnoreStart - Exception handling path requires CompareRunner/xstep failures which are environment-dependent
             return JsonRpcResponse::error($id, -32000, 'xcompare execution failed: ' . $e->getMessage());

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -14,6 +14,7 @@ use function dirname;
 use function explode;
 use function fclose;
 use function fwrite;
+use function getenv;
 use function is_array;
 use function json_decode;
 use function proc_close;
@@ -195,6 +196,112 @@ class McpServerIntegrationTest extends TestCase
         $this->assertStringContainsString('tools/list', $stderr);
     }
 
+    public function testServerDiscoverOverStdio(): void
+    {
+        // MCP 2026-07-28: server/discover is the dual-era probe on stdio
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"server/discover"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+
+        $result = $responses[0]['result'];
+        $this->assertContains('2026-07-28', $result['supportedVersions']);
+        $this->assertContains('2024-11-05', $result['supportedVersions']);
+        $this->assertArrayHasKey('capabilities', $result);
+        $this->assertSame('complete', $result['resultType']);
+        $this->assertSame(
+            'xdebug-mcp-server',
+            $result['_meta']['io.modelcontextprotocol/serverInfo']['name'],
+        );
+    }
+
+    public function testStatelessModernWorkflowOverStdio(): void
+    {
+        // MCP 2026-07-28: no initialize handshake — every request carries its
+        // protocol version and client capabilities in _meta
+        $meta = '"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}';
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{' . $meta . '}}' . "\n"
+            . '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"xback","arguments":{"script":"php tests/fake/loop-counter.php","breakpoint":"tests/fake/loop-counter.php:10"},' . $meta . '}}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(2, $responses);
+
+        $this->assertCount(6, $responses[0]['result']['tools']);
+        $this->assertSame('complete', $responses[0]['result']['resultType']);
+        $this->assertSame(
+            'xdebug-mcp-server',
+            $responses[0]['result']['_meta']['io.modelcontextprotocol/serverInfo']['name'],
+        );
+
+        $this->assertArrayHasKey('content', $responses[1]['result']);
+        $this->assertStringContainsString('backtrace', $responses[1]['result']['content'][0]['text']);
+    }
+
+    public function testUnsupportedProtocolVersionOverStdio(): void
+    {
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2030-01-01","io.modelcontextprotocol/clientCapabilities":{}}}}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+
+        $error = $responses[0]['error'];
+        $this->assertSame(-32022, $error['code']);
+        $this->assertContains('2026-07-28', $error['data']['supportedVersions']);
+    }
+
+    public function testModernMetaMissingRequiredFieldsOverStdio(): void
+    {
+        // _meta declares clientCapabilities but omits protocolVersion
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+        $this->assertSame(-32602, $responses[0]['error']['code']);
+    }
+
+    public function testLegacyInitializeWorkflowOverStdio(): void
+    {
+        // Dual-era: legacy clients (2025-11-25 and earlier) keep working.
+        // The initialized notification must produce no response.
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"legacy","version":"1.0"}}}' . "\n"
+            . '{"jsonrpc":"2.0","method":"notifications/initialized"}' . "\n"
+            . '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(2, $responses, 'notification must not produce a response');
+        $this->assertSame('2025-06-18', $responses[0]['result']['protocolVersion']);
+        $this->assertCount(6, $responses[1]['result']['tools']);
+    }
+
+    public function testRequestWithNonProtocolMetaPassesAsLegacyOverStdio(): void
+    {
+        // _meta without io.modelcontextprotocol/* keys (e.g. progressToken)
+        // is not a modern request and must not be rejected
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"progressToken":"tok1"}}}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+        $this->assertCount(6, $responses[0]['result']['tools']);
+    }
+
     /**
      * Spawn the real bin/xdebug-mcp CLI (no mocks), write $input to STDIN,
      * close the pipe (which makes the server's fgets loop reach EOF and exit),
@@ -213,7 +320,20 @@ class McpServerIntegrationTest extends TestCase
         ];
 
         $binary = dirname(__DIR__, 2) . '/bin/xdebug-mcp';
-        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge($_ENV, $env));
+
+        // $_ENV is often nearly empty under PHPUnit (variables_order=GPCS);
+        // ensure PATH/HOME survive so tool calls can locate php and Xdebug
+        $baseEnv = $_ENV;
+        foreach (['PATH', 'HOME'] as $key) {
+            $value = getenv($key);
+            if ($value === false || isset($baseEnv[$key])) {
+                continue;
+            }
+
+            $baseEnv[$key] = $value;
+        }
+
+        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge($baseEnv, $env));
 
         $this->assertIsResource($process);
 

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -260,9 +260,11 @@ class McpServerIntegrationTest extends TestCase
 
     public function testModernMetaMissingRequiredFieldsOverStdio(): void
     {
-        // _meta declares clientCapabilities but omits protocolVersion
+        // _meta declares protocolVersion but omits clientCapabilities.
+        // (A request with clientCapabilities but no protocolVersion has no
+        // stateless marker and passes as legacy.)
         [$stdout] = $this->runServerProcess(
-            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/clientCapabilities":{}}}}' . "\n",
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}' . "\n",
             ['MCP_DEBUG' => ''],
         );
 
@@ -302,6 +304,19 @@ class McpServerIntegrationTest extends TestCase
         $this->assertCount(6, $responses[0]['result']['tools']);
     }
 
+    public function testNonArrayParamsOverStdio(): void
+    {
+        // Regression: scalar params must yield -32602, not -32603 with internals
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":"oops"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+        $this->assertSame(-32602, $responses[0]['error']['code']);
+    }
+
     /**
      * Spawn the real bin/xdebug-mcp CLI (no mocks), write $input to STDIN,
      * close the pipe (which makes the server's fgets loop reach EOF and exit),
@@ -322,18 +337,8 @@ class McpServerIntegrationTest extends TestCase
         $binary = dirname(__DIR__, 2) . '/bin/xdebug-mcp';
 
         // $_ENV is often nearly empty under PHPUnit (variables_order=GPCS);
-        // ensure PATH/HOME survive so tool calls can locate php and Xdebug
-        $baseEnv = $_ENV;
-        foreach (['PATH', 'HOME'] as $key) {
-            $value = getenv($key);
-            if ($value === false || isset($baseEnv[$key])) {
-                continue;
-            }
-
-            $baseEnv[$key] = $value;
-        }
-
-        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge($baseEnv, $env));
+        // forward the real environment so tool calls can locate php and Xdebug
+        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge(getenv(), $env));
 
         $this->assertIsResource($process);
 

--- a/tests/Integration/McpServerIntegrationTest.php
+++ b/tests/Integration/McpServerIntegrationTest.php
@@ -240,7 +240,10 @@ class McpServerIntegrationTest extends TestCase
         );
 
         $this->assertArrayHasKey('content', $responses[1]['result']);
-        $this->assertStringContainsString('backtrace', $responses[1]['result']['content'][0]['text']);
+        // Match the success marker, not just "backtrace" — the failure
+        // message ("Stack trace (backtrace) failed") contains it too
+        $this->assertStringContainsString('Stack trace (backtrace) retrieved', $responses[1]['result']['content'][0]['text']);
+        $this->assertStringNotContainsString('failed', $responses[1]['result']['content'][0]['text']);
     }
 
     public function testUnsupportedProtocolVersionOverStdio(): void
@@ -255,7 +258,41 @@ class McpServerIntegrationTest extends TestCase
 
         $error = $responses[0]['error'];
         $this->assertSame(-32022, $error['code']);
-        $this->assertContains('2026-07-28', $error['data']['supportedVersions']);
+        $this->assertContains('2026-07-28', $error['data']['supported']);
+        $this->assertSame('2030-01-01', $error['data']['requested']);
+    }
+
+    public function testServerDiscoverWithModernMetaOverStdio(): void
+    {
+        // Modern (2026-07-28) form: params._meta is required on every request,
+        // including server/discover — exercise both eras of the probe
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+
+        $result = $responses[0]['result'];
+        $this->assertContains('2026-07-28', $result['supportedVersions']);
+        $this->assertSame('complete', $result['resultType']);
+    }
+
+    public function testNotificationWithInvalidParamsGetsNoResponse(): void
+    {
+        // JSON-RPC 2.0 §4.1: notifications must not be answered, even with
+        // an error — the following request must still get its response
+        [$stdout] = $this->runServerProcess(
+            '{"jsonrpc":"2.0","method":"notifications/initialized","params":"oops"}' . "\n"
+            . '{"jsonrpc":"2.0","id":9,"method":"tools/list"}' . "\n",
+            ['MCP_DEBUG' => ''],
+        );
+
+        $responses = $this->decodeResponses($stdout);
+        $this->assertCount(1, $responses);
+        $this->assertSame(9, $responses[0]['id']);
+        $this->assertCount(6, $responses[0]['result']['tools']);
     }
 
     public function testModernMetaMissingRequiredFieldsOverStdio(): void
@@ -337,8 +374,13 @@ class McpServerIntegrationTest extends TestCase
         $binary = dirname(__DIR__, 2) . '/bin/xdebug-mcp';
 
         // $_ENV is often nearly empty under PHPUnit (variables_order=GPCS);
-        // forward the real environment so tool calls can locate php and Xdebug
-        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge(getenv(), $env));
+        // forward the real environment so tool calls can locate php and
+        // Xdebug — but strip inherited Xdebug settings, which take precedence
+        // over the tools' own on-demand Xdebug configuration and break them
+        $forward = getenv();
+        unset($forward['XDEBUG_MODE'], $forward['XDEBUG_CONFIG'], $forward['XDEBUG_TRIGGER']);
+
+        $process = proc_open(['php', $binary], $descriptorSpec, $pipes, null, array_merge($forward, $env));
 
         $this->assertIsResource($process);
 

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -8,6 +8,7 @@ use Koriym\XdebugMcp\DTO\GenericResult;
 use Koriym\XdebugMcp\DTO\JsonRpcResponse;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use Koriym\XdebugMcp\McpServer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Throwable;
@@ -345,23 +346,32 @@ class McpServerTest extends TestCase
         $this->assertEquals('2025-11-25', $response['result']['protocolVersion']);
     }
 
-    public function testInitializeNeverReturnsStatelessVersion(): void
+    /** @param array<string, string> $params */
+    #[DataProvider('provideInitializeVersionsFallingBackToLegacy')]
+    public function testInitializeNeverReturnsStatelessVersion(array $params): void
     {
         // 2026-07-28 has no initialize handshake, so an initialize result
         // must not name it — fall back to the latest legacy revision
-        foreach ([['protocolVersion' => '2026-07-28'], []] as $index => $params) {
-            $request = [
-                'jsonrpc' => '2.0',
-                'id' => 90 + $index,
-                'method' => 'initialize',
-                'params' => $params,
-            ];
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 90,
+            'method' => 'initialize',
+            'params' => $params,
+        ];
 
-            $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
-            $response = $responseObj->toArray();
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
 
-            $this->assertEquals('2025-11-25', $response['result']['protocolVersion']);
-        }
+        $this->assertEquals('2025-11-25', $response['result']['protocolVersion']);
+    }
+
+    /** @return array<string, array{0: array<string, string>}> */
+    public static function provideInitializeVersionsFallingBackToLegacy(): array
+    {
+        return [
+            'stateless version requested' => [['protocolVersion' => '2026-07-28']],
+            'version omitted' => [[]],
+        ];
     }
 
     public function testNonArrayParamsReturnsInvalidParams(): void
@@ -516,22 +526,31 @@ class McpServerTest extends TestCase
         $this->assertArrayHasKey('tools', $response['result']);
     }
 
-    public function testListResultsContainCacheableFields(): void
+    #[DataProvider('provideListMethods')]
+    public function testListResultsContainCacheableFields(string $method): void
     {
-        foreach (['tools/list', 'prompts/list', 'resources/list'] as $index => $method) {
-            $request = [
-                'jsonrpc' => '2.0',
-                'id' => 30 + $index,
-                'method' => $method,
-            ];
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 30,
+            'method' => $method,
+        ];
 
-            $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
-            $response = $responseObj->toArray();
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
 
-            $this->assertArrayHasKey('ttlMs', $response['result'], $method);
-            $this->assertArrayHasKey('cacheScope', $response['result'], $method);
-            $this->assertSame('complete', $response['result']['resultType'], $method);
-        }
+        $this->assertArrayHasKey('ttlMs', $response['result'], $method);
+        $this->assertArrayHasKey('cacheScope', $response['result'], $method);
+        $this->assertSame('complete', $response['result']['resultType'], $method);
+    }
+
+    /** @return array<string, array{0: string}> */
+    public static function provideListMethods(): array
+    {
+        return [
+            'tools/list' => ['tools/list'],
+            'prompts/list' => ['prompts/list'],
+            'resources/list' => ['resources/list'],
+        ];
     }
 
     public function testValidatePhpBinaryScript(): void

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -342,7 +342,138 @@ class McpServerTest extends TestCase
 
         $this->assertArrayHasKey('result', $response);
         // Should default to latest supported version
-        $this->assertEquals('2025-06-18', $response['result']['protocolVersion']);
+        $this->assertEquals('2026-07-28', $response['result']['protocolVersion']);
+    }
+
+    public function testServerDiscover(): void
+    {
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 20,
+            'method' => 'server/discover',
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('supportedVersions', $response['result']);
+        $this->assertContains('2026-07-28', $response['result']['supportedVersions']);
+        $this->assertContains('2024-11-05', $response['result']['supportedVersions']);
+        $this->assertArrayHasKey('capabilities', $response['result']);
+        $this->assertArrayHasKey('tools', $response['result']['capabilities']);
+        $this->assertArrayHasKey('instructions', $response['result']);
+        $this->assertSame('complete', $response['result']['resultType']);
+        $this->assertSame(
+            'xdebug-mcp-server',
+            $response['result']['_meta']['io.modelcontextprotocol/serverInfo']['name'],
+        );
+    }
+
+    public function testStatelessRequestWithoutInitialize(): void
+    {
+        // MCP 2026-07-28: no handshake; every request carries its protocol
+        // version and capabilities in _meta
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 21,
+            'method' => 'tools/list',
+            'params' => [
+                '_meta' => [
+                    'io.modelcontextprotocol/protocolVersion' => '2026-07-28',
+                    'io.modelcontextprotocol/clientCapabilities' => [],
+                    'io.modelcontextprotocol/clientInfo' => ['name' => 'modern-client', 'version' => '1.0.0'],
+                ],
+            ],
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('tools', $response['result']);
+        $this->assertSame('complete', $response['result']['resultType']);
+        $this->assertSame(
+            'xdebug-mcp-server',
+            $response['result']['_meta']['io.modelcontextprotocol/serverInfo']['name'],
+        );
+    }
+
+    public function testUnsupportedProtocolVersionMetaReturnsError(): void
+    {
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 22,
+            'method' => 'tools/list',
+            'params' => [
+                '_meta' => [
+                    'io.modelcontextprotocol/protocolVersion' => '1999-01-01',
+                    'io.modelcontextprotocol/clientCapabilities' => [],
+                ],
+            ],
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals(-32022, $response['error']['code']);
+        $this->assertStringContainsString('Unsupported protocol version', $response['error']['message']);
+        $this->assertContains('2026-07-28', $response['error']['data']['supportedVersions']);
+    }
+
+    public function testModernMetaMissingRequiredFieldsReturnsInvalidParams(): void
+    {
+        // _meta has io.modelcontextprotocol/* keys but lacks clientCapabilities
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 23,
+            'method' => 'tools/list',
+            'params' => [
+                '_meta' => ['io.modelcontextprotocol/protocolVersion' => '2026-07-28'],
+            ],
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals(-32602, $response['error']['code']);
+    }
+
+    public function testLegacyRequestWithoutMetaIsNotRejected(): void
+    {
+        // Dual-era: requests without modern _meta (legacy clients) pass through
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 24,
+            'method' => 'tools/list',
+            'params' => ['_meta' => ['progressToken' => 'abc']],
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('tools', $response['result']);
+    }
+
+    public function testListResultsContainCacheableFields(): void
+    {
+        foreach (['tools/list', 'prompts/list', 'resources/list'] as $index => $method) {
+            $request = [
+                'jsonrpc' => '2.0',
+                'id' => 30 + $index,
+                'method' => $method,
+            ];
+
+            $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+            $response = $responseObj->toArray();
+
+            $this->assertArrayHasKey('ttlMs', $response['result'], $method);
+            $this->assertArrayHasKey('cacheScope', $response['result'], $method);
+            $this->assertSame('complete', $response['result']['resultType'], $method);
+        }
     }
 
     public function testValidatePhpBinaryScript(): void

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -476,7 +476,8 @@ class McpServerTest extends TestCase
         $this->assertArrayHasKey('error', $response);
         $this->assertEquals(-32022, $response['error']['code']);
         $this->assertStringContainsString('Unsupported protocol version', $response['error']['message']);
-        $this->assertContains('2026-07-28', $response['error']['data']['supportedVersions']);
+        $this->assertContains('2026-07-28', $response['error']['data']['supported']);
+        $this->assertSame('1999-01-01', $response['error']['data']['requested']);
     }
 
     public function testModernMetaMissingRequiredFieldsReturnsInvalidParams(): void

--- a/tests/Unit/McpServerTest.php
+++ b/tests/Unit/McpServerTest.php
@@ -341,8 +341,65 @@ class McpServerTest extends TestCase
         $response = $responseObj->toArray();
 
         $this->assertArrayHasKey('result', $response);
-        // Should default to latest supported version
-        $this->assertEquals('2026-07-28', $response['result']['protocolVersion']);
+        // Should default to the latest legacy (handshake-era) version
+        $this->assertEquals('2025-11-25', $response['result']['protocolVersion']);
+    }
+
+    public function testInitializeNeverReturnsStatelessVersion(): void
+    {
+        // 2026-07-28 has no initialize handshake, so an initialize result
+        // must not name it — fall back to the latest legacy revision
+        foreach ([['protocolVersion' => '2026-07-28'], []] as $index => $params) {
+            $request = [
+                'jsonrpc' => '2.0',
+                'id' => 90 + $index,
+                'method' => 'initialize',
+                'params' => $params,
+            ];
+
+            $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+            $response = $responseObj->toArray();
+
+            $this->assertEquals('2025-11-25', $response['result']['protocolVersion']);
+        }
+    }
+
+    public function testNonArrayParamsReturnsInvalidParams(): void
+    {
+        // Regression: scalar params must yield -32602, not an internal error
+        // leaking method signatures/file paths
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 95,
+            'method' => 'tools/list',
+            'params' => 'oops',
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('error', $response);
+        $this->assertEquals(-32602, $response['error']['code']);
+        $this->assertStringNotContainsString('McpServer', $response['error']['message']);
+    }
+
+    public function testPrefixedNonVersionMetaKeyPassesAsLegacy(): void
+    {
+        // io.modelcontextprotocol/ is a reserved prefix for the whole spec
+        // (logLevel, subscriptionId, ...); only protocolVersion marks a
+        // stateless request. Other reserved keys alone must not be rejected.
+        $request = [
+            'jsonrpc' => '2.0',
+            'id' => 96,
+            'method' => 'tools/list',
+            'params' => ['_meta' => ['io.modelcontextprotocol/logLevel' => 'debug']],
+        ];
+
+        $responseObj = $this->invokePrivateMethod($this->server, 'handleRequest', [$request]);
+        $response = $responseObj->toArray();
+
+        $this->assertArrayHasKey('result', $response);
+        $this->assertArrayHasKey('tools', $response['result']);
     }
 
     public function testServerDiscover(): void


### PR DESCRIPTION
## Intent

Support the latest MCP specification revision [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog), which makes the protocol fully stateless: no `initialize` handshake, per-request protocol metadata, and a mandatory `server/discover` RPC.

## Approach

Dual-era server: modern stateless requests and legacy handshake clients are served by the same stdio process.

- `server/discover` RPC: advertises supported protocol versions, capabilities, identity, and instructions (also the stdio backward-compatibility probe for dual-era clients)
- Per-request validation of `_meta` protocol fields (`io.modelcontextprotocol/protocolVersion`, `clientCapabilities`): missing fields → `-32602`, unsupported version → `-32022` with `data.supportedVersions`. Requests without modern `_meta` keys pass through as legacy
- Every result now carries `resultType: "complete"` and server identity in `_meta["io.modelcontextprotocol/serverInfo"]` (ignored by legacy clients)
- `ttlMs`/`cacheScope` cache hints on `tools/list`, `prompts/list`, `resources/list`, and `server/discover` (CacheableResult)
- Supported versions extended to `2024-11-05` … `2026-07-28`; legacy `initialize` negotiation stays within legacy revisions and falls back to `2025-11-25` — an initialize result never names the stateless `2026-07-28` (which has no handshake)
- Requests with non-object `params` are rejected with `-32602` instead of an internal error leaking method signatures
- Result DTOs introduced for the fixed protocol shapes (`InitializeResult`, `DiscoverResult`, `ResourcesListResult`, `PromptsListResult`, `ToolCallResult`, `PromptExecutionResult`), replacing loose `GenericResult` arrays; the previously unreadable deeply-nested array shapes are centralized as PHPStan domain types in `src/DTO/Types.php` (`@phpstan-type JsonObject`, `ErrorData`, …)
- README: recommends the Skill integration over the MCP server for AI coding agents (comparison table + when MCP is the right choice), and fixes the outdated tool list (MCP exposes all one-shot tools including `xcompare`)

### Conscious decisions (from review)

- `resultType`/`_meta` are injected unconditionally in `JsonRpcResponse`, including legacy-era results. Verified against the 2026-07-28 `schema.ts`: `resultType` is a required `Result` field for this revision, absent-is-`complete` is mandated for older clients, and `serverInfo` in `_meta` is a SHOULD on every result — unconditional injection is the spec-recommended behavior, not just a tolerated extra. `_meta` itself is allowed on any result in every revision.
- Stateless detection keys only on the presence of `io.modelcontextprotocol/protocolVersion` in `_meta`. Other keys under the reserved prefix (`logLevel`, `subscriptionId`, …) may appear on their own and are not treated as stateless markers.
- The `-32022` error data follows the 2026-07-28 `UnsupportedProtocolVersionError` schema exactly: `data: {supported: string[], requested: string}`.
- Notifications (requests without an `id`) are never answered, per JSON-RPC 2.0 §4.1 — including malformed ones.

## Verification

Covered by reusable tests that spawn the real `bin/xdebug-mcp` process (run in CI via `composer test`):

- Stateless workflow: `server/discover` → `tools/list` → `tools/call` with no handshake
- `-32022` / `-32602` error paths, non-protocol `_meta` (e.g. `progressToken`) passing as legacy
- Legacy `initialize` + `notifications/initialized` workflow unchanged

Also fixed along the way: the integration test process spawner now forwards the real environment (minus inherited `XDEBUG_MODE`/`XDEBUG_CONFIG`/`XDEBUG_TRIGGER`, which would hijack the tools' own Xdebug configuration) so MCP tool calls work under PHPUnit's minimal `$_ENV`. Tool execution paths that run in-process (e.g. `handleRequest` invoked directly in tests, or plain CLI use with `XDEBUG_MODE` exported) still inherit the variable — that is a pre-existing product bug, tracked separately in #94.

## Test output

- `composer test`: 385 tests, 1035 assertions, OK (7 skipped, pre-existing)
- `composer sa` (PHPStan level 10): no errors
- `composer cs`: clean

## Risk

Low. All changes are additive; legacy clients (Claude Code/Desktop etc. on 2025-11-25 and earlier) follow the exact same code path as before. No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stateless MCP request support, allowing compatible requests without initialization.
  - Added server discovery with protocol versions, capabilities, instructions, and cache information.
  - Added cache metadata to tool, resource, and prompt listings.
  - Added the `xcompare` tool to MCP guidance and availability documentation.

- **Bug Fixes**
  - Improved handling of invalid parameters and malformed protocol metadata.
  - Corrected error details and notification behavior.
  - Preserved compatibility with legacy MCP protocol negotiation.

- **Documentation**
  - Clarified when to use Skill integrations versus MCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->