### PR TITLE
Fix xback output shape and PHP binary detection in xstep/xback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `xstep`/`xrepl` accept an absolute PHP binary after `--` as the README documents (e.g. `-- /opt/homebrew/opt/php@7.2/bin/php app.php`); `xback` accepts one without `--php`.
+- `xback` emits the documented `xback.json` document (`stack` frames with `level`, `--depth` applied) instead of the `xstep.json` one.
+- README and skill docs: xtrace, xprofile, and xcoverage need `--json` for JSON output; the xrepl `l` command shows the current location, not source code.
+
 ## [0.13.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- `xstep`/`xrepl` accept an absolute PHP binary after `--` as the README documents (e.g. `-- /opt/homebrew/opt/php@7.2/bin/php app.php`); `xback` accepts one without `--php`.
+- `xstep`/`xrepl` accept an absolute PHP binary after `--` as the README documents; `xback` accepts one without `--php`.
 - `xback` emits the documented `xback.json` document (`stack` frames with `level`, `--depth` applied) instead of the `xstep.json` one.
 - README and skill docs: xtrace, xprofile, and xcoverage need `--json` for JSON output; the xrepl `l` command shows the current location, not source code.
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ Run the demo examples to see each tool in action:
 ./bin/xstep --break="demo/buggy.php:22" -- php demo/buggy.php
 
 # Trace execution flow
-./bin/xtrace --context="Debug demo" -- php demo/buggy.php
+./bin/xtrace --json --context="Debug demo" -- php demo/buggy.php
 
 # Profile performance bottlenecks
 ./bin/xprofile --json -- php demo/slow.php
 
 # Analyze code coverage (raw mode for plain PHP scripts)
-./bin/xcoverage --raw -- php demo/coverage.php
+./bin/xcoverage --json --raw -- php demo/coverage.php
 
 # Get stack trace at breakpoint
 ./bin/xback --break="demo/buggy.php:44" -- php demo/buggy.php
@@ -127,7 +127,7 @@ Run the demo examples to see each tool in action:
 ./bin/xcompare --break="src/calc.php:25" --run="php src/calc.php 10" --compare-with=main
 ```
 
-Each command outputs structured JSON data that AI can analyze to provide debugging insights.
+Each command outputs structured JSON that AI can analyze to provide debugging insights. xtrace, xprofile, and xcoverage print text unless `--json` is given; the other tools print JSON by default.
 
 ## How It Works
 
@@ -194,15 +194,15 @@ Run `--help` on any tool for detailed options.
 
 ## Schema-Backed JSON Output
 
-Every tool emits JSON with a `$schema` URL, so the output is machine-verifiable and self-describing — no log-string parsing needed:
+Every tool emits JSON with a schema URL (`$schema`, or `schema` for xtrace and xprofile), so the output is machine-verifiable and self-describing — no log-string parsing needed. xstep, xback, and xcompare print JSON by default; xtrace, xprofile, and xcoverage with `--json`:
 
 ```json
 {
   "$schema": "https://koriym.github.io/xdebug-mcp/schemas/xstep.json",
   "breaks": [
     {
-      "location": {"file": "demo/buggy.php", "line": 22},
-      "variables": {"$user": "NULL", "$id": "42"}
+      "stack": [{"function": "calculateSum", "file": "buggy.php", "line": 22}],
+      "variables": {"$a": "int: 10", "$b": "int: 5"}
     }
   ],
   "trace": { "...": "..." }
@@ -250,7 +250,7 @@ xrepl --break="script.php:42" -- php script.php
 | `c` | Continue execution |
 | `p <var>` | Print variable (e.g., `p $user`) |
 | `bt` | Show backtrace |
-| `l` | List source code |
+| `l` | Show current location (stack and variables) |
 | `q` | Quit debugger |
 
 ## Docker Support

--- a/bin/xback
+++ b/bin/xback
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 use Koriym\XdebugMcp\DebugServer;
 use Koriym\XdebugMcp\Constants;
+use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 
 /**
  * Display help information
@@ -20,7 +21,7 @@ function showHelp(): void
     echo "  --depth=N         Maximum stack depth to return (default: 10)\n";
     echo "  --context=TEXT    Context description for AI analysis\n";
     echo "  --cwd=PATH        Run from PATH (target project root)\n";
-    echo "  --php=PATH        Use this PHP binary instead of the default 'php'\n";
+    echo "  --php=PATH        Run the command with this PHP binary\n";
     echo "  --help, -h        Show this help\n";
     echo "\n";
     echo "OUTPUT: Structured JSON (schema: xback.json)\n";
@@ -86,16 +87,23 @@ function parseBreakpoint(string $breakSpec, bool $isDockerCommand = false): ?arr
 
 /**
  * Output structured backtrace JSON
+ *
+ * @param list<array{function: string, file: string, line: int}> $frames Innermost first, as recorded by DebugServer
  */
-function outputBacktraceJson(string $script, ?string $breakpointStr, string $context, int $depth, array $stack): void
+function outputBacktraceJson(string $script, ?string $breakpointStr, string $context, int $depth, array $frames): void
 {
+    $stack = [];
+    foreach (array_slice($frames, 0, $depth) as $level => $frame) {
+        $stack[] = ['level' => $level] + $frame;
+    }
+
     $result = [
         '$schema' => 'https://koriym.github.io/xdebug-mcp/schemas/xback.json',
         'script' => $script,
         'breakpoint' => $breakpointStr,
         'context' => $context,
         'depth' => $depth,
-        'stack' => array_slice($stack, 0, $depth),
+        'stack' => $stack,
         'timestamp' => date('c'),
     ];
 
@@ -187,10 +195,6 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
     // Detect Docker/Podman/Kubectl commands
     $isDockerCommand = \Koriym\XdebugMcp\ContainerHelper::isContainerCommand($command);
 
-    // Decide whether the --php override should apply to the local command.
-    // Keep $command[0] as the literal 'php' so DebugServer's strict-equality
-    // check still selects the local-PHP execution branch; the actual override
-    // path is plumbed through DebugServer's `phpBinary` option below.
     $applyPhpOverride = (
         !$isDockerCommand
         && $phpOverride !== null
@@ -223,8 +227,12 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
         } else {
             throw new RuntimeException("Could not find PHP command in Docker command: " . implode(' ', $command));
         }
-    } elseif ($command[0] === 'php' && isset($command[1])) {
-        $targetScript = $command[1];
+    } elseif (PhpCommandParser::isPhpBinary($command[0])) {
+        $scriptIndex = PhpCommandParser::findScriptIndex($command, 0);
+        if ($scriptIndex === false) {
+            throw new RuntimeException("Could not determine target script from command: " . implode(' ', $command));
+        }
+        $targetScript = $command[$scriptIndex];
         if (!file_exists($targetScript)) {
             throw new RuntimeException("Target script not found: $targetScript");
         }
@@ -247,51 +255,15 @@ function outputBacktraceJson(string $script, ?string $breakpointStr, string $con
         'jsonOutput' => true,
         'context' => $context,
         'maxSteps' => 1,
+        'onResult' => static function (array $result) use ($targetScript, $breakpointStr, $context, $depth): void {
+            outputBacktraceJson($targetScript, $breakpointStr, $context, $depth, $result['breaks'][0]['stack'] ?? []);
+        },
     ];
 
     if ($applyPhpOverride) {
         $options['phpBinary'] = $phpOverride;
     }
 
-    // Capture DebugServer output
-    ob_start();
     $server = new DebugServer($targetScript, Constants::XDEBUG_DEBUG_PORT, null, $options, true);
     $server();
-    $output = ob_get_clean();
-
-    // Parse DebugServer output and reformat to backtrace schema
-    $debugData = json_decode($output, true);
-
-    $stack = [];
-    if (isset($debugData['breaks'][0]['stack'])) {
-        // If DebugServer provides stack info
-        foreach ($debugData['breaks'][0]['stack'] as $level => $frameStr) {
-            if (preg_match('/^(.+) at (.+):(\d+)$/', $frameStr, $m)) {
-                $stack[] = [
-                    'level' => $level,
-                    'function' => $m[1],
-                    'file' => $m[2],
-                    'line' => (int)$m[3],
-                ];
-            }
-        }
-    } elseif (isset($debugData['breaks'][0]['location'])) {
-        // Fallback: use location from breaks
-        $loc = $debugData['breaks'][0]['location'];
-        $stack[] = [
-            'level' => 0,
-            'function' => '{main}',
-            'file' => $loc['file'] ?? $targetScript,
-            'line' => $loc['line'] ?? 1,
-        ];
-    }
-
-    // Output in backtrace schema format
-    outputBacktraceJson(
-        $targetScript,
-        $breakpointStr,
-        $context,
-        $depth,
-        $stack
-    );
 })();

--- a/bin/xstep
+++ b/bin/xstep
@@ -6,6 +6,7 @@ declare(strict_types=1);
 use Koriym\XdebugMcp\DebugServer;
 use Koriym\XdebugMcp\Constants;
 use Koriym\XdebugMcp\Exceptions\InvalidLineException;
+use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 
 /**
  * Exception for invalid breakpoint format
@@ -90,7 +91,7 @@ function showHelp(string $commandName = 'xstep'): void
         echo "  c        Continue execution\n";
         echo "  p <var>  Print variable (e.g., p \$user)\n";
         echo "  bt       Show backtrace\n";
-        echo "  l        List source code\n";
+        echo "  l        Show current location (stack and variables)\n";
         echo "  q        Quit debugger\n";
         echo "\n";
     } else {
@@ -387,7 +388,7 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
     // Handle legacy format: script.php [breakpoint_file] [break_line]
     // Skip when --break= is used so positional args don't leak into $targetScript
     // (e.g. `-- php main.php` with a `php/` directory in CWD would match file_exists).
-    if (empty($breakpoints) && count($command) >= 1 && !str_contains($command[0], ' ') && file_exists($command[0])) {
+    if (empty($breakpoints) && count($command) >= 1 && !str_contains($command[0], ' ') && !PhpCommandParser::isPhpBinary($command[0]) && file_exists($command[0])) {
         $targetScript = $command[0];
         if (!isset($breakpointFile) && isset($command[1])) {
             $breakpointFile = $command[1];
@@ -415,12 +416,11 @@ function parseBreakpoints(string $breakSpec, bool $isDockerCommand = false): arr
             throw new RuntimeException("Could not find PHP command in Docker command: " . implode(' ', $command));
         }
     } else {
-        // New format: complex command after --
-        if ($command[0] === 'php' && isset($command[1])) {
-            $targetScript = $command[1];
-        } else {
+        $scriptIndex = PhpCommandParser::isPhpBinary($command[0]) ? PhpCommandParser::findScriptIndex($command, 0) : false;
+        if ($scriptIndex === false) {
             throw new RuntimeException("Could not determine target script from command: " . implode(' ', $command));
         }
+        $targetScript = $command[$scriptIndex];
     }
 
     // Validate target script (skip for Docker where script is in container)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -145,7 +145,7 @@ Commands:
 - `c` - Continue execution
 - `p <var>` - Print variable (e.g., `p $user`)
 - `bt` - Show backtrace
-- `l` - List source code
+- `l` - Show current location (stack and variables)
 - `q` - Quit debugger
 
 ### Docker Support

--- a/skills/xdebug/SKILL.md
+++ b/skills/xdebug/SKILL.md
@@ -47,7 +47,7 @@ The word "trace" can mean different things:
 
 Trace execution forward from start to finish. Captures complete execution flow, function calls, parameters, and timing data.
 
-**Output**: JSON with `$schema` URL for semantic details and AI analysis strategies.
+**Output**: Text by default; `--json` gives JSON with a `schema` URL for semantic details and AI analysis strategies.
 **Key fields**: `{lines, functions, max_depth, db_queries}`
 
 ```bash
@@ -121,7 +121,7 @@ Stop at breakpoint, step forward N times, record variable changes at each step. 
 
 Identify performance bottlenecks with precision data.
 
-**Output**: JSON with a `schema` URL. `time_ms`/`memory_mb` are measured from the cachegrind summary; `bottlenecks` is a structured array. Read the linked schema for the field shapes — don't infer the format here.
+**Output**: Text by default; `--json` gives JSON with a `schema` URL. `time_ms`/`memory_mb` are measured from the cachegrind summary; `bottlenecks` is a structured array. Read the linked schema for the field shapes — don't infer the format here.
 **Key fields**: `{time_ms, memory_mb, bottlenecks}`
 
 ```bash
@@ -149,11 +149,11 @@ Identify performance bottlenecks with precision data.
 
 Collect code coverage data for PHPUnit or any PHP script. Shows only uncovered lines (compact output).
 
-**Output**: JSON with `$schema` URL for semantic details.
+**Output**: Text by default; `--json` gives JSON with a `$schema` URL for semantic details.
 **Key fields**: `{summary: {coverage_percent, covered_lines, uncovered_lines}, uncovered: {file: [lines]}}`
 
 ```bash
-~/.composer/vendor/bin/xcoverage [--include-vendor=PATTERNS] -- command
+~/.composer/vendor/bin/xcoverage [--json] [--include-vendor=PATTERNS] -- command
 ~/.composer/vendor/bin/xcoverage -- vendor/bin/phpunit        # PHPUnit
 ~/.composer/vendor/bin/xcoverage -- php script.php            # Any PHP script
 ```
@@ -179,7 +179,7 @@ Collect code coverage data for PHPUnit or any PHP script. Shows only uncovered l
 Get call stack (backtrace) at a specific line. Shows "who called this?" - the chain of function calls that led to this point.
 
 **Output**: JSON with `$schema` URL for semantic details.
-**Key fields**: `{backtrace: [{file, line, function, args}]}`
+**Key fields**: `{script, breakpoint, stack: [{level, function, file, line}]}`
 
 ```bash
 ~/.composer/vendor/bin/xback [--break=SPEC] [--depth=N] [--context=TEXT] -- command
@@ -267,7 +267,7 @@ Human-friendly interactive debugging session with breakpoints and variable inspe
 - `c` - Continue execution
 - `p <var>` - Print variable (e.g., `p $user`)
 - `bt` - Show backtrace
-- `l` - List source code
+- `l` - Show current location (stack and variables)
 - `q` - Quit debugger
 
 ### Examples

--- a/src/DebugServer.php
+++ b/src/DebugServer.php
@@ -23,6 +23,7 @@ use Koriym\XdebugMcp\Exceptions\BreakpointException;
 use Koriym\XdebugMcp\Exceptions\DebugSessionException;
 use Koriym\XdebugMcp\Exceptions\InvalidArgumentException;
 use Koriym\XdebugMcp\Utilities\PathNormalizer;
+use Koriym\XdebugMcp\Utilities\PhpCommandParser;
 use Koriym\XdebugMcp\Utilities\XdebugEnv;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -185,7 +186,7 @@ final class DebugServer
     /** @var array{id: string, label: string, file: string, line: int, condition?: string}|null */
     private array|null $activeBreakpoint = null;
 
-    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null, phpBinary?: string, includeVendor?: string|null} $options */
+    /** @param array{command?: list<string>, context?: string, breakpoint?: string, steps?: int, connectionTimeout?: float, executionTimeout?: float, traceOnly?: bool, maxSteps?: int, jsonOutput?: bool, breakpoints?: list<array{file: string, line: int|string, condition?: string}>, readTimeout?: float, watches?: list<string>, pretty?: bool, maxValueBytes?: int|null, maxDepth?: int|null, phpBinary?: string, includeVendor?: string|null, onResult?: callable(XstepJsonOutput): void} $options */
     public function __construct(
         private readonly string $targetScript,
         private readonly int $debugPort,
@@ -418,7 +419,7 @@ final class DebugServer
 
                     $cmd = implode(' ', $command);
                     $this->traceFile = $traceFile;
-                } elseif ($command[0] === 'php') {
+                } elseif (PhpCommandParser::isPhpBinary($command[0])) {
                     // Local PHP command
                     XdebugEnv::noticeIfInherited('debug,trace');
 
@@ -430,11 +431,9 @@ final class DebugServer
                     $xdebugFlag = XdebugFinder::getXdebugFlag();
                     $xdebugPart = $xdebugFlag !== '' ? $xdebugFlag . ' ' : '';
 
-                    // Allow callers (e.g. xback --php=...) to override the spawned
-                    // PHP binary while keeping $command[0] as the literal 'php'.
                     $phpBinary = ($this->options['phpBinary'] ?? '') !== ''
                         ? (string) $this->options['phpBinary']
-                        : 'php';
+                        : $command[0];
                     $includeVendorEnv = ($this->options['includeVendor'] ?? null) !== null
                         ? 'XDEBUG_MCP_INCLUDE_VENDOR=' . escapeshellarg((string) $this->options['includeVendor']) . ' '
                         : '';
@@ -466,7 +465,7 @@ final class DebugServer
                     );
                     $this->traceFile = $traceFile;
                 } else {
-                    throw new RuntimeException("Custom command must start with 'php' or be a Docker/Podman/Kubectl command");
+                    throw new RuntimeException('Custom command must start with a PHP binary or be a Docker/Podman/Kubectl command');
                 }
             } else {
                 // Default: simple script execution
@@ -2768,6 +2767,25 @@ final class DebugServer
     }
 
     /**
+     * An `onResult` sink receives the document instead of stdout. The process
+     * exits right after the document is produced, so this is the only way for
+     * an embedding script (bin/xback) to reshape it.
+     *
+     * @param XstepJsonOutput $result
+     */
+    private function emitResult(array $result): void
+    {
+        $sink = $this->options['onResult'] ?? null;
+        if ($sink !== null) {
+            $sink($result);
+
+            return;
+        }
+
+        echo $this->encodeJsonOutput($result) . "\n";
+    }
+
+    /**
      * Add the actually-bound debug port to the JSON result, so a caller only
      * seeing --json output can still tell which port Xdebug is listening on.
      *
@@ -2890,9 +2908,7 @@ final class DebugServer
             ];
         }
 
-        $result = $this->addPortInfoToResult($result);
-
-        echo $this->encodeJsonOutput($result) . "\n";
+        $this->emitResult($this->addPortInfoToResult($result));
     }
 
     /**
@@ -3751,9 +3767,7 @@ final class DebugServer
 
         // Output format based on jsonMode or jsonOutput option
         if ($this->jsonMode || ($this->options['jsonOutput'] ?? false)) {
-            $debugState = $this->addPortInfoToResult($debugState);
-
-            echo $this->encodeJsonOutput($debugState) . "\n";
+            $this->emitResult($this->addPortInfoToResult($debugState));
 
             // Mark step-recording output as done only after JSON was successfully
             // emitted so the cleanup phase can still fall back to its own output

--- a/src/McpServer.php
+++ b/src/McpServer.php
@@ -245,7 +245,7 @@ final class McpServer
             ),
             'xback' => new McpTool(
                 'xback',
-                'Capture call stack (backtrace) at specific line. Returns JSON with $schema URL for semantic details. Key fields: {backtrace: [{file, line, function, args}]}.',
+                'Capture call stack (backtrace) at specific line. Returns JSON with $schema URL for semantic details. Key fields: {script, breakpoint, stack: [{level, function, file, line}]}.',
                 [
                     'type' => 'object',
                     'properties' => [
@@ -676,7 +676,7 @@ final class McpServer
                 ],
                 [
                     'name' => 'xback',
-                    'description' => 'Capture call stack (backtrace) at specific line. Returns JSON with $schema URL for semantic details. Key fields: {backtrace: [{file, line, function, args}]}.',
+                    'description' => 'Capture call stack (backtrace) at specific line. Returns JSON with $schema URL for semantic details. Key fields: {script, breakpoint, stack: [{level, function, file, line}]}.',
                     'arguments' => [
                         [
                             'name' => 'script',

--- a/tests/Integration/XdebugCommandsTest.php
+++ b/tests/Integration/XdebugCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\XdebugMcp\Tests\Integration;
 
+use JsonSchema\Validator;
 use Koriym\XdebugMcp\XdebugFinder;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,7 @@ use function dirname;
 use function escapeshellarg;
 use function explode;
 use function file_exists;
+use function file_get_contents;
 use function file_put_contents;
 use function getenv;
 use function is_dir;
@@ -480,6 +482,33 @@ PHP);
         $this->assertStringContainsString('--max-depth=N', $output);
     }
 
+    public function testXstepAcceptsAbsolutePhpBinaryPath(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $fixture = dirname(__DIR__) . '/fixtures/debug_test.php';
+        $command = sprintf(
+            'cd %s && ./bin/xstep --break=%s -- %s %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($fixture . ':27'),
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($fixture),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+        $this->assertStringNotContainsString('Could not determine target script', $output);
+
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+
+        $payload = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('https://koriym.github.io/xdebug-mcp/schemas/xstep.json', $payload['$schema']);
+        $this->assertSame(27, $payload['breaks'][0]['stack'][0]['line']);
+    }
+
     public function testXbackCommandExists(): void
     {
         $this->assertTrue(file_exists(__DIR__ . '/../../bin/xback'));
@@ -572,10 +601,6 @@ PHP);
 
         $fixture = dirname(__DIR__) . '/fixtures/print_cwd.php';
 
-        // Run with --php pointing at an absolute PHP binary path. Without the
-        // fix this fails with "Custom command must start with 'php' or be a
-        // Docker/Podman/Kubectl command" because $command[0] becomes the
-        // absolute path and DebugServer's strict-equality check rejects it.
         $command = sprintf(
             'cd %s && ./bin/xback --php=%s -- php %s 2>&1',
             escapeshellarg(dirname(__DIR__, 2)),
@@ -586,7 +611,7 @@ PHP);
         $output = shell_exec($command);
         $this->assertNotNull($output);
         $this->assertStringNotContainsString(
-            "must start with 'php'",
+            'must start with a PHP binary',
             $output,
             '--php override should not fall through to the DebugServer error path',
         );
@@ -597,6 +622,42 @@ PHP);
         $payload = json_decode(substr($output, $jsonStart), true, 512, JSON_THROW_ON_ERROR);
         $this->assertIsArray($payload);
         $this->assertArrayHasKey('$schema', $payload);
+    }
+
+    public function testXbackOutputsBacktraceSchema(): void
+    {
+        if (! XdebugFinder::isXdebugAvailable()) {
+            $this->markTestSkipped('Xdebug not available');
+        }
+
+        $fixture = dirname(__DIR__) . '/fixtures/debug_test.php';
+        $command = sprintf(
+            'cd %s && ./bin/xback --break=%s --depth=2 -- php %s 2>&1',
+            escapeshellarg(dirname(__DIR__, 2)),
+            escapeshellarg($fixture . ':18'),
+            escapeshellarg($fixture),
+        );
+
+        $output = shell_exec($command);
+        $this->assertNotNull($output);
+
+        $jsonStart = strrpos($output, '{"$schema"');
+        $this->assertNotFalse($jsonStart, $output);
+        $json = substr($output, $jsonStart);
+
+        $schema = json_decode((string) file_get_contents(dirname(__DIR__, 2) . '/docs/schemas/xback.json'), false, 512, JSON_THROW_ON_ERROR);
+        $document = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        $validator = new Validator();
+        $validator->validate($document, $schema);
+        $this->assertTrue($validator->isValid(), var_export($validator->getErrors(), true));
+
+        $payload = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('https://koriym.github.io/xdebug-mcp/schemas/xback.json', $payload['$schema']);
+        $this->assertSame($fixture, $payload['script']);
+        $this->assertSame([
+            ['level' => 0, 'function' => 'calculate_sum', 'file' => 'debug_test.php', 'line' => 18],
+            ['level' => 1, 'function' => 'main', 'file' => 'debug_test.php', 'line' => 27],
+        ], $payload['stack']);
     }
 
     public function testAllCommandsAreExecutable(): void


### PR DESCRIPTION
Fixes the four mismatches found while verifying the README against the tools.

- `xstep`/`xrepl`/`xback` accept an absolute PHP binary path after `--` (e.g. `-- /opt/homebrew/opt/php@7.2/bin/php app.php`); DebugServer spawns that binary unless `--php` overrides it.
- `xback` emits the documented `xback.json` document: `stack` frames carry `level` and `--depth` is applied. It used to print the `xstep.json` document because DebugServer exits right after printing, so the output-buffer reshaping in `bin/xback` never ran.
- DebugServer gains an `onResult` sink so an embedding script can reshape the result before exit.
- README and skill docs: xtrace, xprofile, and xcoverage print text unless `--json` is given; the xrepl `l` command shows the current location, not source code.

Tests: `testXstepAcceptsAbsolutePhpBinaryPath` and `testXbackOutputsBacktraceSchema` (validates the output against `docs/schemas/xback.json`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `xstep`, `xrepl`, and `xback` now accept absolute PHP binary paths as documented.
  * `xback` now returns the documented JSON structure with stack levels and depth-limited results.
  * `xback` without `--break` reports the first executable line in the target script and captures the correct user-code frame.

* **Documentation**
  * Clarified JSON output requirements for tracing, profiling, and coverage commands.
  * Updated the REPL `l` command and command output schemas to reflect current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->